### PR TITLE
Preserve optional chains in exhaustive-deps suggestions

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1757,6 +1757,40 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent({foo, one}) {
+          useEffect(() => {
+            console.log(one);
+            if (foo?.bar) {
+              console.log(foo.bar);
+            }
+          }, [one]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'foo?.bar'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [foo?.bar, one]',
+              output: normalizeIndent`
+                function MyComponent({foo, one}) {
+                  useEffect(() => {
+                    console.log(one);
+                    if (foo?.bar) {
+                      console.log(foo.bar);
+                    }
+                  }, [foo?.bar, one]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const local = someFunc();
           useEffect(() => {
@@ -8191,11 +8225,11 @@ const testsTypescript = {
       errors: [
         {
           message:
-            "React Hook useEffect has a missing dependency: 'pizza.crust'. " +
+            "React Hook useEffect has a missing dependency: 'pizza?.crust'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [pizza.crust]',
+              desc: 'Update the dependencies array to be: [pizza?.crust]',
               output: normalizeIndent`
                 function MyComponent() {
                   const pizza = {};
@@ -8203,7 +8237,7 @@ const testsTypescript = {
                   useEffect(() => ({
                     crust: pizza?.crust,
                     density: pizza.crust.density,
-                  }), [pizza.crust]);
+                  }), [pizza?.crust]);
                 }
               `,
             },
@@ -8225,11 +8259,11 @@ const testsTypescript = {
       errors: [
         {
           message:
-            "React Hook useEffect has a missing dependency: 'pizza.crust'. " +
+            "React Hook useEffect has a missing dependency: 'pizza?.crust'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [pizza.crust]',
+              desc: 'Update the dependencies array to be: [pizza?.crust]',
               output: normalizeIndent`
                 function MyComponent() {
                   const pizza = {};
@@ -8237,7 +8271,7 @@ const testsTypescript = {
                   useEffect(() => ({
                     crust: pizza.crust,
                     density: pizza?.crust.density,
-                  }), [pizza.crust]);
+                  }), [pizza?.crust]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -1905,13 +1905,11 @@ function markNode(
 ): void {
   if (optionalChains) {
     if ('optional' in node && node.optional) {
-      // We only want to consider it optional if *all* usages were optional.
-      if (!optionalChains.has(result)) {
-        // Mark as (maybe) optional. If there's a required usage, this will be overridden.
-        optionalChains.set(result, true);
-      }
-    } else {
-      // Mark as required.
+      // Prefer optional chaining if any usage needs it, because dependency
+      // arrays are evaluated outside guarded blocks.
+      optionalChains.set(result, true);
+    } else if (!optionalChains.has(result)) {
+      // Mark as required unless an optional usage has already been seen.
       optionalChains.set(result, false);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #23248.

When the same dependency path is read through both optional and non-optional member expressions, the exhaustive-deps suggestion should keep the optional form. Dependency arrays are evaluated outside guarded blocks, so suggesting the non-optional form can introduce a render-time error while fixing an unrelated dependency.

## Tests

- `corepack yarn --cwd packages/eslint-plugin-react-hooks jest ESLintRuleExhaustiveDeps-test --runInBand`
- `corepack yarn --cwd packages/eslint-plugin-react-hooks typecheck`
- `git diff --check`