### PR TITLE
Update pull request template contribution link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
   9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
   10. If you haven't already, complete the CLA.
 
-  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
+  Learn more about contributing: https://legacy.reactjs.org/docs/how-to-contribute.html
 -->
 
 ## Summary


### PR DESCRIPTION
﻿## Summary

Updates the pull request template's contribution guide URL to match the `legacy.reactjs.org` contribution guide links already used in `README.md`.

## How did you test this change?

- `git diff --check`
- Confirmed `https://legacy.reactjs.org/docs/how-to-contribute.html` returns HTTP 200 with `Invoke-WebRequest`
- Docs-only/template-only change; no runtime tests were needed
