### PR TITLE
Performance: store effects in array instead of linked list

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -145,11 +145,10 @@ export function commitHookEffectListMount(
   try {
     const updateQueue: FunctionComponentUpdateQueue | null =
       (finishedWork.updateQueue: any);
-    const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
-    if (lastEffect !== null) {
-      const firstEffect = lastEffect.next;
-      let effect = firstEffect;
-      do {
+    const effects = updateQueue !== null ? updateQueue.effects : null;
+    if (effects !== null) {
+      for (let i = 0; i < effects.length; i++) {
+        const effect = effects[i];
         if ((effect.tag & flags) === flags) {
           if (enableSchedulingProfiler) {
             if ((flags & HookPassive) !== NoHookEffect) {
@@ -237,8 +236,7 @@ export function commitHookEffectListMount(
             }
           }
         }
-        effect = effect.next;
-      } while (effect !== firstEffect);
+      }
     }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);
@@ -253,11 +251,10 @@ export function commitHookEffectListUnmount(
   try {
     const updateQueue: FunctionComponentUpdateQueue | null =
       (finishedWork.updateQueue: any);
-    const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
-    if (lastEffect !== null) {
-      const firstEffect = lastEffect.next;
-      let effect = firstEffect;
-      do {
+    const effects = updateQueue !== null ? updateQueue.effects : null;
+    if (effects !== null) {
+      for (let i = 0; i < effects.length; i++) {
+        const effect = effects[i];
         if ((effect.tag & flags) === flags) {
           // Unmount
           const inst = effect.inst;
@@ -293,8 +290,7 @@ export function commitHookEffectListUnmount(
             }
           }
         }
-        effect = effect.next;
-      } while (effect !== firstEffect);
+      }
     }
   } catch (error) {
     captureCommitPhaseError(finishedWork, finishedWork.return, error);


### PR DESCRIPTION
## Summary

Considering that effects are only appended (the list of effects is never mutated in the middle), `Array` seems like a better fit because it has a better cache locality, and it creates less memory allocations so there's less pressure on the GC.

## How did you test this change?

I have tested various benchmarks we have in [Base UI](https://github.com/mui/base-ui) and they've shown a fairly small but consistent improvement across the board. I've also spin up [this benchmark](https://gist.github.com/romgrk/3c64ac061e2267d65db22703d32a5abf) that puts an extreme focus on effects to illustrate clearly the improvement. The average runtime is consistently lower, but interestingly the standard deviation is also consistently lower, which probably indicates that the garbage collector is doing less pauses (due to the fewer memory allocations).

Before:
<img width="877" height="121" alt="image" src="https://github.com/user-attachments/assets/6f1cf943-01e9-43eb-b6a2-a39cc4fffab4" />
After:
<img width="877" height="121" alt="image" src="https://github.com/user-attachments/assets/469bbd68-a72f-44a4-9bd7-d866d54cbd57" />

