### PR TITLE
[Fabric] Clear host instance fields

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -125,28 +125,32 @@ class ReactFabricHostComponent {
   }
 
   blur() {
-    TextInputState.blurTextInput(this);
+    if (this._internalInstanceHandle != null) {
+      TextInputState.blurTextInput(this);
+    }
   }
 
   focus() {
-    TextInputState.focusTextInput(this);
+    if (this._internalInstanceHandle != null) {
+      TextInputState.focusTextInput(this);
+    }
   }
 
   measure(callback: MeasureOnSuccessCallback) {
-    const {stateNode} = this._internalInstanceHandle;
-    if (stateNode != null) {
+    const fiber = this._internalInstanceHandle;
+    if (fiber != null && fiber.stateNode != null) {
       fabricMeasure(
-        stateNode.node,
+        fiber.stateNode.node,
         mountSafeCallback_NOT_REALLY_SAFE(this, callback),
       );
     }
   }
 
   measureInWindow(callback: MeasureInWindowOnSuccessCallback) {
-    const {stateNode} = this._internalInstanceHandle;
-    if (stateNode != null) {
+    const fiber = this._internalInstanceHandle;
+    if (fiber != null && fiber.stateNode != null) {
       fabricMeasureInWindow(
-        stateNode.node,
+        fiber.stateNode.node,
         mountSafeCallback_NOT_REALLY_SAFE(this, callback),
       );
     }
@@ -169,7 +173,12 @@ class ReactFabricHostComponent {
 
       return;
     }
-
+    if (
+      this._internalInstanceHandle == null ||
+      relativeToNativeNode._internalInstanceHandle == null
+    ) {
+      return;
+    }
     const toStateNode = this._internalInstanceHandle.stateNode;
     const fromStateNode =
       relativeToNativeNode._internalInstanceHandle.stateNode;
@@ -522,6 +531,8 @@ export function preparePortalMount(portalInstance: Instance): void {
   // noop
 }
 
-export function detachDeletedInstance(node: Instance): void {
-  // noop
+export function detachDeletedInstance(instance: Instance): void {
+  const canonical = instance.canonical;
+  canonical.currentProps = null;
+  canonical._internalInstanceHandle = null;
 }


### PR DESCRIPTION
We didn't implement this method. I don't know if we should, but seems like refs could hold host instances, so they could leak. So it might be good to disconnect the props and the fiber pointers. I edited the existing methods to remove non-null assumptions. Not sure if there is other code in RN reading these.