### PR TITLE
[compiler] Fix refs lint false positives for JSX ref props

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -149,19 +149,6 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           }
           break;
         }
-        case 'PropertyLoad': {
-          if (
-            isUseRefType(value.object.identifier) &&
-            value.property === 'current'
-          ) {
-            continue;
-          }
-          const temp = env.lookup(value.object);
-          if (temp != null) {
-            env.define(lvalue, temp);
-          }
-          break;
-        }
       }
     }
   }

--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
@@ -195,7 +195,80 @@ const tests: CompilerTestCases = {
   ],
 };
 
+const refsTests: CompilerTestCases = {
+  valid: [
+    {
+      name: 'Allows JSX ref from a props member without marking all props as refs',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        function Test(props) {
+          return (
+            <div>
+              <button ref={props.buttonRef}>
+                {props.text}
+              </button>
+            </div>
+          );
+        }
+      `,
+    },
+    {
+      name: 'Allows JSX ref from React 19 props.ref with sibling props',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        function TextArea(props) {
+          return (
+            <TextInput
+              ref={props.ref}
+              placeholder={props.placeholder}
+              type="body"
+            />
+          );
+        }
+      `,
+    },
+    {
+      name: 'Allows JSX refs stored as object properties',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        import {useRef} from 'react';
+
+        function App() {
+          const groupRefs = {
+            group1: useRef(null),
+            group2: useRef(null),
+          };
+
+          return (
+            <>
+              <ComboBoxItemGroup ref={groupRefs.group1} />
+              <ComboBoxItemGroup ref={groupRefs.group2} />
+            </>
+          );
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'Reports direct access to props.ref.current during render',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        function Component(props) {
+          return <div>{props.ref.current}</div>;
+        }
+      `,
+      errors: [
+        {
+          message: /Cannot access ref value during render/,
+        },
+      ],
+    },
+  ],
+};
+
 const eslintTester = new ESLintTesterV8({
   parser: require.resolve('@typescript-eslint/parser-v5'),
 });
 eslintTester.run('react-compiler', allRules['immutability'].rule, tests);
+eslintTester.run('react-compiler refs', allRules['refs'].rule, refsTests);


### PR DESCRIPTION
## Summary

The refs lint rule was aliasing non-current property loads back to their parent object. When a JSX ref attribute inferred `props.ref`, `props.buttonRef`, or `groupRefs.group1` as a ref, the parent object was then treated as a ref too, which made sibling props or sibling ref entries look like `ref.current` accesses during render.

This keeps property-load values separate in the ref validation environment so JSX ref forwarding remains valid while direct `props.ref.current` reads still report.

Fixes #35575
Fixes #34775
Fixes #35813
Fixes #35997

## How did you test this change?

- `corepack yarn --cwd packages/eslint-plugin-react-hooks build:compiler`
- `corepack yarn --cwd packages/eslint-plugin-react-hooks jest ReactCompilerRuleTypescript-test --runInBand`
- `corepack yarn --cwd packages/eslint-plugin-react-hooks typecheck`
- `git diff --check`