### PR TITLE
Recognize use$ and use_ as hook names

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/scripts/babel-plugin-annotate-react-code.ts
+++ b/compiler/packages/babel-plugin-react-compiler/scripts/babel-plugin-annotate-react-code.ts
@@ -137,7 +137,7 @@ function isComponentOrHookLike(
 }
 
 function isHookName(s: string): boolean {
-  return /^use[A-Z0-9]/.test(s);
+  return /^use[A-Z0-9]/.test(s) || s === 'use$' || s === 'use_';
 }
 
 /*

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -895,7 +895,7 @@ function hasMemoCacheFunctionImport(
 }
 
 function isHookName(s: string): boolean {
-  return /^use[A-Z0-9]/.test(s);
+  return /^use[A-Z0-9]/.test(s) || s === 'use$' || s === 'use_';
 }
 
 /*

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -1033,9 +1033,9 @@ export class Environment {
 
 const REANIMATED_MODULE_NAME = 'react-native-reanimated';
 
-// From https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#LL18C1-L23C2
+// From packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
 export function isHookName(name: string): boolean {
-  return /^use[A-Z0-9]/.test(name);
+  return /^use[A-Z0-9]/.test(name) || name === 'use$' || name === 'use_';
 }
 
 export function parseEnvironmentConfig(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-conditional-call-hook-symbol-names.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-conditional-call-hook-symbol-names.expect.md
@@ -1,0 +1,46 @@
+
+## Input
+
+```javascript
+import {use$, use_} from 'shared-runtime';
+
+function Component(props) {
+  if (props.cond) {
+    use$();
+  }
+  if (props.otherCond) {
+    use_();
+  }
+  return null;
+}
+
+```
+
+
+## Error
+
+```
+Found 2 errors:
+
+Error: Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)
+
+error.invalid-conditional-call-hook-symbol-names.ts:5:4
+  3 | function Component(props) {
+  4 |   if (props.cond) {
+> 5 |     use$();
+    |     ^^^^ Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)
+  6 |   }
+  7 |   if (props.otherCond) {
+  8 |     use_();
+
+Error: Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)
+
+error.invalid-conditional-call-hook-symbol-names.ts:8:4
+   6 |   }
+   7 |   if (props.otherCond) {
+>  8 |     use_();
+     |     ^^^^ Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)
+   9 |   }
+  10 |   return null;
+  11 | }
+```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-conditional-call-hook-symbol-names.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-conditional-call-hook-symbol-names.js
@@ -1,0 +1,11 @@
+import {use$, use_} from 'shared-runtime';
+
+function Component(props) {
+  if (props.cond) {
+    use$();
+  }
+  if (props.otherCond) {
+    use_();
+  }
+  return null;
+}

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -155,6 +155,13 @@ const allTests = {
     },
     {
       code: normalizeIndent`
+        // Valid because hook names may use JavaScript identifier symbols.
+        function use$() { useState(); }
+        function use_() { useState(); }
+      `,
+    },
+    {
+      code: normalizeIndent`
         // Valid because hooks can call hooks.
         function useHook() {
           useHook1();

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -24,10 +24,12 @@ import {getAdditionalEffectHooksFromSettings} from '../shared/Utils';
 
 /**
  * Catch all identifiers that begin with "use" followed by an uppercase Latin
- * character to exclude identifiers like "user".
+ * character or number, or the symbol-only hook names use$ and use_, to exclude
+ * identifiers like "user" and preserve existing behavior for names like
+ * "use_hook".
  */
 function isHookName(s: string): boolean {
-  return s === 'use' || /^use[A-Z0-9]/.test(s);
+  return s === 'use' || /^use[A-Z0-9]/.test(s) || s === 'use$' || s === 'use_';
 }
 
 /**


### PR DESCRIPTION
## Summary
- recognize `use$` and `use_` as hook names in compiler hook classification
- keep existing behavior for names like `use_hook` that are intentionally not hook names
- align the public `rules-of-hooks` heuristic and add compiler/ESLint regression coverage

## Issue
Fixes #32473.

## Validation
- `corepack yarn workspace snap run snap --pattern error.invalid-conditional-call-hook-symbol-names --sync`
- `corepack yarn workspace eslint-plugin-react-hooks test ESLintRulesOfHooks-test.js --runInBand`
- `corepack yarn workspace babel-plugin-react-compiler run lint -- --quiet`
- `corepack yarn workspace eslint-plugin-react-hooks typecheck`
- `corepack yarn prettier`
- `corepack yarn prettier --write packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js`
- `git diff --cached --check`