### PR TITLE
[eprh] Bump hermes-parser to 0.33.3

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/core": "^7.24.4",
     "@babel/parser": "^7.24.4",
-    "hermes-parser": "^0.25.1",
+    "hermes-parser": "^0.33.3",
     "zod": "^3.25.0 || ^4.0.0",
     "zod-validation-error": "^3.5.0 || ^4.0.0"
   },

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -187,6 +187,7 @@ let getRollupInteropValue = id => {
     'JSResourceReferenceImpl',
     'error-stack-parser',
     'neo-async',
+    'os',
     'webpack/lib/dependencies/ModuleDependency',
     'webpack/lib/dependencies/NullDependency',
     'webpack/lib/Template',

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -1276,6 +1276,7 @@ const bundles = [
       'zod-validation-error',
       'zod-validation-error/v4',
       'crypto',
+      'os',
       'util',
     ],
     tsconfig: './packages/eslint-plugin-react-hooks/tsconfig.json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8167,6 +8167,7 @@ eslint-plugin-no-unsanitized@4.0.2:
 
 "eslint-plugin-react-internal@link:./scripts/eslint-rules":
   version "0.0.0"
+  uid ""
 
 eslint-plugin-react@^6.7.1:
   version "6.10.3"
@@ -10126,11 +10127,6 @@ hermes-eslint@^0.32.0:
     hermes-estree "0.32.0"
     hermes-parser "0.32.0"
 
-hermes-estree@0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.25.1.tgz#6aeec17d1983b4eabf69721f3aa3eb705b17f480"
-  integrity sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==
-
 hermes-estree@0.29.1:
   version "0.29.1"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.29.1.tgz#043c7db076e0e8ef8c5f6ed23828d1ba463ebcc5"
@@ -10140,6 +10136,11 @@ hermes-estree@0.32.0:
   version "0.32.0"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.32.0.tgz#bb7da6613ab8e67e334a1854ea1e209f487d307b"
   integrity sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==
+
+hermes-estree@0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.33.3.tgz#6d6b593d4b471119772c82bdb0212dfadabb6f17"
+  integrity sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==
 
 hermes-parser@0.29.1:
   version "0.29.1"
@@ -10155,12 +10156,12 @@ hermes-parser@0.32.0, hermes-parser@^0.32.0:
   dependencies:
     hermes-estree "0.32.0"
 
-hermes-parser@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.25.1.tgz#5be0e487b2090886c62bd8a11724cd766d5f54d1"
-  integrity sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==
+hermes-parser@^0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.33.3.tgz#da50ababb7a5ab636d339e7b2f6e3848e217e09d"
+  integrity sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==
   dependencies:
-    hermes-estree "0.25.1"
+    hermes-estree "0.33.3"
 
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
## Summary

Bumps `hermes-parser` from `^0.25.1` to `^0.33.3` in `eslint-plugin-react-hooks`.

The previous version was significantly behind the latest release. This update brings in parser improvements and bug fixes from 8 minor versions of `hermes-parser`.

## Test plan

- Ran the `eslint-plugin-react-hooks` test suite
- Ran `yarn lint` on the repository
- Ran `yarn build eslint-plugin-react-hooks` from the root of the monorepo

> [!NOTE]
> In order to build `eslint-plugin-react-hooks`, I had to add `@types/babel__code-frame` to `babel-plugin-react-compiler/package.json`, that change is not included in this PR