### PR TITLE
Fix: ReactDOM.preloadModule crashes with repeated custom as value

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -6552,7 +6552,7 @@ function preloadModule(
           resumableState.moduleUnknownResources.hasOwnProperty(as);
         let resources;
         if (hasAsType) {
-          resources = resumableState.unknownResources[as];
+          resources = resumableState.moduleUnknownResources[as];
           if (resources.hasOwnProperty(key)) {
             // we can return if we already have this resource
             return;


### PR DESCRIPTION
## Summary

Fixes a crash in `ReactDOM.preloadModule()` when called multiple times with the same custom `as` value (e.g., `as: 'serviceworker'`).

## Root Cause

In `ReactFizzConfigDOM.js` line 6555, the code checks `resumableState.moduleUnknownResources.hasOwnProperty(as)` but then reads from `resumableState.unknownResources[as]` — which is `undefined` for custom `as` types since they're stored in `moduleUnknownResources`, not `unknownResources`.

## Fix

One-word change: `unknownResources` → `moduleUnknownResources` on line 6555.

**Before:**
```js
resources = resumableState.unknownResources[as];  // undefined for custom as
```

**After:**
```js
resources = resumableState.moduleUnknownResources[as];  // correct bucket
```

## Reproduction

```js
function App() {
  ReactDOM.preloadModule('worker-a', {as: 'serviceworker'});
  ReactDOM.preloadModule('worker-b', {as: 'serviceworker'});
  return <div>hello</div>;
}
```

The second call crashes with: `TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')`

Fixes #36440