### PR TITLE
fix(react-is): support legacy React elements (react.element)

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -12,6 +12,7 @@
 import {
   REACT_CONTEXT_TYPE,
   REACT_ELEMENT_TYPE,
+  REACT_LEGACY_ELEMENT_TYPE,
   REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
   REACT_LAZY_TYPE,
@@ -42,6 +43,7 @@ export function typeOf(object: any): mixed {
     const $$typeof = object.$$typeof;
     switch ($$typeof) {
       case REACT_ELEMENT_TYPE:
+      case REACT_LEGACY_ELEMENT_TYPE:
         const type = object.type;
 
         switch (type) {
@@ -140,7 +142,8 @@ export function isElement(object: any): boolean {
   return (
     typeof object === 'object' &&
     object !== null &&
-    object.$$typeof === REACT_ELEMENT_TYPE
+    (object.$$typeof === REACT_ELEMENT_TYPE ||
+      object.$$typeof === REACT_LEGACY_ELEMENT_TYPE)
   );
 }
 export function isForwardRef(object: any): boolean {

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -13,6 +13,7 @@ let React;
 let ReactDOM;
 let ReactIs;
 let SuspenseList;
+let ReactSymbols;
 
 describe('ReactIs', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('ReactIs', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactIs = require('react-is');
+    ReactSymbols = require('shared/ReactSymbols');
 
     if (gate(flags => flags.enableSuspenseList)) {
       SuspenseList = React.unstable_SuspenseList;
@@ -114,6 +116,19 @@ describe('ReactIs', () => {
     expect(ReactIs.isElement(<React.Fragment />)).toBe(true);
     expect(ReactIs.isElement(<React.StrictMode />)).toBe(true);
     expect(ReactIs.isElement(<React.Suspense />)).toBe(true);
+  });
+
+  it('should identify legacy elements from older React versions', () => {
+    // Simulate a legacy React element with the old $$typeof symbol
+    const legacyElement = {
+      $$typeof: ReactSymbols.REACT_LEGACY_ELEMENT_TYPE,
+      type: 'div',
+      key: null,
+      ref: null,
+      props: {},
+    };
+    expect(ReactIs.isElement(legacyElement)).toBe(true);
+    expect(ReactIs.typeOf(legacyElement)).toBe(ReactIs.Element);
   });
 
   it('should identify ref forwarding component', () => {


### PR DESCRIPTION
## Bug Fix Summary

**Issue**: #36409 - `react-is@19` does not recognise elements from React 18

## Problem

React 19 changed $$typeof from `Symbol('react.element')` to `Symbol('react.transitional.element')`. The react-is@19 package only checks for the new symbol, breaking backward compatibility with React 17/18 elements.

## Solution

Update `isElement()` and `typeOf()` in `packages/react-is/src/ReactIs.js` to also recognize `REACT_LEGACY_ELEMENT_TYPE`.

## Changes

1. **ReactIs.js**: Import `REACT_LEGACY_ELEMENT_TYPE` and add it to:
   - `typeOf()` switch statement
   - `isElement()` check

2. **ReactIs-test.js**: Add test case `should identify legacy elements from older React versions`

## Testing

```js
// Before fix
reactIs.isElement(react18Element) // false

// After fix
reactIs.isElement(react18Element) // true
```

---

This fix ensures tools that upgrade to `react-is@19` (like jest's pretty-format) can still identify elements created by React 17/18 without requiring users to upgrade React.
