### PR TITLE
docs: fix duplicated word in DOM server comments

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -3686,7 +3686,7 @@ function pushStartHead(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is the wrong spot.
     return pushStartGenericElement(target, props, 'head', formatContext);
   }
 }
@@ -3720,7 +3720,7 @@ function pushStartBody(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is the wrong spot.
     return pushStartGenericElement(target, props, 'body', formatContext);
   }
 }
@@ -3754,7 +3754,7 @@ function pushStartHtml(
     );
   } else {
     // This <html> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is the wrong spot.
     return pushStartGenericElement(target, props, 'html', formatContext);
   }
 }


### PR DESCRIPTION
Fixes a duplicated word in three nearby server-rendering validation comments.

This is comment-only; no runtime behavior changes.