### PR TITLE
[Flight] allow context providers from client modules

### DIFF
--- a/fixtures/flight/src/App.js
+++ b/fixtures/flight/src/App.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {renderToReadableStream} from 'react-server-dom-unbundled/server';
 import {createFromReadableStream} from 'react-server-dom-webpack/client';
 import {PassThrough, Readable} from 'stream';
-
+import {ClientContext, ClientReadContext} from './ClientContext.js';
 import Container from './Container.js';
 
 import {Counter} from './Counter.js';
@@ -235,6 +235,11 @@ export default async function App({prerender, noCache}) {
           <Foo>{dedupedChild}</Foo>
           <Bar>{Promise.resolve([dedupedChild])}</Bar>
           <Navigate />
+          <ClientContext value="from server">
+            <div>
+              <ClientReadContext />
+            </div>
+          </ClientContext>
           {prerender ? null : ( // TODO: prerender is broken for large content for some reason.
             <React.Suspense fallback={null}>
               <LargeContent />

--- a/fixtures/flight/src/ClientContext.js
+++ b/fixtures/flight/src/ClientContext.js
@@ -1,0 +1,12 @@
+'use client';
+
+import {createContext, use} from 'react';
+
+const ClientContext = createContext(null);
+
+function ClientReadContext() {
+  const value = use(ClientContext);
+  return <p>{value}</p>;
+}
+
+export {ClientContext, ClientReadContext};

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -128,6 +128,7 @@ import {
   REACT_LAZY_TYPE,
   REACT_FORWARD_REF_TYPE,
   REACT_MEMO_TYPE,
+  REACT_CONTEXT_TYPE,
 } from 'shared/ReactSymbols';
 import {setCurrentFiber} from './ReactCurrentFiber';
 import {
@@ -2140,6 +2141,10 @@ function mountLazyComponent(
         props,
         renderLanes,
       );
+    } else if ($$typeof === REACT_CONTEXT_TYPE) {
+      workInProgress.tag = ContextProvider;
+      workInProgress.type = Component;
+      return updateContextProvider(null, workInProgress, renderLanes);
     }
   }
 

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -116,6 +116,44 @@ describe('ReactLazy', () => {
     expect(root).toMatchRenderedOutput('Hi again');
   });
 
+  it('renders a lazy context provider', async () => {
+    const Context = React.createContext('default');
+    function ConsumerText() {
+      return <Text text={React.useContext(Context)} />;
+    }
+    // Context.Provider === Context, so we can lazy-load the context itself
+    const LazyProvider = lazy(() => fakeImport(Context));
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyProvider value="Hi">
+          <ConsumerText />
+        </LazyProvider>
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    await waitForAll(['Loading...']);
+    expect(root).not.toMatchRenderedOutput('Hi');
+
+    await act(() => resolveFakeImport(Context));
+    assertLog(['Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
+
+    // Should not suspend on update
+    root.update(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyProvider value="Hi again">
+          <ConsumerText />
+        </LazyProvider>
+      </Suspense>,
+    );
+    await waitForAll(['Hi again']);
+    expect(root).toMatchRenderedOutput('Hi again');
+  });
+
   it('can resolve synchronously without suspending', async () => {
     const LazyText = lazy(() => ({
       then(cb) {
@@ -858,13 +896,20 @@ describe('ReactLazy', () => {
     );
   });
 
-  it('throws with a useful error when wrapping Context with lazy()', async () => {
-    const Context = React.createContext(null);
-    const BadLazy = lazy(() => fakeImport(Context));
+  it('renders a lazy context provider without value prop', async () => {
+    // Context providers work when wrapped in lazy()
+    const Context = React.createContext('default');
+    const LazyProvider = lazy(() => fakeImport(Context));
+
+    function ConsumerText() {
+      return <Text text={React.useContext(Context)} />;
+    }
 
     const root = ReactTestRenderer.create(
       <Suspense fallback={<Text text="Loading..." />}>
-        <BadLazy />
+        <LazyProvider value="provided">
+          <ConsumerText />
+        </LazyProvider>
       </Suspense>,
       {
         unstable_isConcurrent: true,
@@ -873,16 +918,9 @@ describe('ReactLazy', () => {
 
     await waitForAll(['Loading...']);
 
-    await resolveFakeImport(Context);
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <BadLazy />
-      </Suspense>,
-    );
-    await waitForThrow(
-      'Element type is invalid. Received a promise that resolves to: Context. ' +
-        'Lazy element type must resolve to a class or function.',
-    );
+    await act(() => resolveFakeImport(Context));
+    assertLog(['provided']);
+    expect(root).toMatchRenderedOutput('provided');
   });
 
   it('throws with a useful error when wrapping Context.Consumer with lazy()', async () => {

--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
@@ -182,11 +182,10 @@ const deepProxyHandlers: Proxy$traps<mixed> = {
         // $FlowFixMe[prop-missing]
         return Object.prototype[Symbol.toStringTag];
       case 'Provider':
-        throw new Error(
-          `Cannot render a Client Context Provider on the Server. ` +
-            `Instead, you can export a Client Component wrapper ` +
-            `that itself renders a Client Context Provider.`,
-        );
+        // Context.Provider === Context in React, so return the same reference.
+        // This allows server components to render <ClientContext.Provider>
+        // which will be serialized and executed on the client.
+        return receiver;
       case 'then':
         throw new Error(
           `Cannot await or return from a thenable. ` +

--- a/packages/react-server-dom-unbundled/src/ReactFlightUnbundledReferences.js
+++ b/packages/react-server-dom-unbundled/src/ReactFlightUnbundledReferences.js
@@ -182,11 +182,10 @@ const deepProxyHandlers: Proxy$traps<mixed> = {
         // $FlowFixMe[prop-missing]
         return Object.prototype[Symbol.toStringTag];
       case 'Provider':
-        throw new Error(
-          `Cannot render a Client Context Provider on the Server. ` +
-            `Instead, you can export a Client Component wrapper ` +
-            `that itself renders a Client Context Provider.`,
-        );
+        // Context.Provider === Context in React, so return the same reference.
+        // This allows server components to render <ClientContext.Provider>
+        // which will be serialized and executed on the client.
+        return receiver;
       case 'then':
         throw new Error(
           `Cannot await or return from a thenable. ` +

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
@@ -182,11 +182,10 @@ const deepProxyHandlers: Proxy$traps<mixed> = {
         // $FlowFixMe[prop-missing]
         return Object.prototype[Symbol.toStringTag];
       case 'Provider':
-        throw new Error(
-          `Cannot render a Client Context Provider on the Server. ` +
-            `Instead, you can export a Client Component wrapper ` +
-            `that itself renders a Client Context Provider.`,
-        );
+        // Context.Provider === Context in React, so return the same reference.
+        // This allows server components to render <ClientContext.Provider>
+        // which will be serialized and executed on the client.
+        return receiver;
       case 'then':
         throw new Error(
           `Cannot await or return from a thenable. ` +

--- a/packages/react-server/src/ReactFlightServerTemporaryReferences.js
+++ b/packages/react-server/src/ReactFlightServerTemporaryReferences.js
@@ -65,11 +65,10 @@ const proxyHandlers: Proxy$traps<mixed> = {
         // $FlowFixMe[prop-missing]
         return Object.prototype[Symbol.toStringTag];
       case 'Provider':
-        throw new Error(
-          `Cannot render a Client Context Provider on the Server. ` +
-            `Instead, you can export a Client Component wrapper ` +
-            `that itself renders a Client Context Provider.`,
-        );
+        // Context.Provider === Context in React, so return the same reference.
+        // This allows server components to render <ClientContext.Provider>
+        // which will be serialized and executed on the client.
+        return receiver;
       case 'then':
         // Allow returning a temporary reference from an async function
         // Unlike regular Client References, a Promise would never have been serialized as


### PR DESCRIPTION
Allows Server Components to import Context from a `"use client'` module and render its Provider. 


That means you can now import Context in a server component and pass it a value for the Client to read without a client component wrapper:


```js
import {Context, ClientCompoent} from './Client';


export function App() {
  return (
    <Context value="from server">
      <ClientComponent />
    </Context>
  );
}

```

```js
// Client.js
"use client"

export const Context = createContext(null);

export function ClientComponent() {
  return <div>{use(Context)}</div>
}
```

Note: this is not server context. It's just creating the Context with a value from the server in the client bundle. You cannot `use(Context)` in a server component.

Only tricky part was that I needed to add `REACT_CONTEXT_TYPE` handling in mountLazyComponent so lazy-resolved Context types can be rendered. Previously only functions, REACT_FORWARD_REF_TYPE, and REACT_MEMO_TYPE were handled.

Tested in the Flight fixture.

ty bb claude

Closes https://github.com/facebook/react/issues/35340