### PR TITLE
[DevTools] Ignore missing nodes in ranked chart

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingCharts-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCharts-test.js
@@ -10,6 +10,8 @@
 import type Store from 'react-devtools-shared/src/devtools/store';
 
 import {getVersionedRenderImplementation} from './utils';
+import {ElementTypeFunction} from 'react-devtools-shared/src/frontend/types';
+import {getChartData as getRankedChartDataFromBuilder} from 'react-devtools-shared/src/devtools/views/Profiler/RankedChartBuilder';
 
 describe('profiling charts', () => {
   let React;
@@ -30,6 +32,72 @@ describe('profiling charts', () => {
   });
 
   const {render} = getVersionedRenderImplementation();
+
+  it('ranked chart should ignore durations for nodes missing from the commit tree', () => {
+    const commitTree = {
+      rootID: 1,
+      nodes: new Map([
+        [
+          1,
+          {
+            children: [2],
+            compiledWithForget: false,
+            displayName: null,
+            hocDisplayNames: null,
+            id: 1,
+            key: null,
+            parentID: 0,
+            treeBaseDuration: 0,
+            type: ElementTypeFunction,
+          },
+        ],
+        [
+          2,
+          {
+            children: [],
+            compiledWithForget: false,
+            displayName: 'Parent',
+            hocDisplayNames: null,
+            id: 2,
+            key: null,
+            parentID: 1,
+            treeBaseDuration: 10,
+            type: ElementTypeFunction,
+          },
+        ],
+      ]),
+    };
+    const profilerStore = {
+      getCommitData() {
+        return {
+          fiberActualDurations: new Map([
+            [2, 10],
+            [3, 5],
+          ]),
+          fiberSelfDurations: new Map([
+            [2, 10],
+            [3, 5],
+          ]),
+        };
+      },
+    };
+
+    const chartData = getRankedChartDataFromBuilder({
+      commitIndex: 0,
+      commitTree,
+      profilerStore,
+      rootID: 123,
+    });
+
+    expect(chartData.nodes).toEqual([
+      {
+        id: 2,
+        label: 'Parent (10ms)',
+        name: 'Parent',
+        value: 10,
+      },
+    ]);
+  });
 
   function getFlamegraphChartData(rootID, commitIndex) {
     const commitTree = store.profilerStore.profilingCache.getCommitTree({

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/RankedChartBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/RankedChartBuilder.js
@@ -58,7 +58,7 @@ export function getChartData({
     const node = nodes.get(id);
 
     if (node == null) {
-      throw Error(`Could not find node with id "${id}" in commit tree`);
+      return;
     }
 
     const {displayName, key, parentID, type, compiledWithForget} = node;


### PR DESCRIPTION
## Summary

Fixes #35818.

The ranked Profiler chart can receive duration entries for fibers that are no longer present in the reconstructed commit tree. Instead of throwing while rendering the chart, skip those stale duration entries and continue rendering the remaining ranked data.

## How did you test this change?

- yarn test --build --project devtools packages/react-devtools-shared/src/__tests__/profilingCharts-test.js --runInBand