### PR TITLE
[Fizz] Readability refactor (follow up to #25437)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -10,7 +10,6 @@
 'use strict';
 import {
   replaceScriptsAndMove,
-  mergeOptions,
   stripExternalRuntimeInNodes,
   withLoadingReadyState,
 } from '../test-utils/FizzTestUtils';
@@ -300,10 +299,10 @@ describe('ReactDOMFizzServer', () => {
   }
   function renderToPipeableStream(jsx, options) {
     // Merge options with renderOptions, which may contain featureFlag specific behavior
-    return ReactDOMFizzServer.renderToPipeableStream(
-      jsx,
-      mergeOptions(options, renderOptions),
-    );
+    return ReactDOMFizzServer.renderToPipeableStream(jsx, {
+      ...renderOptions,
+      ...options,
+    });
   }
 
   it('should asynchronously load a lazy component', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -10,7 +10,6 @@
 'use strict';
 import {
   replaceScriptsAndMove,
-  mergeOptions,
   withLoadingReadyState,
 } from '../test-utils/FizzTestUtils';
 
@@ -251,10 +250,10 @@ describe('ReactDOMFloat', () => {
 
   function renderToPipeableStream(jsx, options) {
     // Merge options with renderOptions, which may contain featureFlag specific behavior
-    return ReactDOMFizzServer.renderToPipeableStream(
-      jsx,
-      mergeOptions(options, renderOptions),
-    );
+    return ReactDOMFizzServer.renderToPipeableStream(jsx, {
+      ...renderOptions,
+      ...options,
+    });
   }
 
   // @gate enableFloat

--- a/packages/react-dom/src/test-utils/FizzTestUtils.js
+++ b/packages/react-dom/src/test-utils/FizzTestUtils.js
@@ -133,13 +133,6 @@ async function replaceScriptsAndMove(
   }
 }
 
-function mergeOptions(options: Object, defaultOptions: Object): Object {
-  return {
-    ...defaultOptions,
-    ...options,
-  };
-}
-
 function stripExternalRuntimeInNodes(
   nodes: HTMLElement[] | HTMLCollection<HTMLElement>,
   externalRuntimeSrc: string | null,
@@ -192,7 +185,6 @@ async function withLoadingReadyState<T>(
 
 export {
   replaceScriptsAndMove,
-  mergeOptions,
   stripExternalRuntimeInNodes,
   withLoadingReadyState,
 };


### PR DESCRIPTION
## Summary
Follow-up / cleanup PR to https://github.com/facebook/react/pull/25437

- Split `write[...]Instruction` into two sets of functions, functions writing the inline script format and functions writing the data attribute format. This is only moving code around (no functional changes)
- removed redundant test helper

## How did you test this change?
- Only ReactDOM www build should be affected (small bundle size change from moving code around)
- `ReactDOMFizzServer-test.js` `ReactDOMFloat-test.js`