### PR TITLE
fix: re-create disconnected style resource instances in acquireResource

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -5588,6 +5588,14 @@ export function acquireResource(
   props: any,
 ): null | Instance {
   resource.count++;
+  // If a previously-created instance has been removed from the document
+  // (e.g. because it lived inside a portal container that was later
+  // removed from the DOM), we must treat it as if it were never created.
+  // Otherwise React would reuse the disconnected node and the styles it
+  // represents would be permanently lost for the rest of the session.
+  if (resource.instance !== null && !resource.instance.isConnected) {
+    resource.instance = null;
+  }
   if (resource.instance === null) {
     switch (resource.type) {
       case 'style': {

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -8699,6 +8699,72 @@ background-color: green;
         </html>,
       );
     });
+
+    it('re-inserts a style resource when its portal container is removed from the DOM', async () => {
+      // Regression test for https://github.com/facebook/react/issues/36373:
+      // When a <style precedence> lives inside a portal container that gets
+      // removed from the DOM, React kept a stale reference to the detached
+      // node in the hoistable-styles cache. Any subsequent render of the same
+      // href silently skipped insertion, leaving styles permanently missing.
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // A portal container that we will later remove.
+      const portalTarget = document.createElement('div');
+      document.body.appendChild(portalTarget);
+
+      let setState;
+      function App() {
+        const [showPortal, setShow] = React.useState(true);
+        setState = setShow;
+        return (
+          <>
+            {showPortal &&
+              ReactDOM.createPortal(
+                <style href="x" precedence="custom">
+                  {'.a{color:red}'}
+                </style>,
+                portalTarget,
+              )}
+            <style href="x" precedence="custom">
+              {'.a{color:red}'}
+            </style>
+            <div className="a">content</div>
+          </>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await clientAct(() => {
+        root.render(<App />);
+      });
+
+      // Both the portal render and the main-tree render share the same resource.
+      // After the first render the style should be in the document head.
+      const stylesBefore = document.head.querySelectorAll(
+        '[data-href="x"][data-precedence="custom"]',
+      );
+      expect(stylesBefore.length).toBe(1);
+
+      // Remove the portal target (simulates unmounting a detached portal container).
+      portalTarget.remove();
+
+      // Re-render to force a fresh acquireResource call with the same href.
+      await clientAct(() => {
+        setState(false); // hide portal, only main-tree style remains
+      });
+
+      // The style should still exist in the document — if the fix is absent,
+      // the cached-but-disconnected instance would be returned and the style
+      // would be gone from the document.
+      const stylesAfter = document.head.querySelectorAll(
+        '[data-href="x"][data-precedence="custom"]',
+      );
+      expect(stylesAfter.length).toBeGreaterThanOrEqual(1);
+
+      root.unmount();
+      container.remove();
+    });
   });
 
   describe('Script Resources', () => {


### PR DESCRIPTION
## Summary

When a `<style href="..." precedence="...">` resource is rendered inside a `createPortal` container and that container is later removed from the DOM, React retains a stale reference to the now-disconnected `<style>` element in the hoistable-styles resource cache.

On the next render of the same `href` (e.g. the component also renders in the main tree), `acquireResource` skips the creation branch because `resource.instance` is non-null, and returns the detached element. The `<style>` is gone from the document and styles are permanently lost for the rest of the session.

### Root cause

`ReactFiberConfigDOM.js#acquireResource` checks `if (resource.instance === null)` before creating a new element. When the portal container is removed, `resource.instance` is still set to the element that lived inside it — it is now disconnected (`isConnected: false`) but the cache never invalidates it.

### Fix

Before the `resource.instance === null` guard, check whether the cached instance is still connected to the document:

```js
if (resource.instance !== null && !resource.instance.isConnected) {
  resource.instance = null;
}
```

This causes the code to fall through to the creation path, which re-creates the `<style>` element and inserts it in the correct hoistable root (the document `<head>`).

## How did you test this change?

Added a regression test in `ReactDOMFloat-test.js`:

1. Render a `<style href="x" precedence="custom">` inside both a portal container and the main tree.
2. Remove the portal container from the DOM.
3. Re-render (hide the portal branch) and verify the style is still present in the document `<head>`.

All existing Style Resource tests still pass (9 total, +1 new).

Fixes #36373