### PR TITLE
Fix uDV: Re-render while in "initial" state

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -608,6 +608,24 @@ describe('ReactDeferredValue', () => {
     },
   );
 
+  it("can update initial value in place if final value hasn't committed yet", async () => {
+    function App({text}) {
+      return <AsyncText text={useDeferredValue(text, `Preview ${text}...`)} />;
+    }
+
+    const root = ReactNoop.createRoot();
+
+    resolveText('Preview A...');
+    await act(() => root.render(<App text="A" />));
+    assertLog(['Preview A...', 'Suspend! [A]']);
+    expect(root).toMatchRenderedOutput('Preview A...');
+
+    resolveText('Preview B...');
+    await act(() => root.render(<App text="B" />));
+    assertLog(['Preview B...', 'Suspend! [B]']);
+    expect(root).toMatchRenderedOutput('Preview B...');
+  });
+
   it('avoids a useDeferredValue waterfall when separated by a Suspense boundary', async () => {
     // Same as the previous test but with a Suspense boundary separating the
     // two useDeferredValue hooks.


### PR DESCRIPTION
Unlike `useState`, the `initialValue` option to `useDeferredValue` is reactive — if the hook re-renders with a different initial value before the final value commits, React should update to the new initial value.

To implement this, we need to track some extra state that represents whether the hook's currently rendered value is an "initial" one. The state is flipped to `false` when the canonical value renders for the first time, and remains false for the rest of the component's lifetime (or until the component's visibility is toggled by an Activity boundary).