### PR TITLE
Ignore type parameters in exhaustive-deps captures

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -8011,6 +8011,21 @@ const testsTypescript = {
     },
     {
       code: normalizeIndent`
+        function useBug<T>(val: T) {
+          const ref = useRef<T>(val);
+
+          const fn = () => {
+            const temp: T = ref.current;
+          };
+
+          useEffect(() => {
+            fn();
+          }, []);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const [state, setState] = React.useState<number>(0);
 

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -446,6 +446,26 @@ const rule = {
           if (ref.resolved == null) {
             continue;
           }
+          const referenceNode = fastFindReferenceWithParent(
+            fnNode,
+            ref.identifier,
+          );
+          if (
+            referenceNode?.parent?.type === 'TSTypeQuery' ||
+            referenceNode?.parent?.type === 'TSTypeReference' ||
+            // @ts-expect-error Flow-specific AST node type
+            referenceNode?.parent?.type === 'GenericTypeAnnotation'
+          ) {
+            continue;
+          }
+          const def = ref.resolved.defs[0];
+          if (
+            def != null &&
+            // @ts-expect-error We don't have flow types
+            def.type === 'TypeParameter'
+          ) {
+            continue;
+          }
           if (
             pureScopes.has(ref.resolved.scope) &&
             // Stable values are fine though,


### PR DESCRIPTION
Summary
- Fix exhaustive-deps so TypeScript/Flow type-only references inside helper functions are not treated as render captures.
- Add a TypeScript regression test for a stable helper that reads a ref and mentions a generic type parameter.

Fixes #25149.

Test plan
- `corepack yarn --cwd packages/eslint-plugin-react-hooks jest ESLintRuleExhaustiveDeps-test --runInBand`
- `corepack yarn --cwd packages/eslint-plugin-react-hooks typecheck`
- `git diff --check`