### PR TITLE
Run DevTools tests against npm releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 aliases:
   - &docker
@@ -371,6 +371,23 @@ jobs:
       - *run_yarn
       - run: yarn test --project=devtools --build --ci
 
+  yarn_test_release_devtools:
+    docker: *docker
+    environment: *environment
+    parameters:
+      version:
+        type: string
+        default: next
+    steps:
+      - checkout
+      - attach_workspace: *attach_workspace
+      - *restore_yarn_cache
+      - *run_yarn
+      - run:
+          name: Download a specific version of React + renderers
+          command: node scripts/jest/install-devtools-release-test-deps.js << parameters.version >>
+      - run: yarn test --project=devtools --build --ci
+
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
     docker: *docker
     environment: *environment
@@ -515,6 +532,9 @@ workflows:
           requires:
             - yarn_build
       - yarn_test_build_devtools:
+          requires:
+            - yarn_build
+      - yarn_test_release_devtools:
           requires:
             - yarn_build
       # FIXME: Temporarily disabled to unblock master.

--- a/scripts/jest/install-devtools-release-test-deps.js
+++ b/scripts/jest/install-devtools-release-test-deps.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+
+const fs = require('fs');
+const {exec} = require('child-process-promise');
+
+// Installs an older version of React DOM into build/node_modules.
+//
+// DevTools uses React Test Renderer for its unit tests. Not React DOM. So
+// by updating React DOM to an older release, it will affect the "backend" (the
+// code that runs in the browser) but not the "frontend" (the code that runs
+// the DevTools React app itself). If we were to use React DOM in the DevTools
+// tests, we'd need to figure out a way to load separate versions for the
+// backend and the front end.
+
+const version = process.argv[2];
+
+async function main() {
+  await exec('mkdir build-tmp');
+  await exec('npm install --prefix ./build-tmp react-dom@' + version);
+  const modules = fs.readdirSync('build-tmp/node_modules');
+  for (const dep of modules) {
+    if (
+      dep.startsWith('.') ||
+      // Don't replace React isomorphic package, since the backend may use
+      // component types/features that don't exist in an older version
+      dep === 'react'
+    ) {
+      continue;
+    }
+    await exec(`rm -rf build/node_modules/${dep}`);
+    await exec(
+      `cp -r build-tmp/node_modules/${dep} ` + `build/node_modules/${dep}`
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
WIP

Adds a CircleCI job that runs the DevTools tests against a given version of React.