### PR TITLE
Fix typos in comments

### DIFF
--- a/packages/react-reconciler/src/ReactFiberComponentStack.js
+++ b/packages/react-reconciler/src/ReactFiberComponentStack.js
@@ -182,7 +182,7 @@ export function getOwnerStackByFiberInDev(workInProgress: Fiber): string {
         // In a real app it's typically not useful since the root app is always controlled
         // by the framework. These also tend to have noisy stacks because they're not rooted
         // in a React render but in some imperative bootstrapping code. It could be useful
-        // if the element was created in module scope. E.g. hoisted. We could add a a single
+        // if the element was created in module scope. E.g. hoisted. We could add a single
         // stack frame for context for example but it doesn't say much if that's a wrapper.
         if (owner && debugStack) {
           const formattedStack = formatOwnerStack(debugStack);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1922,7 +1922,7 @@ export function flushSyncFromReconciler<R>(fn: (() => R) | void): R | void {
 }
 
 // If called outside of a render or commit will flush all sync work on all roots
-// Returns whether the the call was during a render or not
+// Returns whether the call was during a render or not
 export function flushSyncWork(): boolean {
   if ((executionContext & (RenderContext | CommitContext)) === NoContext) {
     flushSyncWorkOnAllRoots();

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -12,7 +12,7 @@
  * and Temporal.* types. See https://github.com/facebook/react/pull/22064.
  *
  * The functions in this module will throw an easier-to-understand,
- * easier-to-debug exception with a clear errors message message explaining the
+ * easier-to-debug exception with a clear error message explaining the
  * problem. (Instead of a confusing exception thrown inside the implementation
  * of the `value` object).
  */
@@ -63,7 +63,7 @@ function testStringCoercion(value: mixed) {
   // To find which value is throwing, check the browser or debugger console.
   // Before this exception was thrown, there should be `console.error` output
   // that shows the type (Symbol, Temporal.PlainDate, etc.) that caused the
-  // problem and how that type was used: key, atrribute, input value prop, etc.
+  // problem and how that type was used: key, attribute, input value prop, etc.
   // In most cases, this console output also shows the component and its
   // ancestor components where the exception happened.
   //


### PR DESCRIPTION
  ## Summary                                                                 

  Fix four typos in code comments:                                              
  
  - `CheckStringCoercion.js:15` — "errors message message" → "error message"    
  - `CheckStringCoercion.js:66` — "atrribute" → "attribute"                  
  - `ReactFiberWorkLoop.js:1925` — "the the call" → "the call"                  
  - `ReactFiberComponentStack.js:185` — "a a single" → "a single"               
                                                                                
  ## How did you test this change?                                              
                                                                                
  Comment-only changes, no runtime impact.