### PR TITLE
[react-refresh] fix memory leak: only add root to helpersByRoot on mount

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -509,8 +509,6 @@ export function injectIntoGlobalHook(globalObject: any): void {
     ) {
       const helpers = helpersByRendererID.get(id);
       if (helpers !== undefined) {
-        helpersByRoot.set(root, helpers);
-
         const current = root.current;
         const alternate = current.alternate;
 
@@ -530,6 +528,7 @@ export function injectIntoGlobalHook(globalObject: any): void {
 
           if (!wasMounted && isMounted) {
             // Mount a new root.
+            helpersByRoot.set(root, helpers);
             mountedRoots.add(root);
             failedRoots.delete(root);
           } else if (wasMounted && isMounted) {
@@ -545,13 +544,14 @@ export function injectIntoGlobalHook(globalObject: any): void {
               helpersByRoot.delete(root);
             }
           } else if (!wasMounted && !isMounted) {
-            if (didError) {
+            if (didError && helpersByRoot.has(root)) {
               // We'll remount it on future edits.
               failedRoots.add(root);
             }
           }
         } else {
           // Mount a new root.
+          helpersByRoot.set(root, helpers);
           mountedRoots.add(root);
         }
       }


### PR DESCRIPTION
## Summary

Fixes #36379

### Problem

`helpersByRoot.set(root, helpers)` was called unconditionally on **every** `onCommitFiberRoot` invocation. This means that even after a root is unmounted (and correctly deleted from `helpersByRoot` in the `wasMounted && !isMounted` branch), any subsequent commit from that renderer ID would re-add the root to the Map.

This causes memory leaks for secondary renderers such as **react-three-fiber**, where Canvas roots are repeatedly mounted and unmounted. The `helpersByRoot` Map grows without bound, preventing garbage collection of fiber roots and their associated component trees.

### Fix

Move `helpersByRoot.set(root, helpers)` into the **mount** branches only:

1. **`!wasMounted && isMounted`** (new mount with an existing alternate): set the root in `helpersByRoot`.
2. **`else`** (first mount without alternate): set the root in `helpersByRoot`.
3. **`wasMounted && isMounted`** (update): no change needed — root is already in the Map from the initial mount.
4. **`!wasMounted && !isMounted && didError`**: guard `failedRoots.add(root)` with `helpersByRoot.has(root)` to avoid retaining roots that were never successfully mounted.

### Testing

- Existing tests in `ReactFreshMultipleRenderer-test.internal.js` exercise the multi-renderer path and should continue to pass.
- The reporter provided a [repro repo with WeakRef visualization](https://github.com/facebook/react/issues/36379) showing the leak before and after the fix.