### PR TITLE
Allow hooks in static member components

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -76,6 +76,19 @@ const allTests = {
     },
     {
       code: normalizeIndent`
+        // Valid because components can be static members.
+        function MyComponent() {
+          return <MyComponent.Ready />;
+        }
+
+        MyComponent.Ready = () => {
+          useHook();
+          return null;
+        };
+      `,
+    },
+    {
+      code: normalizeIndent`
         // Valid because hooks can use hooks.
         function useHookWithHook() {
           useHook();

--- a/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts
@@ -55,7 +55,12 @@ function isHook(node: Node): boolean {
  * always start with an uppercase letter.
  */
 function isComponentName(node: Node): boolean {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  return (
+    (node.type === 'Identifier' && /^[A-Z]/.test(node.name)) ||
+    (node.type === 'MemberExpression' &&
+      !node.computed &&
+      isComponentName(node.property))
+  );
 }
 
 function isReactFunction(node: Node, functionName: string): boolean {


### PR DESCRIPTION
## Summary

Fixes #24791.

`rules-of-hooks` already recognizes PascalCase identifiers as components. This extends that component-name check to PascalCase member expressions, so static member components like `MyComponent.Ready = () => { useHook(); }` are handled the same way when they are used as `<MyComponent.Ready />`.

## Tests

- `corepack yarn --cwd packages/eslint-plugin-react-hooks jest ESLintRulesOfHooks-test --runInBand`
- `corepack yarn --cwd packages/eslint-plugin-react-hooks typecheck`
- `git diff --check`