### PR TITLE
[compiler][rfc] Enable hook guards in dev mode by default

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -50,6 +50,7 @@
     "pretty-format": "^24",
     "react": "0.0.0-experimental-4beb1fd8-20241118",
     "react-dom": "0.0.0-experimental-4beb1fd8-20241118",
+    "react-compiler-runtime": "0.0.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "zod": "^3.22.4",

--- a/compiler/packages/babel-plugin-react-compiler/scripts/jest/makeTransform.ts
+++ b/compiler/packages/babel-plugin-react-compiler/scripts/jest/makeTransform.ts
@@ -29,6 +29,7 @@ const e2eTransformerCacheKey = 1;
 const forgetOptions: EnvironmentConfig = validateEnvironmentConfig({
   enableAssumeHooksFollowRulesOfReact: true,
   enableFunctionOutlining: false,
+  enableEmitHookGuards: null,
 });
 const debugMode = process.env['DEBUG_FORGET_COMPILER'] != null;
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Babel/BabelPlugin.ts
@@ -61,6 +61,18 @@ export default function BabelPluginReactCompiler(
               },
             };
           }
+          if (opts.environment.enableEmitHookGuards != null) {
+            const enableEmitHookGuards = opts.environment.enableEmitHookGuards;
+            if (enableEmitHookGuards.devonly === true && !isDev) {
+              opts = {
+                ...opts,
+                environment: {
+                  ...opts.environment,
+                  enableEmitHookGuards: null,
+                },
+              };
+            }
+          }
           compileProgram(prog, {
             opts,
             filename: pass.filename ?? null,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/parseConfigPragma-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/parseConfigPragma-test.ts
@@ -27,6 +27,7 @@ describe('parseConfigPragmaForTests()', () => {
       panicThreshold: 'all_errors',
       environment: {
         ...defaultOptions.environment,
+        enableEmitHookGuards: null,
         enableUseTypeAnnotations: true,
         validateNoSetStateInPassiveEffects: true,
         validateNoSetStateInRender: false,


### PR DESCRIPTION

This validation ensures that React compiler-enabled apps remain correct. That is, code that errors with this validation is most likely ***invalid*** with React compiler is enabled (specifically, hook calls will be compiled to if-else memo blocks).

Hook guards are used extensively for Meta's react compiler rollouts. There, they're enabled for developers (for dev builds) and on e2e test runs. Let's enable by default for oss as well

### Examples of inputs this rule throws on

* Components should not be invoked directly as React Compiler could memoize the call to AnotherComponent, which introduces conditional hook calls in its compiled output.
  ```js
  function Invalid1(props) {
   const myJsx = AnotherComponent(props);
   return <div> { myJsx } </div>;
  }
  ```
* Hooks must be named as hooks. Similarly, hook calls may not appear in functions that are not components or hooks.
  ```js
  const renamedHook = useState;
  function Invalid2() {
    const [state, setState] = renamedHook(0);
  }

  function Invalid3() {
    const myFunc = () => useContext(...);
    myFunc();
  }
  ```

* Hooks must be directly called (from the body of a component or hook)
  ```
  function call(fn) {
    return fn();
  }

  function Invalid4() {
    const result = call(useMyHook);
  }
  ```


### Example of hook guard error (in dev build)
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/e9ada403-b0d7-4840-b6d5-ad600519c6e6" />
