### PR TITLE
[Fiber] Prevent metadata hoisting in hidden `<Activity>` trees

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9552,6 +9552,427 @@ background-color: green;
         <title data-foo="bar">another title</title>,
       );
     });
+
+    // @gate enableActivity
+    it('does not hoist title tags inside hidden Activity boundaries', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Visible Title</title>
+            </Activity>
+            <Activity mode="hidden">
+              <title>Hidden Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only the visible Activity's title should be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Visible Title</title>,
+      );
+    });
+
+    // @gate enableActivity
+    it('removes title tags when Activity transitions from visible to hidden', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Activity Title</title>,
+      );
+
+      // Hide the Activity
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="hidden">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should be removed from document head
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+    });
+
+    // @gate enableActivity
+    it('adds title tags when Activity transitions from hidden to visible', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="hidden">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should not be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Show the Activity
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should now be hoisted
+      // Note: The title may have a style attribute from being previously hidden
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('Activity Title');
+    });
+
+    // @gate enableActivity
+    it('handles multiple Activity boundaries with different visibility states', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>First Title</title>
+            </Activity>
+            <Activity mode="hidden">
+              <title>Second Title</title>
+            </Activity>
+            <Activity mode="visible">
+              <title>Third Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only visible Activities' titles should be hoisted
+      // Both visible titles are hoisted, but the last one in tree order wins
+      const titles = getMeaningfulChildren(document.head);
+      expect(Array.isArray(titles)).toBe(true);
+      expect(titles.length).toBe(2);
+      expect(titles[0].props.children).toBe('Third Title');
+      expect(titles[1].props.children).toBe('First Title');
+    });
+
+    // @gate enableActivity
+    it('handles nested Activity boundaries correctly', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Outer Title</title>
+              <Activity mode="hidden">
+                <title>Inner Hidden Title</title>
+              </Activity>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only the outer visible Activity's title should be hoisted
+      // The inner hidden Activity's title should not be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Outer Title</title>,
+      );
+    });
+
+    // @gate enableActivity
+    it('handles meta tags inside hidden Activity boundaries', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <meta name="visible" content="visible-content" />
+            </Activity>
+            <Activity mode="hidden">
+              <meta name="hidden" content="hidden-content" />
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only the visible Activity's meta should be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <meta name="visible" content="visible-content" />,
+      );
+    });
+
+    // @gate enableActivity
+    it('does not hoist a hoistable nested under a HostComponent inside a hidden Activity', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <div>
+              <title>Nested Hidden Title</title>
+              <meta name="nested-hidden" content="nope" />
+            </div>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+    });
+
+    // @gate enableActivity
+    it('mounts nested hoistables when their ancestor Activity transitions to visible', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <div>
+              <title>Reveal Me</title>
+            </div>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      await act(() => {
+        root.render(
+          <Activity mode="visible">
+            <div>
+              <title>Reveal Me</title>
+            </div>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('Reveal Me');
+    });
+
+    // @gate enableActivity
+    it('updates a hidden title without inserting it into the head', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <title>Original Hidden</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Update the prop while still hidden — the head must remain empty.
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <title>Updated Hidden</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Now reveal — the latest text should be in the head.
+      await act(() => {
+        root.render(
+          <Activity mode="visible">
+            <title>Updated Hidden</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('Updated Hidden');
+    });
+
+    // @gate enableActivity
+    it('removes a previously-mounted title when its Activity is deleted while hidden', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="visible">
+            <title>To Be Deleted</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>To Be Deleted</title>,
+      );
+
+      // Hide first — this unmounts from the head.
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <title>To Be Deleted</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Delete the entire Activity while it's hidden. This must not throw
+      // (the deletion path needs to tolerate already-detached instances).
+      await act(() => {
+        root.render(<div />);
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+    });
+
+    // @gate enableActivity
+    it('does not hoist hidden Activity metadata during hydration', async () => {
+      const Activity = React.Activity;
+
+      // SSR a page where the only title belongs to a VISIBLE Activity. The
+      // hidden Activity has its own <title> that must not end up in <head>.
+      await act(() => {
+        const {pipe} = renderToPipeableStream(
+          <html>
+            <body>
+              <Activity mode="visible">
+                <title>Visible Title</title>
+              </Activity>
+              <Activity mode="hidden">
+                <title>Hidden Title</title>
+              </Activity>
+            </body>
+          </html>,
+        );
+        pipe(writable);
+      });
+
+      // After SSR, only the visible title should be in the head.
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Visible Title</title>,
+      );
+
+      // Hydrate. The hidden Activity's <title> must not be inserted into the
+      // head as a side effect of hydration.
+      ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <body>
+            <Activity mode="visible">
+              <title>Visible Title</title>
+            </Activity>
+            <Activity mode="hidden">
+              <title>Hidden Title</title>
+            </Activity>
+          </body>
+        </html>,
+      );
+      await waitForAll([]);
+
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Visible Title</title>,
+      );
+    });
+
+    // @gate enableActivity
+    it('handles StrictMode without leaving duplicate or missing hoistables', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      // StrictMode triggers a dev-only double invoke of layout effects, which
+      // exercises our disappear/reappear hoistable handling. The final state
+      // must be a single visible title and no hidden title.
+      await act(() => {
+        root.render(
+          <React.StrictMode>
+            <div>
+              <Activity mode="visible">
+                <title>StrictMode Visible</title>
+              </Activity>
+              <Activity mode="hidden">
+                <title>StrictMode Hidden</title>
+              </Activity>
+            </div>
+          </React.StrictMode>,
+        );
+      });
+      await waitForAll([]);
+
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>StrictMode Visible</title>,
+      );
+
+      // Toggle visibility — double invoke must still leave a clean head
+      // with exactly one title (no duplicates, no missing).
+      await act(() => {
+        root.render(
+          <React.StrictMode>
+            <div>
+              <Activity mode="hidden">
+                <title>StrictMode Visible</title>
+              </Activity>
+              <Activity mode="visible">
+                <title>StrictMode Hidden</title>
+              </Activity>
+            </div>
+          </React.StrictMode>,
+        );
+      });
+      await waitForAll([]);
+
+      // The previously-hidden title that just became visible may carry a
+      // style="" attribute from hideInstance/unhideInstance. The semantic
+      // requirement is exactly one <title> with the correct text.
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(Array.isArray(titleElement)).toBe(false);
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('StrictMode Hidden');
+    });
   });
 
   it('does not outline a boundary with suspensey CSS when flushing the shell', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9647,11 +9647,10 @@ background-color: green;
       await waitForAll([]);
 
       // Title should now be hoisted
-      // Note: The title may have a style attribute from being previously hidden
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('Activity Title');
+      // The title retains an empty style attribute from being previously hidden
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title style="">Activity Title</title>,
+      );
     });
 
     // @gate enableActivity
@@ -9678,11 +9677,10 @@ background-color: green;
 
       // Only visible Activities' titles should be hoisted
       // Both visible titles are hoisted, but the last one in tree order wins
-      const titles = getMeaningfulChildren(document.head);
-      expect(Array.isArray(titles)).toBe(true);
-      expect(titles.length).toBe(2);
-      expect(titles[0].props.children).toBe('Third Title');
-      expect(titles[1].props.children).toBe('First Title');
+      expect(getMeaningfulChildren(document.head)).toEqual([
+        <title>Third Title</title>,
+        <title>First Title</title>,
+      ]);
     });
 
     // @gate enableActivity
@@ -9784,10 +9782,9 @@ background-color: green;
       });
       await waitForAll([]);
 
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('Reveal Me');
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Reveal Me</title>,
+      );
     });
 
     // @gate enableActivity
@@ -9826,10 +9823,9 @@ background-color: green;
       });
       await waitForAll([]);
 
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('Updated Hidden');
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title style="">Updated Hidden</title>,
+      );
     });
 
     // @gate enableActivity
@@ -9964,14 +9960,11 @@ background-color: green;
       });
       await waitForAll([]);
 
-      // The previously-hidden title that just became visible may carry a
-      // style="" attribute from hideInstance/unhideInstance. The semantic
-      // requirement is exactly one <title> with the correct text.
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(Array.isArray(titleElement)).toBe(false);
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('StrictMode Hidden');
+      // The previously-hidden title that just became visible carries a
+      // style="" attribute from hideInstance/unhideInstance.
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title style="">StrictMode Hidden</title>,
+      );
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9553,7 +9553,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('does not hoist title tags inside hidden Activity boundaries', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9578,7 +9577,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('removes title tags when Activity transitions from visible to hidden', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9615,7 +9613,6 @@ background-color: green;
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
-    // @gate enableActivity
     it('adds title tags when Activity transitions from hidden to visible', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9653,7 +9650,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('handles multiple Activity boundaries with different visibility states', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9683,7 +9679,6 @@ background-color: green;
       ]);
     });
 
-    // @gate enableActivity
     it('handles nested Activity boundaries correctly', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9709,7 +9704,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('handles meta tags inside hidden Activity boundaries', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9734,7 +9728,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('does not hoist a hoistable nested under a HostComponent inside a hidden Activity', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9754,7 +9747,6 @@ background-color: green;
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
-    // @gate enableActivity
     it('mounts nested hoistables when their ancestor Activity transitions to visible', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9787,7 +9779,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('updates a hidden title without inserting it into the head', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9828,7 +9819,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('removes a previously-mounted title when its Activity is deleted while hidden', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9865,7 +9855,6 @@ background-color: green;
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
-    // @gate enableActivity
     it('does not hoist hidden Activity metadata during hydration', async () => {
       const Activity = React.Activity;
 
@@ -9914,7 +9903,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('handles StrictMode without leaving duplicate or missing hoistables', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9770,6 +9770,427 @@ background-color: green;
         <title data-foo="bar">another title</title>,
       );
     });
+
+    // @gate enableActivity
+    it('does not hoist title tags inside hidden Activity boundaries', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Visible Title</title>
+            </Activity>
+            <Activity mode="hidden">
+              <title>Hidden Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only the visible Activity's title should be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Visible Title</title>,
+      );
+    });
+
+    // @gate enableActivity
+    it('removes title tags when Activity transitions from visible to hidden', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Activity Title</title>,
+      );
+
+      // Hide the Activity
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="hidden">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should be removed from document head
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+    });
+
+    // @gate enableActivity
+    it('adds title tags when Activity transitions from hidden to visible', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="hidden">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should not be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Show the Activity
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Activity Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Title should now be hoisted
+      // Note: The title may have a style attribute from being previously hidden
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('Activity Title');
+    });
+
+    // @gate enableActivity
+    it('handles multiple Activity boundaries with different visibility states', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>First Title</title>
+            </Activity>
+            <Activity mode="hidden">
+              <title>Second Title</title>
+            </Activity>
+            <Activity mode="visible">
+              <title>Third Title</title>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only visible Activities' titles should be hoisted
+      // Both visible titles are hoisted, but the last one in tree order wins
+      const titles = getMeaningfulChildren(document.head);
+      expect(Array.isArray(titles)).toBe(true);
+      expect(titles.length).toBe(2);
+      expect(titles[0].props.children).toBe('Third Title');
+      expect(titles[1].props.children).toBe('First Title');
+    });
+
+    // @gate enableActivity
+    it('handles nested Activity boundaries correctly', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <title>Outer Title</title>
+              <Activity mode="hidden">
+                <title>Inner Hidden Title</title>
+              </Activity>
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only the outer visible Activity's title should be hoisted
+      // The inner hidden Activity's title should not be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Outer Title</title>,
+      );
+    });
+
+    // @gate enableActivity
+    it('handles meta tags inside hidden Activity boundaries', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <div>
+            <Activity mode="visible">
+              <meta name="visible" content="visible-content" />
+            </Activity>
+            <Activity mode="hidden">
+              <meta name="hidden" content="hidden-content" />
+            </Activity>
+          </div>,
+        );
+      });
+      await waitForAll([]);
+
+      // Only the visible Activity's meta should be hoisted
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <meta name="visible" content="visible-content" />,
+      );
+    });
+
+    // @gate enableActivity
+    it('does not hoist a hoistable nested under a HostComponent inside a hidden Activity', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <div>
+              <title>Nested Hidden Title</title>
+              <meta name="nested-hidden" content="nope" />
+            </div>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+    });
+
+    // @gate enableActivity
+    it('mounts nested hoistables when their ancestor Activity transitions to visible', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <div>
+              <title>Reveal Me</title>
+            </div>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      await act(() => {
+        root.render(
+          <Activity mode="visible">
+            <div>
+              <title>Reveal Me</title>
+            </div>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('Reveal Me');
+    });
+
+    // @gate enableActivity
+    it('updates a hidden title without inserting it into the head', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <title>Original Hidden</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Update the prop while still hidden — the head must remain empty.
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <title>Updated Hidden</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Now reveal — the latest text should be in the head.
+      await act(() => {
+        root.render(
+          <Activity mode="visible">
+            <title>Updated Hidden</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('Updated Hidden');
+    });
+
+    // @gate enableActivity
+    it('removes a previously-mounted title when its Activity is deleted while hidden', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <Activity mode="visible">
+            <title>To Be Deleted</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>To Be Deleted</title>,
+      );
+
+      // Hide first — this unmounts from the head.
+      await act(() => {
+        root.render(
+          <Activity mode="hidden">
+            <title>To Be Deleted</title>
+          </Activity>,
+        );
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+
+      // Delete the entire Activity while it's hidden. This must not throw
+      // (the deletion path needs to tolerate already-detached instances).
+      await act(() => {
+        root.render(<div />);
+      });
+      await waitForAll([]);
+      expect(getMeaningfulChildren(document.head)).toEqual(undefined);
+    });
+
+    // @gate enableActivity
+    it('does not hoist hidden Activity metadata during hydration', async () => {
+      const Activity = React.Activity;
+
+      // SSR a page where the only title belongs to a VISIBLE Activity. The
+      // hidden Activity has its own <title> that must not end up in <head>.
+      await act(() => {
+        const {pipe} = renderToPipeableStream(
+          <html>
+            <body>
+              <Activity mode="visible">
+                <title>Visible Title</title>
+              </Activity>
+              <Activity mode="hidden">
+                <title>Hidden Title</title>
+              </Activity>
+            </body>
+          </html>,
+        );
+        pipe(writable);
+      });
+
+      // After SSR, only the visible title should be in the head.
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Visible Title</title>,
+      );
+
+      // Hydrate. The hidden Activity's <title> must not be inserted into the
+      // head as a side effect of hydration.
+      ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <body>
+            <Activity mode="visible">
+              <title>Visible Title</title>
+            </Activity>
+            <Activity mode="hidden">
+              <title>Hidden Title</title>
+            </Activity>
+          </body>
+        </html>,
+      );
+      await waitForAll([]);
+
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Visible Title</title>,
+      );
+    });
+
+    // @gate enableActivity
+    it('handles StrictMode without leaving duplicate or missing hoistables', async () => {
+      const Activity = React.Activity;
+      const root = ReactDOMClient.createRoot(container);
+
+      // StrictMode triggers a dev-only double invoke of layout effects, which
+      // exercises our disappear/reappear hoistable handling. The final state
+      // must be a single visible title and no hidden title.
+      await act(() => {
+        root.render(
+          <React.StrictMode>
+            <div>
+              <Activity mode="visible">
+                <title>StrictMode Visible</title>
+              </Activity>
+              <Activity mode="hidden">
+                <title>StrictMode Hidden</title>
+              </Activity>
+            </div>
+          </React.StrictMode>,
+        );
+      });
+      await waitForAll([]);
+
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>StrictMode Visible</title>,
+      );
+
+      // Toggle visibility — double invoke must still leave a clean head
+      // with exactly one title (no duplicates, no missing).
+      await act(() => {
+        root.render(
+          <React.StrictMode>
+            <div>
+              <Activity mode="hidden">
+                <title>StrictMode Visible</title>
+              </Activity>
+              <Activity mode="visible">
+                <title>StrictMode Hidden</title>
+              </Activity>
+            </div>
+          </React.StrictMode>,
+        );
+      });
+      await waitForAll([]);
+
+      // The previously-hidden title that just became visible may carry a
+      // style="" attribute from hideInstance/unhideInstance. The semantic
+      // requirement is exactly one <title> with the correct text.
+      const titleElement = getMeaningfulChildren(document.head);
+      expect(titleElement).toBeTruthy();
+      expect(Array.isArray(titleElement)).toBe(false);
+      expect(titleElement.type).toBe('title');
+      expect(titleElement.props.children).toBe('StrictMode Hidden');
+    });
   });
 
   it('does not outline a boundary with suspensey CSS when flushing the shell', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9771,7 +9771,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('does not hoist title tags inside hidden Activity boundaries', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9796,7 +9795,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('removes title tags when Activity transitions from visible to hidden', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9833,7 +9831,6 @@ background-color: green;
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
-    // @gate enableActivity
     it('adds title tags when Activity transitions from hidden to visible', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9871,7 +9868,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('handles multiple Activity boundaries with different visibility states', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9901,7 +9897,6 @@ background-color: green;
       ]);
     });
 
-    // @gate enableActivity
     it('handles nested Activity boundaries correctly', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9927,7 +9922,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('handles meta tags inside hidden Activity boundaries', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9952,7 +9946,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('does not hoist a hoistable nested under a HostComponent inside a hidden Activity', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -9972,7 +9965,6 @@ background-color: green;
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
-    // @gate enableActivity
     it('mounts nested hoistables when their ancestor Activity transitions to visible', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -10005,7 +9997,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('updates a hidden title without inserting it into the head', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -10046,7 +10037,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('removes a previously-mounted title when its Activity is deleted while hidden', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);
@@ -10083,7 +10073,6 @@ background-color: green;
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
-    // @gate enableActivity
     it('does not hoist hidden Activity metadata during hydration', async () => {
       const Activity = React.Activity;
 
@@ -10132,7 +10121,6 @@ background-color: green;
       );
     });
 
-    // @gate enableActivity
     it('handles StrictMode without leaving duplicate or missing hoistables', async () => {
       const Activity = React.Activity;
       const root = ReactDOMClient.createRoot(container);

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9865,11 +9865,10 @@ background-color: green;
       await waitForAll([]);
 
       // Title should now be hoisted
-      // Note: The title may have a style attribute from being previously hidden
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('Activity Title');
+      // The title retains an empty style attribute from being previously hidden
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title style="">Activity Title</title>,
+      );
     });
 
     // @gate enableActivity
@@ -9896,11 +9895,10 @@ background-color: green;
 
       // Only visible Activities' titles should be hoisted
       // Both visible titles are hoisted, but the last one in tree order wins
-      const titles = getMeaningfulChildren(document.head);
-      expect(Array.isArray(titles)).toBe(true);
-      expect(titles.length).toBe(2);
-      expect(titles[0].props.children).toBe('Third Title');
-      expect(titles[1].props.children).toBe('First Title');
+      expect(getMeaningfulChildren(document.head)).toEqual([
+        <title>Third Title</title>,
+        <title>First Title</title>,
+      ]);
     });
 
     // @gate enableActivity
@@ -10002,10 +10000,9 @@ background-color: green;
       });
       await waitForAll([]);
 
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('Reveal Me');
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title>Reveal Me</title>,
+      );
     });
 
     // @gate enableActivity
@@ -10044,10 +10041,9 @@ background-color: green;
       });
       await waitForAll([]);
 
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('Updated Hidden');
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title style="">Updated Hidden</title>,
+      );
     });
 
     // @gate enableActivity
@@ -10182,14 +10178,11 @@ background-color: green;
       });
       await waitForAll([]);
 
-      // The previously-hidden title that just became visible may carry a
-      // style="" attribute from hideInstance/unhideInstance. The semantic
-      // requirement is exactly one <title> with the correct text.
-      const titleElement = getMeaningfulChildren(document.head);
-      expect(titleElement).toBeTruthy();
-      expect(Array.isArray(titleElement)).toBe(false);
-      expect(titleElement.type).toBe('title');
-      expect(titleElement.props.children).toBe('StrictMode Hidden');
+      // The previously-hidden title that just became visible carries a
+      // style="" attribute from hideInstance/unhideInstance.
+      expect(getMeaningfulChildren(document.head)).toEqual(
+        <title style="">StrictMode Hidden</title>,
+      );
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -248,6 +248,93 @@ describe('rendering React components at document', () => {
       expect(container.textContent).toBe('parsnip');
     });
 
+    it('removes hoisted <title> when hiding an Activity boundary', async () => {
+      const Activity = React.Activity;
+
+      function App({mode, titleText}) {
+        return (
+          <html>
+            <head>
+              <Activity mode={mode}>
+                <title>{titleText}</title>
+              </Activity>
+            </head>
+            <body>Hello</body>
+          </html>
+        );
+      }
+
+      const testDocument = getTestDocument(
+        '<!doctype html><html><head></head><body></body></html>',
+      );
+      const root = ReactDOMClient.createRoot(testDocument);
+
+      await act(() => root.render(<App mode="visible" titleText="A" />));
+      expect(testDocument.head.querySelector('title').textContent).toBe('A');
+
+      await act(() => root.render(<App mode="hidden" titleText="A" />));
+      expect(testDocument.head.querySelector('title')).toBe(null);
+
+      await act(() => root.render(<App mode="visible" titleText="B" />));
+      expect(testDocument.head.querySelector('title').textContent).toBe('B');
+    });
+
+    it('does not unmount a hoistable that was never mounted when reappearing', async () => {
+      const Activity = React.Activity;
+
+      function App({mode, showTitle}) {
+        return (
+          <html>
+            <head>
+              <Activity mode={mode}>
+                {showTitle ? <title>Title</title> : null}
+              </Activity>
+            </head>
+            <body>Hello</body>
+          </html>
+        );
+      }
+
+      const testDocument = getTestDocument(
+        '<!doctype html><html><head></head><body></body></html>',
+      );
+      const root = ReactDOMClient.createRoot(testDocument);
+
+      await act(() => root.render(<App mode="hidden" showTitle={true} />));
+      expect(testDocument.head.querySelector('title')).toBe(null);
+
+      await act(() => root.render(<App mode="visible" showTitle={false} />));
+      expect(testDocument.head.querySelector('title')).toBe(null);
+    });
+
+    it('removes hoistables deleted in the same commit that hides an Activity', async () => {
+      const Activity = React.Activity;
+
+      function App({mode, showTitle}) {
+        return (
+          <html>
+            <head>
+              <Activity mode={mode}>
+                {showTitle ? <title>Title</title> : null}
+              </Activity>
+            </head>
+            <body>Hello</body>
+          </html>
+        );
+      }
+
+      const testDocument = getTestDocument(
+        '<!doctype html><html><head></head><body></body></html>',
+      );
+      const root = ReactDOMClient.createRoot(testDocument);
+
+      await act(() => root.render(<App mode="visible" showTitle={true} />));
+      expect(testDocument.head.querySelector('title')).not.toBe(null);
+
+      await act(() => root.render(<App mode="hidden" showTitle={false} />));
+      expect(testDocument.head.querySelector('title')).toBe(null);
+    });
+
     it('should give helpful errors on state desync', async () => {
       class Component extends React.Component {
         render() {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1146,6 +1146,13 @@ function updateActivityComponent(
           renderLanes,
         );
         workInProgress.lanes = laneToLanes(OffscreenLane);
+        // memoizedState on Offscreen is used to indicate whether it is hidden.
+        const nextState: OffscreenState = {
+          baseLanes: NoLanes,
+          cachePool: null,
+        };
+        primaryChildFragment.memoizedState = nextState;
+
         return bailoutOffscreenComponent(null, primaryChildFragment);
       } else {
         // We must push the suspense handler context *before* attempting to

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1146,13 +1146,6 @@ function updateActivityComponent(
           renderLanes,
         );
         workInProgress.lanes = laneToLanes(OffscreenLane);
-        // memoizedState on Offscreen is used to indicate whether it is hidden.
-        const nextState: OffscreenState = {
-          baseLanes: NoLanes,
-          cachePool: null,
-        };
-        primaryChildFragment.memoizedState = nextState;
-
         return bailoutOffscreenComponent(null, primaryChildFragment);
       } else {
         // We must push the suspense handler context *before* attempting to

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1168,13 +1168,6 @@ function updateActivityComponent(
           renderLanes,
         );
         workInProgress.lanes = laneToLanes(OffscreenLane);
-        // memoizedState on Offscreen is used to indicate whether it is hidden.
-        const nextState: OffscreenState = {
-          baseLanes: NoLanes,
-          cachePool: null,
-        };
-        primaryChildFragment.memoizedState = nextState;
-
         return bailoutOffscreenComponent(null, primaryChildFragment);
       } else {
         // We must push the suspense handler context *before* attempting to

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1168,7 +1168,7 @@ function updateActivityComponent(
           renderLanes,
         );
         workInProgress.lanes = laneToLanes(OffscreenLane);
-        // memoizedState on Offscreen is used to indicate whether it is hidden.
+        // This tree hasn't been mounted yet so there are no baseLanes to carry over.
         const nextState: OffscreenState = {
           baseLanes: NoLanes,
           cachePool: null,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1168,6 +1168,13 @@ function updateActivityComponent(
           renderLanes,
         );
         workInProgress.lanes = laneToLanes(OffscreenLane);
+        // memoizedState on Offscreen is used to indicate whether it is hidden.
+        const nextState: OffscreenState = {
+          baseLanes: NoLanes,
+          cachePool: null,
+        };
+        primaryChildFragment.memoizedState = nextState;
+
         return bailoutOffscreenComponent(null, primaryChildFragment);
       } else {
         // We must push the suspense handler context *before* attempting to

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -3280,8 +3280,7 @@ export function reappearLayoutEffects(
         // is re-attached. Moving this to the mutation phase would require an
         // additional unconditional traversal of the Activity subtree (the
         // mutation traversal is gated by subtreeFlags and would skip an
-        // unchanged hoistable). The reviewer guidance was to reuse this
-        // existing visibility traversal, so we accept the layout-phase order.
+        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
         const instance = finishedWork.stateNode;
         if (
           finishedWork.memoizedState === null &&

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1497,9 +1497,8 @@ function commitDeletionEffectsOnFiber(
           // since mount), the instance was either never inserted or was
           // detached by the disappear traversal. Guard the removeChild so we
           // don't throw in those cases.
-          const instance = deletedFiber.stateNode;
-          if (instance.parentNode !== null) {
-            unmountHoistable(instance);
+          if (!offscreenSubtreeWasHidden) {
+            unmountHoistable(deletedFiber.stateNode);
           }
         }
         break;
@@ -2177,7 +2176,7 @@ function commitMutationEffectsOnFiber(
               // Instance was actually mounted in the document; it may not be
               // if it lives inside a hidden Activity boundary.
               const instance = current.stateNode;
-              if (instance !== null && instance.parentNode !== null) {
+              if (instance !== null && !offscreenSubtreeWasHidden) {
                 unmountHoistable(instance);
               }
             } else {
@@ -2592,6 +2591,14 @@ function commitMutationEffectsOnFiber(
               (finishedWork.mode & ConcurrentMode) !== NoMode
             ) {
               // Disappear the layout effects of all the children
+              const newOffscreenSubtreeIsHidden =
+                isHidden || offscreenSubtreeIsHidden;
+              const newOffscreenSubtreeWasHidden =
+                wasHidden || offscreenSubtreeWasHidden;
+              const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
+              const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
+              offscreenSubtreeIsHidden = newOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = newOffscreenSubtreeWasHidden;
               recursivelyTraverseDisappearLayoutEffects(finishedWork);
 
               if (
@@ -2609,6 +2616,8 @@ function commitMutationEffectsOnFiber(
                   componentEffectEndTime,
                 );
               }
+              offscreenSubtreeIsHidden = prevOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = prevOffscreenSubtreeWasHidden;
             }
           }
         }
@@ -3078,23 +3087,15 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
       safelyDetachRef(finishedWork, finishedWork.return);
 
       if (supportsResources) {
-        // The disappear traversal runs from the mutation phase whenever an
-        // Activity transitions from visible to hidden. We piggy-back on it
-        // (rather than adding a separate recursive traversal) to remove
-        // hoisted metadata such as <title> and <meta> from the document.
-        //
         // We only act on Hoistable Instances (memoizedState === null).
         // Resources (memoizedState !== null) are ref-counted and intentionally
         // remain in the document across Activity visibility transitions;
         // they are released only on actual deletion.
-        //
-        // The parentNode guard makes this idempotent and safe under StrictMode
-        // dev double-invoke: if the instance is already detached we skip.
         const instance = finishedWork.stateNode;
         if (
           finishedWork.memoizedState === null &&
           instance !== null &&
-          instance.parentNode !== null
+          !offscreenSubtreeWasHidden
         ) {
           unmountHoistable(instance);
         }
@@ -3285,7 +3286,7 @@ export function reappearLayoutEffects(
         if (
           finishedWork.memoizedState === null &&
           instance !== null &&
-          instance.parentNode === null
+          !offscreenSubtreeIsHidden
         ) {
           // currentHoistableRoot is only maintained during the mutation phase.
           // Derive the hoistable root from the instance's owner document so

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2200,6 +2200,13 @@ function commitMutationEffectsOnFiber(
               );
             }
           } else if (newResource === null && finishedWork.stateNode !== null) {
+            if (!offscreenSubtreeIsHidden) {
+              mountHoistable(
+                hoistableRoot,
+                finishedWork.type,
+                finishedWork.stateNode,
+              );
+            }
             commitHostUpdate(
               finishedWork,
               finishedWork.memoizedProps,
@@ -2591,14 +2598,6 @@ function commitMutationEffectsOnFiber(
               (finishedWork.mode & ConcurrentMode) !== NoMode
             ) {
               // Disappear the layout effects of all the children
-              const newOffscreenSubtreeIsHidden =
-                isHidden || offscreenSubtreeIsHidden;
-              const newOffscreenSubtreeWasHidden =
-                wasHidden || offscreenSubtreeWasHidden;
-              const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
-              const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
-              offscreenSubtreeIsHidden = newOffscreenSubtreeIsHidden;
-              offscreenSubtreeWasHidden = newOffscreenSubtreeWasHidden;
               recursivelyTraverseDisappearLayoutEffects(finishedWork);
 
               if (
@@ -2616,8 +2615,6 @@ function commitMutationEffectsOnFiber(
                   componentEffectEndTime,
                 );
               }
-              offscreenSubtreeIsHidden = prevOffscreenSubtreeIsHidden;
-              offscreenSubtreeWasHidden = prevOffscreenSubtreeWasHidden;
             }
           }
         }
@@ -3239,6 +3236,7 @@ export function reappearLayoutEffects(
       }
       // Fallthrough
     }
+    case HostHoistable:
     case HostComponent: {
       // TODO: Enable HostText for RN
       if (enableFragmentRefs && finishedWork.tag === HostComponent) {
@@ -3254,56 +3252,6 @@ export function reappearLayoutEffects(
       // (eg DOM renderer may schedule auto-focus for inputs and form controls).
       // These effects should only be committed when components are first mounted,
       // aka when there is no current/alternate.
-      if (includeWorkInProgressEffects && current === null && flags & Update) {
-        commitHostMount(finishedWork);
-      }
-
-      // TODO: Check flags & Ref
-      safelyAttachRef(finishedWork, finishedWork.return);
-      break;
-    }
-    case HostHoistable: {
-      if (supportsResources) {
-        // The reappear traversal runs whenever an Activity transitions from
-        // hidden to visible. We piggy-back on it (rather than adding a
-        // separate recursive traversal) to insert hoistable metadata such as
-        // <title> and <meta> into the document.
-        //
-        // We only act on Hoistable Instances (memoizedState === null).
-        // Resources stay mounted across Activity visibility transitions.
-        //
-        // The parentNode guard makes this idempotent and safe under StrictMode
-        // dev double-invoke: if the instance is already attached we skip.
-        //
-        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
-        // sibling can therefore observe document.title before the hoistable
-        // is re-attached. Moving this to the mutation phase would require an
-        // additional unconditional traversal of the Activity subtree (the
-        // mutation traversal is gated by subtreeFlags and would skip an
-        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
-        const instance = finishedWork.stateNode;
-        if (
-          finishedWork.memoizedState === null &&
-          instance !== null &&
-          !offscreenSubtreeIsHidden
-        ) {
-          // currentHoistableRoot is only maintained during the mutation phase.
-          // Derive the hoistable root from the instance's owner document so
-          // this works in the layout phase too. Hoistable Instances are
-          // hoisted to document.head, which always lives in ownerDocument.
-          mountHoistable(
-            getHoistableRoot(instance.ownerDocument),
-            finishedWork.type,
-            instance,
-          );
-        }
-      }
-      recursivelyTraverseReappearLayoutEffects(
-        finishedRoot,
-        finishedWork,
-        includeWorkInProgressEffects,
-      );
-
       if (includeWorkInProgressEffects && current === null && flags & Update) {
         commitHostMount(finishedWork);
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2200,13 +2200,6 @@ function commitMutationEffectsOnFiber(
               );
             }
           } else if (newResource === null && finishedWork.stateNode !== null) {
-            if (!offscreenSubtreeIsHidden) {
-              mountHoistable(
-                hoistableRoot,
-                finishedWork.type,
-                finishedWork.stateNode,
-              );
-            }
             commitHostUpdate(
               finishedWork,
               finishedWork.memoizedProps,
@@ -2598,6 +2591,14 @@ function commitMutationEffectsOnFiber(
               (finishedWork.mode & ConcurrentMode) !== NoMode
             ) {
               // Disappear the layout effects of all the children
+              const newOffscreenSubtreeIsHidden =
+                isHidden || offscreenSubtreeIsHidden;
+              const newOffscreenSubtreeWasHidden =
+                wasHidden || offscreenSubtreeWasHidden;
+              const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
+              const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
+              offscreenSubtreeIsHidden = newOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = newOffscreenSubtreeWasHidden;
               recursivelyTraverseDisappearLayoutEffects(finishedWork);
 
               if (
@@ -2615,6 +2616,8 @@ function commitMutationEffectsOnFiber(
                   componentEffectEndTime,
                 );
               }
+              offscreenSubtreeIsHidden = prevOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = prevOffscreenSubtreeWasHidden;
             }
           }
         }
@@ -3236,7 +3239,6 @@ export function reappearLayoutEffects(
       }
       // Fallthrough
     }
-    case HostHoistable:
     case HostComponent: {
       // TODO: Enable HostText for RN
       if (enableFragmentRefs && finishedWork.tag === HostComponent) {
@@ -3252,6 +3254,56 @@ export function reappearLayoutEffects(
       // (eg DOM renderer may schedule auto-focus for inputs and form controls).
       // These effects should only be committed when components are first mounted,
       // aka when there is no current/alternate.
+      if (includeWorkInProgressEffects && current === null && flags & Update) {
+        commitHostMount(finishedWork);
+      }
+
+      // TODO: Check flags & Ref
+      safelyAttachRef(finishedWork, finishedWork.return);
+      break;
+    }
+    case HostHoistable: {
+      if (supportsResources) {
+        // The reappear traversal runs whenever an Activity transitions from
+        // hidden to visible. We piggy-back on it (rather than adding a
+        // separate recursive traversal) to insert hoistable metadata such as
+        // <title> and <meta> into the document.
+        //
+        // We only act on Hoistable Instances (memoizedState === null).
+        // Resources stay mounted across Activity visibility transitions.
+        //
+        // The parentNode guard makes this idempotent and safe under StrictMode
+        // dev double-invoke: if the instance is already attached we skip.
+        //
+        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
+        // sibling can therefore observe document.title before the hoistable
+        // is re-attached. Moving this to the mutation phase would require an
+        // additional unconditional traversal of the Activity subtree (the
+        // mutation traversal is gated by subtreeFlags and would skip an
+        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
+        const instance = finishedWork.stateNode;
+        if (
+          finishedWork.memoizedState === null &&
+          instance !== null &&
+          !offscreenSubtreeIsHidden
+        ) {
+          // currentHoistableRoot is only maintained during the mutation phase.
+          // Derive the hoistable root from the instance's owner document so
+          // this works in the layout phase too. Hoistable Instances are
+          // hoisted to document.head, which always lives in ownerDocument.
+          mountHoistable(
+            getHoistableRoot(instance.ownerDocument),
+            finishedWork.type,
+            instance,
+          );
+        }
+      }
+      recursivelyTraverseReappearLayoutEffects(
+        finishedRoot,
+        finishedWork,
+        includeWorkInProgressEffects,
+      );
+
       if (includeWorkInProgressEffects && current === null && flags & Update) {
         commitHostMount(finishedWork);
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -170,6 +170,7 @@ import {
   acquireResource,
   releaseResource,
   hydrateHoistable,
+  createHoistableInstance,
   mountHoistable,
   unmountHoistable,
   prepareToCommitHoistables,
@@ -1491,7 +1492,15 @@ function commitDeletionEffectsOnFiber(
         if (deletedFiber.memoizedState) {
           releaseResource(deletedFiber.memoizedState);
         } else if (deletedFiber.stateNode) {
-          unmountHoistable(deletedFiber.stateNode);
+          // A Hoistable Instance lives in document.head only when its enclosing
+          // Activity is visible. If the Activity is hidden (or has been hidden
+          // since mount), the instance was either never inserted or was
+          // detached by the disappear traversal. Guard the removeChild so we
+          // don't throw in those cases.
+          const instance = deletedFiber.stateNode;
+          if (instance.parentNode !== null) {
+            unmountHoistable(instance);
+          }
         }
         break;
       }
@@ -2122,13 +2131,32 @@ function commitMutationEffectsOnFiber(
             // or a Hoistable Resource
             if (newResource === null) {
               if (finishedWork.stateNode === null) {
-                finishedWork.stateNode = hydrateHoistable(
-                  hoistableRoot,
-                  finishedWork.type,
-                  finishedWork.memoizedProps,
-                  finishedWork,
-                );
-              } else {
+                // Initial mount. The instance has not been created yet, which
+                // happens during hydration (createHoistableInstance is normally
+                // called in beginWork's updateHostHoistable, but is skipped
+                // when hydrating).
+                if (offscreenSubtreeIsHidden) {
+                  // We're inside a hidden Activity boundary. Create the
+                  // instance off-document so we don't leak metadata into
+                  // the head. It will be mounted by the reappear path when
+                  // the Activity becomes visible.
+                  finishedWork.stateNode = createHoistableInstance(
+                    finishedWork.type,
+                    finishedWork.memoizedProps,
+                    root.containerInfo,
+                    finishedWork,
+                  );
+                } else {
+                  finishedWork.stateNode = hydrateHoistable(
+                    hoistableRoot,
+                    finishedWork.type,
+                    finishedWork.memoizedProps,
+                    finishedWork,
+                  );
+                }
+              } else if (!offscreenSubtreeIsHidden) {
+                // The instance was created in beginWork. Only mount it into
+                // the document if we're not inside a hidden Activity boundary.
                 mountHoistable(
                   hoistableRoot,
                   finishedWork.type,
@@ -2145,18 +2173,28 @@ function commitMutationEffectsOnFiber(
           } else if (currentResource !== newResource) {
             // We are moving to or from Hoistable Resource, or between different Hoistable Resources
             if (currentResource === null) {
-              if (current.stateNode !== null) {
+              // Transitioning from Instance to Resource. Only unmount if the
+              // Instance was actually mounted in the document; it may not be
+              // if it lives inside a hidden Activity boundary.
+              if (
+                current.stateNode !== null &&
+                current.stateNode.parentNode !== null
+              ) {
                 unmountHoistable(current.stateNode);
               }
             } else {
               releaseResource(currentResource);
             }
             if (newResource === null) {
-              mountHoistable(
-                hoistableRoot,
-                finishedWork.type,
-                finishedWork.stateNode,
-              );
+              // Transitioning to an Instance. Only mount if visible; hidden
+              // Activity boundaries will mount via the reappear path.
+              if (!offscreenSubtreeIsHidden) {
+                mountHoistable(
+                  hoistableRoot,
+                  finishedWork.type,
+                  finishedWork.stateNode,
+                );
+              }
             } else {
               acquireResource(
                 hoistableRoot,
@@ -3022,7 +3060,6 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
       }
       // Expected fallthrough to HostComponent
     }
-    case HostHoistable:
     case HostComponent: {
       // TODO (Offscreen) Check: flags & RefStatic
       safelyDetachRef(finishedWork, finishedWork.return);
@@ -3033,6 +3070,36 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
           (enableFragmentRefsTextNodes && finishedWork.tag === HostText))
       ) {
         commitFragmentInstanceDeletionEffects(finishedWork);
+      }
+
+      recursivelyTraverseDisappearLayoutEffects(finishedWork);
+      break;
+    }
+    case HostHoistable: {
+      // TODO (Offscreen) Check: flags & RefStatic
+      safelyDetachRef(finishedWork, finishedWork.return);
+
+      if (supportsResources) {
+        // The disappear traversal runs from the mutation phase whenever an
+        // Activity transitions from visible to hidden. We piggy-back on it
+        // (rather than adding a separate recursive traversal) to remove
+        // hoisted metadata such as <title> and <meta> from the document.
+        //
+        // We only act on Hoistable Instances (memoizedState === null).
+        // Resources (memoizedState !== null) are ref-counted and intentionally
+        // remain in the document across Activity visibility transitions;
+        // they are released only on actual deletion.
+        //
+        // The parentNode guard makes this idempotent and safe under StrictMode
+        // dev double-invoke: if the instance is already detached we skip.
+        const instance = finishedWork.stateNode;
+        if (
+          finishedWork.memoizedState === null &&
+          instance !== null &&
+          instance.parentNode !== null
+        ) {
+          unmountHoistable(instance);
+        }
       }
 
       recursivelyTraverseDisappearLayoutEffects(finishedWork);
@@ -3173,7 +3240,6 @@ export function reappearLayoutEffects(
       }
       // Fallthrough
     }
-    case HostHoistable:
     case HostComponent: {
       // TODO: Enable HostText for RN
       if (enableFragmentRefs && finishedWork.tag === HostComponent) {
@@ -3189,6 +3255,57 @@ export function reappearLayoutEffects(
       // (eg DOM renderer may schedule auto-focus for inputs and form controls).
       // These effects should only be committed when components are first mounted,
       // aka when there is no current/alternate.
+      if (includeWorkInProgressEffects && current === null && flags & Update) {
+        commitHostMount(finishedWork);
+      }
+
+      // TODO: Check flags & Ref
+      safelyAttachRef(finishedWork, finishedWork.return);
+      break;
+    }
+    case HostHoistable: {
+      if (supportsResources) {
+        // The reappear traversal runs whenever an Activity transitions from
+        // hidden to visible. We piggy-back on it (rather than adding a
+        // separate recursive traversal) to insert hoistable metadata such as
+        // <title> and <meta> into the document.
+        //
+        // We only act on Hoistable Instances (memoizedState === null).
+        // Resources stay mounted across Activity visibility transitions.
+        //
+        // The parentNode guard makes this idempotent and safe under StrictMode
+        // dev double-invoke: if the instance is already attached we skip.
+        //
+        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
+        // sibling can therefore observe document.title before the hoistable
+        // is re-attached. Moving this to the mutation phase would require an
+        // additional unconditional traversal of the Activity subtree (the
+        // mutation traversal is gated by subtreeFlags and would skip an
+        // unchanged hoistable). The reviewer guidance was to reuse this
+        // existing visibility traversal, so we accept the layout-phase order.
+        const instance = finishedWork.stateNode;
+        if (
+          finishedWork.memoizedState === null &&
+          instance !== null &&
+          instance.parentNode === null
+        ) {
+          // currentHoistableRoot is only maintained during the mutation phase.
+          // Derive the hoistable root from the instance's owner document so
+          // this works in the layout phase too. Hoistable Instances are
+          // hoisted to document.head, which always lives in ownerDocument.
+          mountHoistable(
+            getHoistableRoot(instance.ownerDocument),
+            finishedWork.type,
+            instance,
+          );
+        }
+      }
+      recursivelyTraverseReappearLayoutEffects(
+        finishedRoot,
+        finishedWork,
+        includeWorkInProgressEffects,
+      );
+
       if (includeWorkInProgressEffects && current === null && flags & Update) {
         commitHostMount(finishedWork);
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2176,11 +2176,9 @@ function commitMutationEffectsOnFiber(
               // Transitioning from Instance to Resource. Only unmount if the
               // Instance was actually mounted in the document; it may not be
               // if it lives inside a hidden Activity boundary.
-              if (
-                current.stateNode !== null &&
-                current.stateNode.parentNode !== null
-              ) {
-                unmountHoistable(current.stateNode);
+              const instance = current.stateNode;
+              if (instance !== null && instance.parentNode !== null) {
+                unmountHoistable(instance);
               }
             } else {
               releaseResource(currentResource);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1495,8 +1495,7 @@ function commitDeletionEffectsOnFiber(
           // A Hoistable Instance lives in document.head only when its enclosing
           // Activity is visible. If the Activity is hidden (or has been hidden
           // since mount), the instance was either never inserted or was
-          // detached by the disappear traversal. Guard the removeChild so we
-          // don't throw in those cases.
+          // detached by the disappear traversal. Skip in those cases.
           if (!offscreenSubtreeWasHidden) {
             unmountHoistable(deletedFiber.stateNode);
           }
@@ -2172,9 +2171,10 @@ function commitMutationEffectsOnFiber(
           } else if (currentResource !== newResource) {
             // We are moving to or from Hoistable Resource, or between different Hoistable Resources
             if (currentResource === null) {
-              // Transitioning from Instance to Resource. Only unmount if the
-              // Instance was actually mounted in the document; it may not be
-              // if it lives inside a hidden Activity boundary.
+              // Transitioning from Instance to Resource. Only unmount when the
+              // Instance is currently mounted in the document; hidden Activity
+              // boundaries keep instances off-document or detach them before
+              // this update is processed.
               const instance = current.stateNode;
               if (instance !== null && !offscreenSubtreeWasHidden) {
                 unmountHoistable(instance);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2211,11 +2211,9 @@ function commitMutationEffectsOnFiber(
               // Transitioning from Instance to Resource. Only unmount if the
               // Instance was actually mounted in the document; it may not be
               // if it lives inside a hidden Activity boundary.
-              if (
-                current.stateNode !== null &&
-                current.stateNode.parentNode !== null
-              ) {
-                unmountHoistable(current.stateNode);
+              const instance = current.stateNode;
+              if (instance !== null && instance.parentNode !== null) {
+                unmountHoistable(instance);
               }
             } else {
               releaseResource(currentResource);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1519,8 +1519,7 @@ function commitDeletionEffectsOnFiber(
           // A Hoistable Instance lives in document.head only when its enclosing
           // Activity is visible. If the Activity is hidden (or has been hidden
           // since mount), the instance was either never inserted or was
-          // detached by the disappear traversal. Guard the removeChild so we
-          // don't throw in those cases.
+          // detached by the disappear traversal. Skip in those cases.
           if (!offscreenSubtreeWasHidden) {
             unmountHoistable(deletedFiber.stateNode);
           }
@@ -2207,9 +2206,10 @@ function commitMutationEffectsOnFiber(
           } else if (currentResource !== newResource) {
             // We are moving to or from Hoistable Resource, or between different Hoistable Resources
             if (currentResource === null) {
-              // Transitioning from Instance to Resource. Only unmount if the
-              // Instance was actually mounted in the document; it may not be
-              // if it lives inside a hidden Activity boundary.
+              // Transitioning from Instance to Resource. Only unmount when the
+              // Instance is currently mounted in the document; hidden Activity
+              // boundaries keep instances off-document or detach them before
+              // this update is processed.
               const instance = current.stateNode;
               if (instance !== null && !offscreenSubtreeWasHidden) {
                 unmountHoistable(instance);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -3156,6 +3156,7 @@ function disappearLayoutEffects(
       // TODO (Offscreen) Check: flags & RefStatic
       safelyDetachRef(finishedWork, finishedWork.return);
 
+      // $FlowFixMe[constant-condition]
       if (supportsResources) {
         // The disappear traversal runs from the mutation phase whenever an
         // Activity transitions from visible to hidden. We piggy-back on it
@@ -3179,7 +3180,10 @@ function disappearLayoutEffects(
         }
       }
 
-      recursivelyTraverseDisappearLayoutEffects(finishedWork);
+      recursivelyTraverseDisappearLayoutEffects(
+        finishedWork,
+        layoutEffectTraversalFlags,
+      );
       break;
     }
     case OffscreenComponent: {
@@ -3381,6 +3385,7 @@ function reappearLayoutEffects(
       break;
     }
     case HostHoistable: {
+      // $FlowFixMe[constant-condition]
       if (supportsResources) {
         // The reappear traversal runs whenever an Activity transitions from
         // hidden to visible. We piggy-back on it (rather than adding a
@@ -3420,7 +3425,7 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        includeWorkInProgressEffects,
+        layoutEffectTraversalFlags,
       );
 
       if (includeWorkInProgressEffects && current === null && flags & Update) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2235,6 +2235,13 @@ function commitMutationEffectsOnFiber(
               );
             }
           } else if (newResource === null && finishedWork.stateNode !== null) {
+            if (!offscreenSubtreeIsHidden) {
+              mountHoistable(
+                hoistableRoot,
+                finishedWork.type,
+                finishedWork.stateNode,
+              );
+            }
             commitHostUpdate(
               finishedWork,
               finishedWork.memoizedProps,
@@ -2640,16 +2647,6 @@ function commitMutationEffectsOnFiber(
               } else {
                 layoutEffectTraversalFlags = NoLayoutEffectTraversalFlags;
               }
-              const newOffscreenSubtreeIsHidden =
-                // $FlowFixMe[constant-condition]
-                isHidden || offscreenSubtreeIsHidden;
-              const newOffscreenSubtreeWasHidden =
-                // $FlowFixMe[constant-condition]
-                wasHidden || offscreenSubtreeWasHidden;
-              const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
-              const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
-              offscreenSubtreeIsHidden = newOffscreenSubtreeIsHidden;
-              offscreenSubtreeWasHidden = newOffscreenSubtreeWasHidden;
               recursivelyTraverseDisappearLayoutEffects(
                 finishedWork,
                 layoutEffectTraversalFlags,
@@ -2670,8 +2667,6 @@ function commitMutationEffectsOnFiber(
                   componentEffectEndTime,
                 );
               }
-              offscreenSubtreeIsHidden = prevOffscreenSubtreeIsHidden;
-              offscreenSubtreeWasHidden = prevOffscreenSubtreeWasHidden;
             }
           }
         }
@@ -3360,6 +3355,7 @@ function reappearLayoutEffects(
       }
       // Fallthrough
     }
+    case HostHoistable:
     case HostComponent: {
       // TODO: Enable HostText for RN
       if (
@@ -3379,57 +3375,6 @@ function reappearLayoutEffects(
       // (eg DOM renderer may schedule auto-focus for inputs and form controls).
       // These effects should only be committed when components are first mounted,
       // aka when there is no current/alternate.
-      if (includeWorkInProgressEffects && current === null && flags & Update) {
-        commitHostMount(finishedWork);
-      }
-
-      // TODO: Check flags & Ref
-      safelyAttachRef(finishedWork, finishedWork.return);
-      break;
-    }
-    case HostHoistable: {
-      // $FlowFixMe[constant-condition]
-      if (supportsResources) {
-        // The reappear traversal runs whenever an Activity transitions from
-        // hidden to visible. We piggy-back on it (rather than adding a
-        // separate recursive traversal) to insert hoistable metadata such as
-        // <title> and <meta> into the document.
-        //
-        // We only act on Hoistable Instances (memoizedState === null).
-        // Resources stay mounted across Activity visibility transitions.
-        //
-        // The parentNode guard makes this idempotent and safe under StrictMode
-        // dev double-invoke: if the instance is already attached we skip.
-        //
-        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
-        // sibling can therefore observe document.title before the hoistable
-        // is re-attached. Moving this to the mutation phase would require an
-        // additional unconditional traversal of the Activity subtree (the
-        // mutation traversal is gated by subtreeFlags and would skip an
-        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
-        const instance = finishedWork.stateNode;
-        if (
-          finishedWork.memoizedState === null &&
-          instance !== null &&
-          !offscreenSubtreeIsHidden
-        ) {
-          // currentHoistableRoot is only maintained during the mutation phase.
-          // Derive the hoistable root from the instance's owner document so
-          // this works in the layout phase too. Hoistable Instances are
-          // hoisted to document.head, which always lives in ownerDocument.
-          mountHoistable(
-            getHoistableRoot(instance.ownerDocument),
-            finishedWork.type,
-            instance,
-          );
-        }
-      }
-      recursivelyTraverseReappearLayoutEffects(
-        finishedRoot,
-        finishedWork,
-        layoutEffectTraversalFlags,
-      );
-
       if (includeWorkInProgressEffects && current === null && flags & Update) {
         commitHostMount(finishedWork);
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2235,13 +2235,6 @@ function commitMutationEffectsOnFiber(
               );
             }
           } else if (newResource === null && finishedWork.stateNode !== null) {
-            if (!offscreenSubtreeIsHidden) {
-              mountHoistable(
-                hoistableRoot,
-                finishedWork.type,
-                finishedWork.stateNode,
-              );
-            }
             commitHostUpdate(
               finishedWork,
               finishedWork.memoizedProps,
@@ -2647,6 +2640,16 @@ function commitMutationEffectsOnFiber(
               } else {
                 layoutEffectTraversalFlags = NoLayoutEffectTraversalFlags;
               }
+              const newOffscreenSubtreeIsHidden =
+                // $FlowFixMe[constant-condition]
+                isHidden || offscreenSubtreeIsHidden;
+              const newOffscreenSubtreeWasHidden =
+                // $FlowFixMe[constant-condition]
+                wasHidden || offscreenSubtreeWasHidden;
+              const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
+              const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
+              offscreenSubtreeIsHidden = newOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = newOffscreenSubtreeWasHidden;
               recursivelyTraverseDisappearLayoutEffects(
                 finishedWork,
                 layoutEffectTraversalFlags,
@@ -2667,6 +2670,8 @@ function commitMutationEffectsOnFiber(
                   componentEffectEndTime,
                 );
               }
+              offscreenSubtreeIsHidden = prevOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = prevOffscreenSubtreeWasHidden;
             }
           }
         }
@@ -3355,7 +3360,6 @@ function reappearLayoutEffects(
       }
       // Fallthrough
     }
-    case HostHoistable:
     case HostComponent: {
       // TODO: Enable HostText for RN
       if (
@@ -3375,6 +3379,57 @@ function reappearLayoutEffects(
       // (eg DOM renderer may schedule auto-focus for inputs and form controls).
       // These effects should only be committed when components are first mounted,
       // aka when there is no current/alternate.
+      if (includeWorkInProgressEffects && current === null && flags & Update) {
+        commitHostMount(finishedWork);
+      }
+
+      // TODO: Check flags & Ref
+      safelyAttachRef(finishedWork, finishedWork.return);
+      break;
+    }
+    case HostHoistable: {
+      // $FlowFixMe[constant-condition]
+      if (supportsResources) {
+        // The reappear traversal runs whenever an Activity transitions from
+        // hidden to visible. We piggy-back on it (rather than adding a
+        // separate recursive traversal) to insert hoistable metadata such as
+        // <title> and <meta> into the document.
+        //
+        // We only act on Hoistable Instances (memoizedState === null).
+        // Resources stay mounted across Activity visibility transitions.
+        //
+        // The parentNode guard makes this idempotent and safe under StrictMode
+        // dev double-invoke: if the instance is already attached we skip.
+        //
+        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
+        // sibling can therefore observe document.title before the hoistable
+        // is re-attached. Moving this to the mutation phase would require an
+        // additional unconditional traversal of the Activity subtree (the
+        // mutation traversal is gated by subtreeFlags and would skip an
+        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
+        const instance = finishedWork.stateNode;
+        if (
+          finishedWork.memoizedState === null &&
+          instance !== null &&
+          !offscreenSubtreeIsHidden
+        ) {
+          // currentHoistableRoot is only maintained during the mutation phase.
+          // Derive the hoistable root from the instance's owner document so
+          // this works in the layout phase too. Hoistable Instances are
+          // hoisted to document.head, which always lives in ownerDocument.
+          mountHoistable(
+            getHoistableRoot(instance.ownerDocument),
+            finishedWork.type,
+            instance,
+          );
+        }
+      }
+      recursivelyTraverseReappearLayoutEffects(
+        finishedRoot,
+        finishedWork,
+        layoutEffectTraversalFlags,
+      );
+
       if (includeWorkInProgressEffects && current === null && flags & Update) {
         commitHostMount(finishedWork);
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -3406,8 +3406,7 @@ function reappearLayoutEffects(
         // is re-attached. Moving this to the mutation phase would require an
         // additional unconditional traversal of the Activity subtree (the
         // mutation traversal is gated by subtreeFlags and would skip an
-        // unchanged hoistable). The reviewer guidance was to reuse this
-        // existing visibility traversal, so we accept the layout-phase order.
+        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
         const instance = finishedWork.stateNode;
         if (
           finishedWork.memoizedState === null &&

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -169,6 +169,7 @@ import {
   acquireResource,
   releaseResource,
   hydrateHoistable,
+  createHoistableInstance,
   mountHoistable,
   unmountHoistable,
   prepareToCommitHoistables,
@@ -1515,7 +1516,15 @@ function commitDeletionEffectsOnFiber(
         if (deletedFiber.memoizedState) {
           releaseResource(deletedFiber.memoizedState);
         } else if (deletedFiber.stateNode) {
-          unmountHoistable(deletedFiber.stateNode);
+          // A Hoistable Instance lives in document.head only when its enclosing
+          // Activity is visible. If the Activity is hidden (or has been hidden
+          // since mount), the instance was either never inserted or was
+          // detached by the disappear traversal. Guard the removeChild so we
+          // don't throw in those cases.
+          const instance = deletedFiber.stateNode;
+          if (instance.parentNode !== null) {
+            unmountHoistable(instance);
+          }
         }
         break;
       }
@@ -2157,13 +2166,32 @@ function commitMutationEffectsOnFiber(
             // or a Hoistable Resource
             if (newResource === null) {
               if (finishedWork.stateNode === null) {
-                finishedWork.stateNode = hydrateHoistable(
-                  hoistableRoot,
-                  finishedWork.type,
-                  finishedWork.memoizedProps,
-                  finishedWork,
-                );
-              } else {
+                // Initial mount. The instance has not been created yet, which
+                // happens during hydration (createHoistableInstance is normally
+                // called in beginWork's updateHostHoistable, but is skipped
+                // when hydrating).
+                if (offscreenSubtreeIsHidden) {
+                  // We're inside a hidden Activity boundary. Create the
+                  // instance off-document so we don't leak metadata into
+                  // the head. It will be mounted by the reappear path when
+                  // the Activity becomes visible.
+                  finishedWork.stateNode = createHoistableInstance(
+                    finishedWork.type,
+                    finishedWork.memoizedProps,
+                    root.containerInfo,
+                    finishedWork,
+                  );
+                } else {
+                  finishedWork.stateNode = hydrateHoistable(
+                    hoistableRoot,
+                    finishedWork.type,
+                    finishedWork.memoizedProps,
+                    finishedWork,
+                  );
+                }
+              } else if (!offscreenSubtreeIsHidden) {
+                // The instance was created in beginWork. Only mount it into
+                // the document if we're not inside a hidden Activity boundary.
                 mountHoistable(
                   hoistableRoot,
                   finishedWork.type,
@@ -2180,18 +2208,28 @@ function commitMutationEffectsOnFiber(
           } else if (currentResource !== newResource) {
             // We are moving to or from Hoistable Resource, or between different Hoistable Resources
             if (currentResource === null) {
-              if (current.stateNode !== null) {
+              // Transitioning from Instance to Resource. Only unmount if the
+              // Instance was actually mounted in the document; it may not be
+              // if it lives inside a hidden Activity boundary.
+              if (
+                current.stateNode !== null &&
+                current.stateNode.parentNode !== null
+              ) {
                 unmountHoistable(current.stateNode);
               }
             } else {
               releaseResource(currentResource);
             }
             if (newResource === null) {
-              mountHoistable(
-                hoistableRoot,
-                finishedWork.type,
-                finishedWork.stateNode,
-              );
+              // Transitioning to an Instance. Only mount if visible; hidden
+              // Activity boundaries will mount via the reappear path.
+              if (!offscreenSubtreeIsHidden) {
+                mountHoistable(
+                  hoistableRoot,
+                  finishedWork.type,
+                  finishedWork.stateNode,
+                );
+              }
             } else {
               acquireResource(
                 hoistableRoot,
@@ -3097,7 +3135,6 @@ function disappearLayoutEffects(
       }
       // Expected fallthrough to HostComponent
     }
-    case HostHoistable:
     case HostComponent: {
       // TODO (Offscreen) Check: flags & RefStatic
       safelyDetachRef(finishedWork, finishedWork.return);
@@ -3115,6 +3152,36 @@ function disappearLayoutEffects(
         finishedWork,
         layoutEffectTraversalFlags,
       );
+      break;
+    }
+    case HostHoistable: {
+      // TODO (Offscreen) Check: flags & RefStatic
+      safelyDetachRef(finishedWork, finishedWork.return);
+
+      if (supportsResources) {
+        // The disappear traversal runs from the mutation phase whenever an
+        // Activity transitions from visible to hidden. We piggy-back on it
+        // (rather than adding a separate recursive traversal) to remove
+        // hoisted metadata such as <title> and <meta> from the document.
+        //
+        // We only act on Hoistable Instances (memoizedState === null).
+        // Resources (memoizedState !== null) are ref-counted and intentionally
+        // remain in the document across Activity visibility transitions;
+        // they are released only on actual deletion.
+        //
+        // The parentNode guard makes this idempotent and safe under StrictMode
+        // dev double-invoke: if the instance is already detached we skip.
+        const instance = finishedWork.stateNode;
+        if (
+          finishedWork.memoizedState === null &&
+          instance !== null &&
+          instance.parentNode !== null
+        ) {
+          unmountHoistable(instance);
+        }
+      }
+
+      recursivelyTraverseDisappearLayoutEffects(finishedWork);
       break;
     }
     case OffscreenComponent: {
@@ -3288,7 +3355,6 @@ function reappearLayoutEffects(
       }
       // Fallthrough
     }
-    case HostHoistable:
     case HostComponent: {
       // TODO: Enable HostText for RN
       if (
@@ -3308,6 +3374,57 @@ function reappearLayoutEffects(
       // (eg DOM renderer may schedule auto-focus for inputs and form controls).
       // These effects should only be committed when components are first mounted,
       // aka when there is no current/alternate.
+      if (includeWorkInProgressEffects && current === null && flags & Update) {
+        commitHostMount(finishedWork);
+      }
+
+      // TODO: Check flags & Ref
+      safelyAttachRef(finishedWork, finishedWork.return);
+      break;
+    }
+    case HostHoistable: {
+      if (supportsResources) {
+        // The reappear traversal runs whenever an Activity transitions from
+        // hidden to visible. We piggy-back on it (rather than adding a
+        // separate recursive traversal) to insert hoistable metadata such as
+        // <title> and <meta> into the document.
+        //
+        // We only act on Hoistable Instances (memoizedState === null).
+        // Resources stay mounted across Activity visibility transitions.
+        //
+        // The parentNode guard makes this idempotent and safe under StrictMode
+        // dev double-invoke: if the instance is already attached we skip.
+        //
+        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
+        // sibling can therefore observe document.title before the hoistable
+        // is re-attached. Moving this to the mutation phase would require an
+        // additional unconditional traversal of the Activity subtree (the
+        // mutation traversal is gated by subtreeFlags and would skip an
+        // unchanged hoistable). The reviewer guidance was to reuse this
+        // existing visibility traversal, so we accept the layout-phase order.
+        const instance = finishedWork.stateNode;
+        if (
+          finishedWork.memoizedState === null &&
+          instance !== null &&
+          instance.parentNode === null
+        ) {
+          // currentHoistableRoot is only maintained during the mutation phase.
+          // Derive the hoistable root from the instance's owner document so
+          // this works in the layout phase too. Hoistable Instances are
+          // hoisted to document.head, which always lives in ownerDocument.
+          mountHoistable(
+            getHoistableRoot(instance.ownerDocument),
+            finishedWork.type,
+            instance,
+          );
+        }
+      }
+      recursivelyTraverseReappearLayoutEffects(
+        finishedRoot,
+        finishedWork,
+        includeWorkInProgressEffects,
+      );
+
       if (includeWorkInProgressEffects && current === null && flags & Update) {
         commitHostMount(finishedWork);
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1521,9 +1521,8 @@ function commitDeletionEffectsOnFiber(
           // since mount), the instance was either never inserted or was
           // detached by the disappear traversal. Guard the removeChild so we
           // don't throw in those cases.
-          const instance = deletedFiber.stateNode;
-          if (instance.parentNode !== null) {
-            unmountHoistable(instance);
+          if (!offscreenSubtreeWasHidden) {
+            unmountHoistable(deletedFiber.stateNode);
           }
         }
         break;
@@ -2212,7 +2211,7 @@ function commitMutationEffectsOnFiber(
               // Instance was actually mounted in the document; it may not be
               // if it lives inside a hidden Activity boundary.
               const instance = current.stateNode;
-              if (instance !== null && instance.parentNode !== null) {
+              if (instance !== null && !offscreenSubtreeWasHidden) {
                 unmountHoistable(instance);
               }
             } else {
@@ -2641,6 +2640,16 @@ function commitMutationEffectsOnFiber(
               } else {
                 layoutEffectTraversalFlags = NoLayoutEffectTraversalFlags;
               }
+              const newOffscreenSubtreeIsHidden =
+                // $FlowFixMe[constant-condition]
+                isHidden || offscreenSubtreeIsHidden;
+              const newOffscreenSubtreeWasHidden =
+                // $FlowFixMe[constant-condition]
+                wasHidden || offscreenSubtreeWasHidden;
+              const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
+              const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
+              offscreenSubtreeIsHidden = newOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = newOffscreenSubtreeWasHidden;
               recursivelyTraverseDisappearLayoutEffects(
                 finishedWork,
                 layoutEffectTraversalFlags,
@@ -2661,6 +2670,8 @@ function commitMutationEffectsOnFiber(
                   componentEffectEndTime,
                 );
               }
+              offscreenSubtreeIsHidden = prevOffscreenSubtreeIsHidden;
+              offscreenSubtreeWasHidden = prevOffscreenSubtreeWasHidden;
             }
           }
         }
@@ -3158,23 +3169,15 @@ function disappearLayoutEffects(
 
       // $FlowFixMe[constant-condition]
       if (supportsResources) {
-        // The disappear traversal runs from the mutation phase whenever an
-        // Activity transitions from visible to hidden. We piggy-back on it
-        // (rather than adding a separate recursive traversal) to remove
-        // hoisted metadata such as <title> and <meta> from the document.
-        //
         // We only act on Hoistable Instances (memoizedState === null).
         // Resources (memoizedState !== null) are ref-counted and intentionally
         // remain in the document across Activity visibility transitions;
         // they are released only on actual deletion.
-        //
-        // The parentNode guard makes this idempotent and safe under StrictMode
-        // dev double-invoke: if the instance is already detached we skip.
         const instance = finishedWork.stateNode;
         if (
           finishedWork.memoizedState === null &&
           instance !== null &&
-          instance.parentNode !== null
+          !offscreenSubtreeWasHidden
         ) {
           unmountHoistable(instance);
         }
@@ -3409,7 +3412,7 @@ function reappearLayoutEffects(
         if (
           finishedWork.memoizedState === null &&
           instance !== null &&
-          instance.parentNode === null
+          !offscreenSubtreeIsHidden
         ) {
           // currentHoistableRoot is only maintained during the mutation phase.
           // Derive the hoistable root from the instance's owner document so


### PR DESCRIPTION
## Summary

This fixes #34738 

In React 19.2, metadata tags (`<title>`) are automatically hoisted to the document <head>. However, these tags were incorrectly being hoisted even when inside hidden <Activity> components, causing the browser's document title to be set by hidden content.

<img width="728" height="461" alt="image" src="https://github.com/user-attachments/assets/1e70fafe-c348-479b-8d83-e6b4b8784032" />


This commit fixes the issue by making the hoisting logic Activity-aware:

1. Check offscreenSubtreeIsHidden before mounting hoistables during the initial commit phase to prevent hoisting in hidden Activities
2. Move mounting of Hoistables to Layout phase which is already traveresed recursively when switching Activity modes. There's a tradeoff where earlier sibling Layout Effects would not observe the new title but that matches the existing tradeoff for Host Singletons.

## How did you test this change?

Added tests for this as well as tested this on local using the reference code from the link https://github.com/nilshartmann/react-activity-title given in #34738 issue description.
