### PR TITLE
[DevTools] Fix XSS in standalone onError via innerHTML

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -195,11 +195,14 @@ function onError({code, message}: $FlowFixMe) {
         <div class="box-header">
           Unknown error
         </div>
-        <div class="box-content">
-          ${message}
-        </div>
+        <div class="box-content"></div>
       </div>
     `;
+    // Use textContent to avoid XSS from error message strings.
+    const contentNode = node.querySelector('.box-content');
+    if (contentNode !== null) {
+      contentNode.textContent = message;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

In `packages/react-devtools-core/src/standalone.js`, the `onError` function was interpolating a server error `message` string directly into an `innerHTML` template literal:

```js
node.innerHTML = `
  <div class="box-content">
    ${message}
  </div>
`;
```

If the `message` string contained HTML (e.g. `<img src=x onerror="...">`) it would be parsed and executed by the browser.

This PR fixes it by setting the static HTML structure first, then assigning the message via `textContent`, which the browser treats as plain text and never interprets as markup.

```js
node.innerHTML = `
  <div class="box">
    <div class="box-header">Unknown error</div>
    <div class="box-content"></div>
  </div>
`;
const contentNode = node.querySelector('.box-content');
if (contentNode !== null) {
  contentNode.textContent = message;
}
```

The `message` value comes from Node.js `http.Server` / `net.Server` error events (`server.on('error', ...)`). These are normally OS/network-level error strings and not directly attacker-controlled, so real-world exploitability is limited. Nevertheless the code structure allowed HTML injection and the fix is straightforward.

## How did you test this change?

Manually verified that a normal server error (e.g. `EACCES`) still renders the error message as plain text in the standalone DevTools shell. No automated tests exist for this UI path in `react-devtools-core`.