### PR TITLE
fix: ignore stable deps in memo preservation

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -26,6 +26,7 @@ import {
   ReactiveValue,
   ScopeId,
   SourceLocation,
+  isStableType,
 } from '../HIR';
 import {Environment} from '../HIR/Environment';
 import {printIdentifier, printManualMemoDependency} from '../HIR/PrintHIR';
@@ -233,6 +234,9 @@ function validateInferredDep(
   env: Environment,
   memoLocation: SourceLocation,
 ): void {
+  if (!dep.reactive && dep.path.length === 0 && isStableType(dep.identifier)) {
+    return;
+  }
   let normalizedDep: ManualMemoDependency;
   const maybeNormalizedRoot = temporaries.get(dep.identifier.id);
   if (maybeNormalizedRoot != null) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-use-callback-namespace-setter.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-use-callback-namespace-setter.expect.md
@@ -1,0 +1,124 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+import * as React from 'react';
+
+function Component(options = {}) {
+  const {skip} = options;
+
+  const recreate = () => (skip ? undefined : {});
+
+  let [observable, setObservable] = React.useState(
+    options.skip ? null : recreate
+  );
+
+  const recreateRef = React.useRef(recreate);
+  React.useLayoutEffect(() => {
+    recreateRef.current = recreate;
+  });
+
+  if (!skip && !observable) {
+    setObservable((observable = recreate()));
+  }
+
+  const restart = React.useCallback(() => {
+    if (observable) {
+      setObservable(recreateRef.current());
+    }
+  }, [observable]);
+
+  return React.useMemo(() => ({restart}), [restart]);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMemoizationGuarantees
+import * as React from "react";
+
+function Component(t0) {
+  const $ = _c(11);
+  let t1;
+  if ($[0] !== t0) {
+    t1 = t0 === undefined ? {} : t0;
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const options = t1;
+  const { skip } = options;
+  let t2;
+  if ($[2] !== skip) {
+    t2 = () => (skip ? undefined : {});
+    $[2] = skip;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  const recreate = t2;
+
+  const [t3, setObservable] = React.useState(options.skip ? null : recreate);
+  let observable = t3;
+
+  const recreateRef = React.useRef(recreate);
+  let t4;
+  if ($[4] !== recreate) {
+    t4 = () => {
+      recreateRef.current = recreate;
+    };
+    $[4] = recreate;
+    $[5] = t4;
+  } else {
+    t4 = $[5];
+  }
+  React.useLayoutEffect(t4);
+
+  if (!skip && !observable) {
+    setObservable((observable = recreate()));
+  }
+  let t5;
+  if ($[6] !== observable || $[7] !== setObservable) {
+    t5 = () => {
+      if (observable) {
+        setObservable(recreateRef.current());
+      }
+    };
+    $[6] = observable;
+    $[7] = setObservable;
+    $[8] = t5;
+  } else {
+    t5 = $[8];
+  }
+
+  observable;
+  const restart = t5;
+  let t6;
+  if ($[9] !== restart) {
+    t6 = { restart };
+    $[9] = restart;
+    $[10] = t6;
+  } else {
+    t6 = $[10];
+  }
+  return t6;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};
+
+```
+      
+### Eval output
+(kind: ok) {"restart":"[[ function params=0 ]]"}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-use-callback-namespace-setter.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-use-callback-namespace-setter.js
@@ -1,0 +1,34 @@
+// @validatePreserveExistingMemoizationGuarantees
+import * as React from 'react';
+
+function Component(options = {}) {
+  const {skip} = options;
+
+  const recreate = () => (skip ? undefined : {});
+
+  let [observable, setObservable] = React.useState(
+    options.skip ? null : recreate
+  );
+
+  const recreateRef = React.useRef(recreate);
+  React.useLayoutEffect(() => {
+    recreateRef.current = recreate;
+  });
+
+  if (!skip && !observable) {
+    setObservable((observable = recreate()));
+  }
+
+  const restart = React.useCallback(() => {
+    if (observable) {
+      setObservable(recreateRef.current());
+    }
+  }, [observable]);
+
+  return React.useMemo(() => ({restart}), [restart]);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};


### PR DESCRIPTION
## Summary

Fixes #35118.

`ValidatePreservedManualMemoization` could incorrectly reject an existing `useCallback` when the callback referenced a `useState` setter that was not listed in the manual dependency array.

`useState` setters are stable values and generally do not need to be included in dependency arrays. However, in cases where the state value from the same destructuring pattern is later reassigned, the preserved manual memoization validation could infer the setter as a missing dependency and skip compilation with:

> The inferred dependency was `setObservable`, but the source dependencies were [observable]. Inferred different dependency than source.

This change skips non-reactive stable inferred dependencies with no property path during preserved manual memoization validation. This matches the treatment of stable values in dependency validation while still preserving checks for reactive values and property paths.

Added a regression fixture based on the repro from #35118.

## How did you test this change?

Ran targeted compiler snap fixtures:

```sh
PATH="$HOME/.nvm/versions/node/v22.18.0/bin:$PATH" yarn workspace snap run snap --pattern preserve-use-callback-namespace-setter --sync