### PR TITLE
docs: standardize contribution guide URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Want to contribute to React? There are a few things you need to know.  
 
-We wrote a **[contribution guide](https://reactjs.org/docs/how-to-contribute.html)** to help you get started.
+We wrote a **[contribution guide](https://legacy.reactjs.org/docs/how-to-contribute.html)** to help you get started.


### PR DESCRIPTION
## Summary

CONTRIBUTING.md currently links to `reactjs.org/docs/how-to-contribute.html`
while README.md uses `legacy.reactjs.org/docs/how-to-contribute.html`.

This PR updates the URL in CONTRIBUTING.md to match README.md, ensuring
contributors are directed to the same canonical page from both files.

Closes #36341

## How did you test this change?

Verified both URLs resolve to the same page. No code changes involved.