### PR TITLE
Preserve resolved dehydrated Suspense content on context change

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3045,6 +3045,19 @@ function updateDehydratedSuspenseComponent(
           // a new real Suspense boundary to take its place, which may render content
           // or fallback. This might suspend for a while and if it does we might still have
           // an opportunity to hydrate before this pass commits.
+
+          if (
+            !didReceiveUpdate &&
+            !isSuspenseInstancePending(suspenseInstance) &&
+            !isSuspenseInstanceFallback(suspenseInstance)
+          ) {
+            // This is a resolved dehydrated boundary, and the only reason
+            // we're here is that context changed. Keep the dehydrated
+            // fragment in place and retry hydration later.
+            workInProgress.flags |= DidCapture | Callback;
+            workInProgress.child = current.child;
+            return null;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

When a resolved dehydrated Suspense boundary contains a suspended child, a parent context change can mark the boundary as needing work during hydration. If selective hydration retries are exhausted, React would give up and replace the dehydrated subtree with a client-rendered boundary, destroying the server HTML and showing the fallback.

Preserve the dehydrated fragment in this case when the boundary is resolved and the only change is context (not props).

Fixes https://github.com/facebook/react/issues/22692

## How did you test this change?

Added regression tests
