### PR TITLE
Detect loops caused by updates during prerender

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -80,6 +80,7 @@ function FiberRootNode(
   this.finishedLanes = NoLanes;
   this.errorRecoveryDisabledLanes = NoLanes;
   this.shellSuspendCounter = 0;
+  this.prerenderInterruptCounter = 0;
 
   this.entangledLanes = NoLanes;
   this.entanglements = createLaneMap(NoLanes);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -776,6 +776,19 @@ export function scheduleUpdateOnFiber(
   markRootUpdated(root, lane);
 
   if (
+    enableSiblingPrerendering &&
+    workInProgressRootIsPrerendering &&
+    workInProgressRoot !== null
+  ) {
+    // This update happened while we were in the middle of a prerender.
+    // Increment a counter. If this happens too often before we finish the
+    // update, we will disable prerenders until the queue is empty. This is to
+    // prevent a potential scenario where an update is spawned by a prerender,
+    // which then interrupts itself, leading to an infinite loop.
+    workInProgressRoot.prerenderInterruptCounter++;
+  }
+
+  if (
     (executionContext & RenderContext) !== NoLanes &&
     root === workInProgressRoot
   ) {

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -260,6 +260,7 @@ type BaseFiberRootProperties = {
   expiredLanes: Lanes,
   errorRecoveryDisabledLanes: Lanes,
   shellSuspendCounter: number,
+  prerenderInterruptCounter: number,
 
   finishedLanes: Lanes,
 


### PR DESCRIPTION
When Meta tried rolling out enableSiblingPrerendering internally, there were reports of infinite render loops that we suspect were caused by updates triggered during the render phase. While we don't have an exact repro, we know that theoretically this is possible because any update, included one triggered as a side effect of rendering, will interrupt an in-progress prerender.

Although we already have warnings and protections against updates that occur during the render phase, the sibling prerendering experiment introduces new scenarios that could cause previously working (though technically incorrect) product code to regress.

The solution in this PR is to maintain a counter of how many times a prerender is interrupted before it successfully completes. Once the counter reaches that threshold, we disable the prerendering mechanism, effectively reverting to the behavior that's in canary today.

The counter is reset the next time the update queue is exhausted, allowing for subsequent prerenders to work as before.