### PR TITLE
Don't hydrate Elements that have dangerouslySetInnerHTML and suppressHydrationWarning

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -2618,6 +2618,10 @@ function diffHydratedGenericElement(
         // Noop
         continue;
       case 'dangerouslySetInnerHTML':
+        // Skip innerHTML comparison only when suppressHydrationWarning is also set
+        if (props.suppressHydrationWarning === true) {
+          continue;
+        }
         const serverHTML = domElement.innerHTML;
         const nextHtml = value ? value.__html : undefined;
         if (nextHtml != null) {
@@ -3220,10 +3224,12 @@ export function hydrateProperties(
   // even listeners these nodes might be wired up to.
   // TODO: Warn if there is more than a single textNode as a child.
   // TODO: Should we use domElement.firstChild.nodeValue to compare?
+  // Skip text content check if both dangerouslySetInnerHTML and suppressHydrationWarning are present
   if (
-    typeof children === 'string' ||
-    typeof children === 'number' ||
-    typeof children === 'bigint'
+    !(props.dangerouslySetInnerHTML != null && props.suppressHydrationWarning === true) &&
+    (typeof children === 'string' ||
+      typeof children === 'number' ||
+      typeof children === 'bigint')
   ) {
     if (
       // $FlowFixMe[unsafe-addition] Flow doesn't want us to use `+` operator with string and bigint

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -276,7 +276,18 @@ function tryHydrateInstance(
     }
 
     hydrationParentFiber = fiber;
-    nextHydratableInstance = getFirstHydratableChild(instance);
+    // Skip hydrating children if this element has both suppressHydrationWarning
+    // and dangerouslySetInnerHTML - this allows developers to opt-out of
+    // hydration validation for elements where server/client HTML intentionally differs
+    const props = fiber.pendingProps;
+    if (
+      props.dangerouslySetInnerHTML != null &&
+      props.suppressHydrationWarning === true
+    ) {
+      nextHydratableInstance = null;
+    } else {
+      nextHydratableInstance = getFirstHydratableChild(instance);
+    }
     rootOrSingletonContext = false;
     return true;
   }


### PR DESCRIPTION
## Summary

In React 18 it was possible to set dangerouslySetInnerHTML and suppressHydrationWarning for elements you would know that change before hydration, this could be:
* react rendered script tags that get modified by the included scripts
* Server Side Includes thar replace parts of the dom

examples are: https://github.com/facebook/react/issues/32975 or https://github.com/facebook/react/issues/24430

if you ask a LLM how to fix those warnings they persist on suppressHydrationWarning still being the way to go with React 19

## How did you test this change?

I added a simple test case and had a local page where i tried it.
