### PR TITLE
Add createElement ref prop compiler fixture

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/createElement-ref-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/createElement-ref-prop.expect.md
@@ -1,0 +1,46 @@
+
+## Input
+
+```javascript
+import React, {useRef} from 'react';
+
+function refInHtmlElement() {
+  const ref = useRef(null);
+  return React.createElement('canvas', {ref});
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: refInHtmlElement,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import React, { useRef } from "react";
+
+function refInHtmlElement() {
+  const $ = _c(1);
+  const ref = useRef(null);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = React.createElement("canvas", { ref });
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: refInHtmlElement,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) <canvas></canvas>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/createElement-ref-prop.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/createElement-ref-prop.js
@@ -1,0 +1,11 @@
+import React, {useRef} from 'react';
+
+function refInHtmlElement() {
+  const ref = useRef(null);
+  return React.createElement('canvas', {ref});
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: refInHtmlElement,
+  params: [],
+};


### PR DESCRIPTION
## Summary
- add a compiler fixture for `React.createElement("canvas", {ref})`
- cover the reported false-positive shape from #31357 with successful output/eval

## Why
The reported createElement/ref case now compiles on current main. This fixture locks in that behavior so `React.createElement` does not regress relative to the JSX `<canvas ref={ref} />` case.

Covers #31357.

## Test Plan
- `corepack yarn workspace snap run snap --update --pattern createElement-ref-prop --sync`
- `corepack yarn workspace snap run snap --pattern createElement-ref-prop --sync`
- `corepack yarn workspace babel-plugin-react-compiler run lint -- --quiet`
- `corepack yarn prettier`