### PR TITLE
Fix unmatched select size value handling

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMSelect.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMSelect.js
@@ -101,8 +101,10 @@ function updateOptions(
         defaultSelected = options[i];
       }
     }
-    if (defaultSelected !== null) {
+    if (defaultSelected !== null && node.size <= 1) {
       defaultSelected.selected = true;
+    } else if (node.size > 1) {
+      node.selectedIndex = -1;
     }
   }
 }

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -486,6 +486,45 @@ describe('ReactDOMSelect', () => {
     expect(select.selectedIndex).toBe(-1);
   });
 
+  it('does not select an item when size is greater than 1 and value does not match', async () => {
+    const stub = (
+      <select size="2" value="giraffe" onChange={noop}>
+        <option value="monkey">A monkey!</option>
+        <option value="giraffe">A giraffe!</option>
+        <option value="gorilla">A gorilla!</option>
+      </select>
+    );
+    const options = stub.props.children;
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(stub);
+    });
+
+    const select = container.firstChild;
+
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(true);
+    expect(select.options[2].selected).toBe(false);
+    expect(select.value).toBe('giraffe');
+    expect(select.selectedIndex).toBe(1);
+
+    await act(() => {
+      root.render(
+        <select size="2" value="not-an-option" onChange={noop}>
+          {options}
+        </select>,
+      );
+    });
+
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(false);
+    expect(select.options[2].selected).toBe(false);
+    expect(select.value).toBe('');
+    expect(select.selectedIndex).toBe(-1);
+  });
+
   it('should remember value when switching to uncontrolled', async () => {
     const stub = (
       <select value={'giraffe'} onChange={noop}>


### PR DESCRIPTION
## Summary

Fixes #24469.

When a controlled single-select has `size > 1` and its `value` does not match any option, React should leave the select with no selected option instead of selecting the first non-disabled option. This matches the browser behavior React already preserves for initially rendered listbox-style selects.

## How did you test this change?

- `corepack yarn test ReactDOMSelect-test`
- `corepack yarn test --prod ReactDOMSelect-test`
- `corepack yarn prettier`
- `corepack yarn linc`
- `./node_modules/.bin/flow.cmd status` with the generated `dom-browser` Flow config