### PR TITLE
Ignore nested typeof references in exhaustive-deps

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -8012,6 +8012,21 @@ const testsTypescript = {
     {
       code: normalizeIndent`
         function MyComponent() {
+          const [foo, setFoo] = React.useState<{bar: number}>({bar: 42});
+
+          useEffect(() => {
+            const square = (x: typeof foo.bar) => x * x;
+            setFoo(previous => ({
+              ...previous,
+              bar: square(previous.bar),
+            }));
+          }, []);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
           const [state, setState] = React.useState<number>(0);
 
           useSpecialEffect(() => {

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -522,6 +522,9 @@ const rule = {
           if (referenceNode == null) {
             continue;
           }
+          if (isInsideTypeQueryOrReference(referenceNode)) {
+            continue;
+          }
           const dependencyNode = getDependency(referenceNode);
           const dependency = analyzePropertyChain(
             dependencyNode,
@@ -1890,6 +1893,20 @@ function getDependency(node: Node): Node {
   } else {
     return node;
   }
+}
+
+function isInsideTypeQueryOrReference(node: Node): boolean {
+  let current: Node | null = node.parent ?? null;
+  while (current != null) {
+    if (
+      current.type === 'TSTypeQuery' ||
+      current.type === 'TSTypeReference'
+    ) {
+      return true;
+    }
+    current = current.parent ?? null;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #27335.

Nested references inside TypeScript `typeof` queries are type-only and should not be reported as Hook dependencies. The rule already ignored direct `TSTypeQuery` parents; this walks from the original reference node so nested paths like `typeof foo.bar` are also skipped.

## Tests

- `corepack yarn --cwd packages/eslint-plugin-react-hooks jest ESLintRuleExhaustiveDeps-test --runInBand`
- `corepack yarn --cwd packages/eslint-plugin-react-hooks typecheck`
- `git diff --check`