### PR TITLE
Infer filter as a mixed readonly array method

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/TypeInference/InferTypes.ts
@@ -108,6 +108,9 @@ function equation(left: Type, right: Type): TypeEquation {
   };
 }
 
+// These method names only exist on arrays in the MixedReadonly model.
+const ARRAY_METHODS_ON_MIXED_READONLY = new Set(['filter']);
+
 function* generate(
   func: HIRFunction,
 ): Generator<TypeEquation, void, undefined> {
@@ -321,6 +324,12 @@ function* generateInstructionTypes(
     }
 
     case 'PropertyLoad': {
+      if (ARRAY_METHODS_ON_MIXED_READONLY.has(String(value.property))) {
+        yield equation(value.object.identifier.type, {
+          kind: 'Object',
+          shapeId: BuiltInMixedReadonlyId,
+        });
+      }
       yield equation(left, {
         kind: 'Property',
         objectType: value.object.identifier.type,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/local-mutation-in-filter-usememo.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/local-mutation-in-filter-usememo.expect.md
@@ -1,0 +1,99 @@
+
+## Input
+
+```javascript
+import React from 'react';
+
+export function Component({items}) {
+  const stuff = React.useMemo(() => {
+    let isCool = false;
+    const someItems = items.filter(cause => {
+      if (cause.foo) {
+        isCool = true;
+      }
+      return true;
+    });
+
+    if (someItems.length > 0) {
+      return {someItems, isCool};
+    }
+  }, [items]);
+  return <div>{stuff?.someItems.length}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{items: [{foo: true}, {foo: false}]}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import React from "react";
+
+export function Component(t0) {
+  const $ = _c(8);
+  const { items } = t0;
+  let t1;
+  bb0: {
+    let isCool;
+    let t2;
+    if ($[0] !== items) {
+      isCool = false;
+      t2 = items.filter((cause) => {
+        if (cause.foo) {
+          isCool = true;
+        }
+
+        return true;
+      });
+      $[0] = items;
+      $[1] = isCool;
+      $[2] = t2;
+    } else {
+      isCool = $[1];
+      t2 = $[2];
+    }
+    const someItems = t2;
+
+    if (someItems.length > 0) {
+      let t3;
+      if ($[3] !== isCool || $[4] !== someItems) {
+        t3 = { someItems, isCool };
+        $[3] = isCool;
+        $[4] = someItems;
+        $[5] = t3;
+      } else {
+        t3 = $[5];
+      }
+      t1 = t3;
+      break bb0;
+    }
+    t1 = undefined;
+  }
+  const stuff = t1;
+
+  const t2 = stuff?.someItems.length;
+  let t3;
+  if ($[6] !== t2) {
+    t3 = <div>{t2}</div>;
+    $[6] = t2;
+    $[7] = t3;
+  } else {
+    t3 = $[7];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ items: [{ foo: true }, { foo: false }] }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>2</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/local-mutation-in-filter-usememo.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/local-mutation-in-filter-usememo.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export function Component({items}) {
+  const stuff = React.useMemo(() => {
+    let isCool = false;
+    const someItems = items.filter(cause => {
+      if (cause.foo) {
+        isCool = true;
+      }
+      return true;
+    });
+
+    if (someItems.length > 0) {
+      return {someItems, isCool};
+    }
+  }, [items]);
+  return <div>{stuff?.someItems.length}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{items: [{foo: true}, {foo: false}]}],
+};


### PR DESCRIPTION
## Summary
- infer `.filter` property loads as the MixedReadonly array method shape
- preserve the existing noAlias callback behavior for untyped props arrays using `.filter`
- add a regression fixture for local mutation inside a filter callback in `useMemo`

## Why
When `items` comes from untyped props, `items.filter` was inferred as a generic function, so the local-mutation validator treated the callback as potentially escaping through the filtered result. The MixedReadonly model already defines `.filter` as a built-in array method with `noAlias`; this change lets that model apply to `.filter` property loads from untyped values.

Fixes #31569.

## Test Plan
- `corepack yarn workspace snap run snap --update --pattern local-mutation-in-filter-usememo --sync`
- `corepack yarn workspace snap run snap --pattern local-mutation-in-filter-usememo --sync`
- `corepack yarn workspace babel-plugin-react-compiler run lint -- --quiet`
- `corepack yarn prettier`

Note: `corepack yarn workspace snap run snap --pattern "{local-mutation-in-filter-usememo,noAlias-filter-on-array-prop}" --sync` showed the new fixture passing; `noAlias-filter-on-array-prop` only failed on CRLF/LF snapshot text in this Windows checkout with identical generated code.