### PR TITLE
Preserve computed object method keys

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -1685,7 +1685,7 @@ function codegenInstructionValue(
                 key,
                 fn.params,
                 fn.body,
-                false,
+                property.key.kind === 'computed',
               );
               babelNode.async = fn.async;
               babelNode.generator = fn.generator;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-object-method-key.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-object-method-key.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  const computedKey = props.computedKey;
+  return {
+    [computedKey]() {
+      return props.value;
+    },
+  };
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{computedKey: 'readValue', value: 42}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+  const $ = _c(3);
+  const computedKey = props.computedKey;
+  let t0;
+  if ($[0] !== computedKey || $[1] !== props.value) {
+    t0 = {
+      [computedKey]() {
+        return props.value;
+      },
+    };
+    $[0] = computedKey;
+    $[1] = props.value;
+    $[2] = t0;
+  } else {
+    t0 = $[2];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ computedKey: "readValue", value: 42 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) {"readValue":"[[ function params=0 ]]"}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-object-method-key.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/computed-object-method-key.js
@@ -1,0 +1,13 @@
+function Component(props) {
+  const computedKey = props.computedKey;
+  return {
+    [computedKey]() {
+      return props.value;
+    },
+  };
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{computedKey: 'readValue', value: 42}],
+};


### PR DESCRIPTION
## Summary
- preserve computed object method keys when generating object methods
- add a compiler fixture covering computed method shorthand output

## Why
Object properties already forward the computed-key flag to Babel codegen, but object methods always passed `false`. That caused computed method shorthand like `{[computedKey]() {}}` to print as `{computedKey() {}}`, changing the property name.

Fixes #35203.

## Test Plan
- `corepack yarn workspace snap run build`
- `corepack yarn workspace snap run snap --update --pattern computed-object-method-key --sync`
- `corepack yarn workspace snap run snap --pattern computed-object-method-key --sync`
- `corepack yarn workspace babel-plugin-react-compiler run lint -- --quiet`
- `corepack yarn prettier`