### PR TITLE
[compiler] Allow recursive useEffectEvent callbacks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -227,15 +227,6 @@ function findHoistedContextDeclarations(
   fn: HIRFunction,
 ): Map<DeclarationId, Place | null> {
   const hoisted = new Map<DeclarationId, Place | null>();
-  function visit(place: Place): void {
-    if (
-      hoisted.has(place.identifier.declarationId) &&
-      hoisted.get(place.identifier.declarationId) == null
-    ) {
-      // If this is the first load of the value, store the location
-      hoisted.set(place.identifier.declarationId, place);
-    }
-  }
   for (const block of fn.body.blocks.values()) {
     for (const instr of block.instructions) {
       if (instr.value.kind === 'DeclareContext') {
@@ -247,6 +238,45 @@ function findHoistedContextDeclarations(
         ) {
           hoisted.set(instr.value.lvalue.place.identifier.declarationId, null);
         }
+      }
+    }
+  }
+  const safeSelfReferences = findSelfReferentialEffectEventInitializers(
+    fn,
+    hoisted,
+  );
+  const initialized = new Set<DeclarationId>();
+  function visit(place: Place): void {
+    if (
+      hoisted.has(place.identifier.declarationId) &&
+      !initialized.has(place.identifier.declarationId) &&
+      hoisted.get(place.identifier.declarationId) == null
+    ) {
+      // If this is the first load of the value, store the location
+      hoisted.set(place.identifier.declarationId, place);
+    }
+  }
+  for (const block of fn.body.blocks.values()) {
+    for (const instr of block.instructions) {
+      if (instr.value.kind === 'StoreContext') {
+        visit(instr.value.value);
+        if (instr.value.lvalue.kind === InstructionKind.Const) {
+          initialized.add(instr.value.lvalue.place.identifier.declarationId);
+        }
+      } else if (
+        instr.value.kind === 'FunctionExpression' ||
+        instr.value.kind === 'ObjectMethod'
+      ) {
+        for (const operand of eachInstructionValueOperand(instr.value)) {
+          if (
+            safeSelfReferences
+              .get(instr.lvalue.identifier.id)
+              ?.has(operand.identifier.declarationId)
+          ) {
+            continue;
+          }
+          visit(operand);
+        }
       } else {
         for (const operand of eachInstructionValueOperand(instr.value)) {
           visit(operand);
@@ -257,7 +287,82 @@ function findHoistedContextDeclarations(
       visit(operand);
     }
   }
+  for (const [declaration, place] of hoisted) {
+    if (place === null) {
+      hoisted.delete(declaration);
+    }
+  }
   return hoisted;
+}
+
+function findSelfReferentialEffectEventInitializers(
+  fn: HIRFunction,
+  hoisted: Map<DeclarationId, Place | null>,
+): Map<IdentifierId, Set<DeclarationId>> {
+  const functionCapturesHoisted = new Map<IdentifierId, Set<DeclarationId>>();
+  const effectEventCallCaptures = new Map<
+    IdentifierId,
+    Map<DeclarationId, Set<IdentifierId>>
+  >();
+  const safeSelfReferences = new Map<IdentifierId, Set<DeclarationId>>();
+
+  for (const block of fn.body.blocks.values()) {
+    for (const instr of block.instructions) {
+      const {value} = instr;
+      if (
+        value.kind === 'FunctionExpression' ||
+        value.kind === 'ObjectMethod'
+      ) {
+        for (const operand of eachInstructionValueOperand(value)) {
+          if (hoisted.has(operand.identifier.declarationId)) {
+            getOrInsertDefault(
+              functionCapturesHoisted,
+              instr.lvalue.identifier.id,
+              new Set(),
+            ).add(operand.identifier.declarationId);
+          }
+        }
+      } else if (value.kind === 'CallExpression') {
+        const hookKind = getHookKind(fn.env, value.callee.identifier);
+        if (hookKind === 'useEffectEvent') {
+          const captures = new Map<DeclarationId, Set<IdentifierId>>();
+          for (const arg of value.args) {
+            if (arg.kind !== 'Identifier') {
+              continue;
+            }
+            const captured = functionCapturesHoisted.get(arg.identifier.id);
+            if (captured == null) {
+              continue;
+            }
+            for (const declaration of captured) {
+              getOrInsertDefault(captures, declaration, new Set()).add(
+                arg.identifier.id,
+              );
+            }
+          }
+          if (captures.size !== 0) {
+            effectEventCallCaptures.set(instr.lvalue.identifier.id, captures);
+          }
+        }
+      } else if (
+        value.kind === 'StoreContext' &&
+        value.lvalue.kind === InstructionKind.Const
+      ) {
+        const declaration = value.lvalue.place.identifier.declarationId;
+        const captures = effectEventCallCaptures.get(value.value.identifier.id);
+        const functionIds = captures?.get(declaration);
+        if (functionIds != null) {
+          for (const functionId of functionIds) {
+            getOrInsertDefault(safeSelfReferences, functionId, new Set()).add(
+              declaration,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return safeSelfReferences;
 }
 
 class Context {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-recursive-useEffectEvent.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-recursive-useEffectEvent.expect.md
@@ -1,0 +1,87 @@
+
+## Input
+
+```javascript
+import {useEffect, useEffectEvent, useState} from 'react';
+
+function TimerBasedComponent(props) {
+  const repeatEvent = useEffectEvent(() => {
+    props.onRepeat();
+    setTimeout(() => {
+      repeatEvent();
+    }, 60);
+  });
+
+  const [down, setDown] = useState(false);
+  useEffect(() => {
+    if (down) {
+      repeatEvent();
+    }
+  }, [down]);
+
+  return <button onClick={() => setDown(!down)} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { useEffect, useEffectEvent, useState } from "react";
+
+function TimerBasedComponent(props) {
+  const $ = _c(9);
+  let t0;
+  if ($[0] !== props) {
+    t0 = () => {
+      props.onRepeat();
+      setTimeout(() => {
+        repeatEvent();
+      }, 60);
+    };
+    $[0] = props;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  const repeatEvent = useEffectEvent(t0);
+
+  const [down, setDown] = useState(false);
+  let t1;
+  if ($[2] !== down || $[3] !== repeatEvent) {
+    t1 = () => {
+      if (down) {
+        repeatEvent();
+      }
+    };
+    $[2] = down;
+    $[3] = repeatEvent;
+    $[4] = t1;
+  } else {
+    t1 = $[4];
+  }
+  let t2;
+  if ($[5] !== down) {
+    t2 = [down];
+    $[5] = down;
+    $[6] = t2;
+  } else {
+    t2 = $[6];
+  }
+  useEffect(t1, t2);
+  let t3;
+  if ($[7] !== down) {
+    t3 = <button onClick={() => setDown(!down)} />;
+    $[7] = down;
+    $[8] = t3;
+  } else {
+    t3 = $[8];
+  }
+  return t3;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-recursive-useEffectEvent.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-recursive-useEffectEvent.tsx
@@ -1,0 +1,19 @@
+import {useEffect, useEffectEvent, useState} from 'react';
+
+function TimerBasedComponent(props) {
+  const repeatEvent = useEffectEvent(() => {
+    props.onRepeat();
+    setTimeout(() => {
+      repeatEvent();
+    }, 60);
+  });
+
+  const [down, setDown] = useState(false);
+  useEffect(() => {
+    if (down) {
+      repeatEvent();
+    }
+  }, [down]);
+
+  return <button onClick={() => setDown(!down)} />;
+}


### PR DESCRIPTION
## Summary

Fixes #34888.

The mutation inference pass was treating recursive references to a function returned from `useEffectEvent` as a use-before-declaration of the hoisted context variable. This happened because the scan for hoisted context accesses did not distinguish the declaration's initializer from true prior accesses, and it also continued to consider references after the `StoreContext Const` initialization as early reads.

This tracks initialized hoisted context declarations while finding early accesses and treats self-references through a `useEffectEvent` initializer as safe. The existing invalid setState-before-declaration case remains covered.

## How did you test this change?

- `corepack yarn prettier --check packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-recursive-useEffectEvent.tsx`
- `corepack yarn build` from `compiler/packages/babel-plugin-react-compiler`
- `corepack yarn snap:build` from `compiler`
- `node ../snap/dist/main.js test --worker-threads false --pattern allow-recursive-useEffectEvent` showed `1 Tests, 1 Passed, 0 Failed` before local snap runner shutdown error `Farm is ended, no more calls can be done to it`
- `node ../snap/dist/main.js test --worker-threads false --pattern error.invalid-hoisting-setstate` showed `1 Tests, 1 Passed, 0 Failed` before the same local snap runner shutdown error