### PR TITLE
DevTools: add React 19 to DevTools test matrix

### DIFF
--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -108,6 +108,7 @@ jobs:
           - "17.0"
           - "18.0"
           - "18.2" # compiler polyfill
+          - "19.0"
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -142,6 +143,7 @@ jobs:
           - "16.8" # hooks
           - "17.0"
           - "18.0"
+          - "19.0"
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Work in progress. The only failing test is this: https://github.com/facebook/react/blob/a06cd9e1d141f598a68377495f4c0fe9ee44e569/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js#L3147

This is because we are using `unstable_getCacheForType` for element inspection on React DevTools side, which is unavailable in public versions of React.