### PR TITLE
useEffectEvent failing lint tests

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7661,6 +7661,36 @@ if (__EXPERIMENTAL__) {
         },
       ],
     },
+    {
+      code: normalizeIndent`
+        // Should error because it's being passed into something
+        // besides useEffect.
+        function MyComponent({ store }) {
+          const subscribe = useEffectEvent(() => store.subscribe());
+          const susbcribe2 = useCallback(() => subscribe(), []);
+        }
+      `,
+      errors: [
+        'TODO: Idk what the error message should say but there should ' +
+          'definitely be one',
+      ],
+    },
+    {
+      code: normalizeIndent`
+        // Should error because it's being passed into something
+        // besides useEffect.
+        function MyComponent({ store }) {
+          const subscribe = useEffectEvent(() => store.subscribe());
+          const susbcribe2 = useMemo(() => {
+            () => subscribe();
+          }, []);
+        }
+      `,
+      errors: [
+        'TODO: Idk what the error message should say but there should ' +
+          'definitely be one',
+      ],
+    },
   ];
 }
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -1258,6 +1258,36 @@ if (__EXPERIMENTAL__) {
     },
     {
       code: normalizeIndent`
+        // Should error because it's being passed into something
+        // besides useEffect.
+        function MyComponent({ store }) {
+          const subscribe = useEffectEvent(() => store.subscribe());
+          const susbcribe2 = useCallback(() => subscribe(), []);
+        }
+      `,
+      errors: [
+        'TODO: Idk what the error message should say but there should ' +
+          'definitely be one',
+      ],
+    },
+    {
+      code: normalizeIndent`
+        // Should error because it's being passed into something
+        // besides useEffect.
+        function MyComponent({ store }) {
+          const subscribe = useEffectEvent(() => store.subscribe());
+          const susbcribe2 = useMemo(() => {
+            () => subscribe();
+          }, []);
+        }
+      `,
+      errors: [
+        'TODO: Idk what the error message should say but there should ' +
+          'definitely be one',
+      ],
+    },
+    {
+      code: normalizeIndent`
         Hook.use();
         Hook._use();
         Hook.useState();


### PR DESCRIPTION
The event function returned from useEffectEvent should not be allowed to flow into anything except for a useEffect scope.

I'm not sure whether it's feasible to handle all cases in the ESLint plugin, without Forget-level flow analysis, but we should try to cover the most common cases.

For example, this currently does not result in a linter error, but it should:

```js
const subscribe = useEffectEvent(() => store.subscribe());
const susbcribe2 = useCallback(() => subscribe(), []);
```

I tried this with both the rules-of-hooks lint rule and the exhaustive-deps lint rule. Neither produced an error.

Even if our flow analysis isn't perfect, you would at least expect it to violate exhaustive-deps because subscribe is omitted from the dependency list of the useCallback call — you're allowed to omit event functions from a useEffect deps array, but not useCallback or useMemo. But really it should error even earlier than that.

I didn't really know which test file to put these cases in, so I put them in both. Whoever fixes this can decide. There are existing relevant test cases for both rules-of-hooks and exhaustive-deps. (I always forget that exhaustive-deps is a separate opt-in.) Because this is a new hook, I really think it should fail even if exhuastive-deps isn't enabled. Going forward it would be nice to merge these into a single rule, perhaps in a new major release of the lint package.