### PR TITLE
[compiler] Preserve JSX pragmas before generated imports

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
@@ -302,7 +302,41 @@ export function addImportsToProgram(
       }
     }
   }
+  preserveLeadingJsxPragmaCommentsOnInsertedStatements(path.node, stmts);
   path.unshiftContainer('body', stmts);
+}
+
+function preserveLeadingJsxPragmaCommentsOnInsertedStatements(
+  program: t.Program,
+  stmts: Array<t.ImportDeclaration | t.VariableDeclaration>,
+): void {
+  const firstInsertedStmt = stmts[0];
+  const firstExistingStmt = program.body[0];
+  if (
+    firstInsertedStmt == null ||
+    firstExistingStmt == null ||
+    firstExistingStmt.leadingComments == null
+  ) {
+    return;
+  }
+  const remainingComments = [];
+  const jsxPragmaComments = [];
+  for (const comment of firstExistingStmt.leadingComments) {
+    if (/@jsx(?:ImportSource|Runtime|Frag)?\b/.test(comment.value)) {
+      jsxPragmaComments.push(comment);
+    } else {
+      remainingComments.push(comment);
+    }
+  }
+  if (jsxPragmaComments.length === 0) {
+    return;
+  }
+  firstInsertedStmt.leadingComments = [
+    ...(firstInsertedStmt.leadingComments ?? []),
+    ...jsxPragmaComments,
+  ];
+  firstExistingStmt.leadingComments =
+    remainingComments.length === 0 ? null : remainingComments;
 }
 
 /*

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Imports-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Imports-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import invariant from 'invariant';
+import {runBabelPluginReactCompiler} from '../Babel/RunReactCompilerBabelPlugin';
+
+it('preserves JSX pragmas before generated runtime imports', () => {
+  const result = runBabelPluginReactCompiler(
+    `/* @jsxImportSource custom-jsx */
+
+import {useState} from 'react';
+
+export default function Component({children}) {
+  const [count] = useState(0);
+  return <div data-count={count}>{children}</div>;
+}`,
+    'test.tsx',
+    'typescript',
+    {panicThreshold: 'all_errors'},
+  );
+
+  invariant(result.code != null, 'Expected Babel transform to emit code');
+  expect(result.code.indexOf('@jsxImportSource custom-jsx')).toBeLessThan(
+    result.code.indexOf('react/compiler-runtime'),
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #36460.

React Compiler adds a runtime import for compiled functions. When a source file starts with a JSX pragma such as `@jsxImportSource`, inserting that runtime import at the very start of the program moves the pragma after a code statement in the generated output. Downstream JSX transforms such as Oxc, SWC, and TypeScript only honor these pragmas before code statements.

This preserves leading JSX pragma comments by moving them onto the first generated compiler import before inserting it. Non-JSX leading comments are left on the original first statement, which avoids changing existing compiler fixture output for test-only config comments.

## How did you test this change?

- `corepack yarn prettier --check packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts packages/babel-plugin-react-compiler/src/__tests__/Imports-test.ts`
- `corepack yarn jest src/__tests__/Imports-test.ts --runInBand`
- `git diff --check`