### PR TITLE
[compiler]: add `useFormContext` to react-hook-form known incompatible APIs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/DefaultModuleTypeProvider.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/DefaultModuleTypeProvider.ts
@@ -65,6 +65,24 @@ export function defaultModuleTypeProvider(
               },
             },
           },
+          useFormContext: {
+            kind: 'hook',
+            returnType: {
+              kind: 'object',
+              properties: {
+                // Only the `watch()` function returned by react-hook-form's `useFormContext()` API is incompatible
+                watch: {
+                  kind: 'function',
+                  positionalParams: [],
+                  restParam: Effect.Read,
+                  calleeEffect: Effect.Read,
+                  returnType: {kind: 'type', name: 'Any'},
+                  returnValueKind: ValueKind.Mutable,
+                  knownIncompatible: `React Hook Form's \`useFormContext()\` API returns a \`watch()\` function which cannot be memoized safely.`,
+                },
+              },
+            },
+          },
         },
       };
     }


### PR DESCRIPTION
#34027 added a check for react-hook-form's `useForm().watch`, but not for `useFormContext().watch`. `useFormContext()` exposes the same `watch` function: when React Compiler memoizes calls to it, the watched value goes stale and form updates are not reflected in the UI. 

This PR mirrors the existing `useForm` rule onto `useFormContext` so the compiler skips memoization in this case as well, [also discussed in the community](https://github.com/orgs/react-hook-form/discussions/12524).