### PR TITLE
Fix: wrap cross-origin property access in try/catch in ReactPerforman…

### DIFF
--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -7,11 +7,11 @@
  * @flow
  */
 
-import {OMITTED_PROP_ERROR} from 'shared/ReactFlightPropertyAccess';
+import { OMITTED_PROP_ERROR } from 'shared/ReactFlightPropertyAccess';
 
 import hasOwnProperty from 'shared/hasOwnProperty';
 import isArray from 'shared/isArray';
-import {REACT_ELEMENT_TYPE} from './ReactSymbols';
+import { REACT_ELEMENT_TYPE } from './ReactSymbols';
 import getComponentNameFromType from './getComponentNameFromType';
 
 const EMPTY_ARRAY = 0;
@@ -62,7 +62,25 @@ export function addObjectToProperties(
   prefix: string,
 ): void {
   let addedProperties = 0;
-  for (const key in object) {
+
+  // Collect keys safely — cross-origin objects (e.g. iframe.contentWindow)
+  // throw SecurityError on any property enumeration.
+  let keys: Array<string>;
+  try {
+    keys = [];
+    for (const key in object) {
+      keys.push(key);
+    }
+  } catch (e) {
+    // Cross-origin object: show a placeholder and bail out early.
+    properties.push([
+      prefix + '\xa0\xa0'.repeat(indent) + '[cross-origin object]',
+      '',
+    ]);
+    return;
+  }
+
+  for (const key of keys) {
     if (hasOwnProperty.call(object, key) && key[0] !== '_') {
       addedProperties++;
       const value = object[key];
@@ -70,10 +88,10 @@ export function addObjectToProperties(
       if (addedProperties >= OBJECT_WIDTH_LIMIT) {
         properties.push([
           prefix +
-            '\xa0\xa0'.repeat(indent) +
-            'Only ' +
-            OBJECT_WIDTH_LIMIT +
-            ' properties are shown. React will not log more properties of this object.',
+          '\xa0\xa0'.repeat(indent) +
+          'Only ' +
+          OBJECT_WIDTH_LIMIT +
+          ' properties are shown. React will not log more properties of this object.',
           '',
         ]);
         break;
@@ -245,9 +263,14 @@ export function addValueToProperties(
           return;
         }
         if (objectName === 'Object') {
-          const proto: any = Object.getPrototypeOf(value);
-          if (proto && typeof proto.constructor === 'function') {
-            objectName = proto.constructor.name;
+          // Object.getPrototypeOf can throw SecurityError on cross-origin objects.
+          try {
+            const proto: any = Object.getPrototypeOf(value);
+            if (proto && typeof proto.constructor === 'function') {
+              objectName = proto.constructor.name;
+            }
+          } catch (e) {
+            // Cross-origin object — leave objectName as 'Object'.
           }
         }
         properties.push([
@@ -310,8 +333,8 @@ export function addObjectDiffToProperties(
     if (prevPropertiesChecked > OBJECT_WIDTH_LIMIT) {
       properties.push([
         'Previous object has more than ' +
-          OBJECT_WIDTH_LIMIT +
-          ' properties. React will not attempt to diff objects with too many properties.',
+        OBJECT_WIDTH_LIMIT +
+        ' properties. React will not attempt to diff objects with too many properties.',
         '',
       ]);
       isDeeplyEqual = false;
@@ -330,8 +353,8 @@ export function addObjectDiffToProperties(
     if (nextPropertiesChecked > OBJECT_WIDTH_LIMIT) {
       properties.push([
         'Next object has more than ' +
-          OBJECT_WIDTH_LIMIT +
-          ' properties. React will not attempt to diff objects with too many properties.',
+        OBJECT_WIDTH_LIMIT +
+        ' properties. React will not attempt to diff objects with too many properties.',
         '',
       ]);
       isDeeplyEqual = false;
@@ -360,7 +383,7 @@ export function addObjectDiffToProperties(
           prevValue !== null &&
           nextValue !== null &&
           readReactElementTypeof(prevValue) ===
-            readReactElementTypeof(nextValue)
+          readReactElementTypeof(nextValue)
         ) {
           if (readReactElementTypeof(nextValue) === REACT_ELEMENT_TYPE) {
             if (
@@ -431,7 +454,7 @@ export function addObjectDiffToProperties(
             properties.push([
               UNCHANGED + '\xa0\xa0'.repeat(indent) + key,
               desc +
-                ' Referentially unequal function closure. Consider memoization.',
+              ' Referentially unequal function closure. Consider memoization.',
             ]);
             continue;
           }


### PR DESCRIPTION
Fix SecurityError crash when cross-origin Window is passed as a prop (DEV build)

## Summary

Fixes a bug where passing a cross-origin Window object (e.g. iframe.contentWindow 
from an iframe with srcDoc="") as a React component prop crashes the entire fiber 
tree in DEV builds, making the UI permanently unresponsive.

## Problem

In React 19.2 DEV builds, the performance logger (logComponentRender) walks all 
component props via addObjectToProperties and addValueToProperties in 
ReactPerformanceTrackProperties.js.

When a prop contains a cross-origin Window object, the browser throws a SecurityError 
on any property access. Because there was no try/catch, this error escaped the commit 
phase and corrupted the work-in-progress fiber tree. Every render after that threw:

    Should not already be working.

...and the app became completely frozen — no clicks, no input, nothing worked.

## Root Cause

Two unguarded operations in ReactPerformanceTrackProperties.js:

1. for (const key in object) — throws SecurityError immediately when object is a 
   cross-origin Window because property enumeration is blocked by the browser.

2. Object.getPrototypeOf(value) — also throws SecurityError on cross-origin objects.

## Fix

File changed:
  packages/react-reconciler/src/ReactPerformanceTrackProperties.js

Change 1 — addObjectToProperties:
  Wrapped the for...in loop in a try/catch. If SecurityError is thrown, pushes a 
  [cross-origin object] placeholder into properties and returns early. Fiber tree 
  is never touched.

Change 2 — addValueToProperties:
  Wrapped Object.getPrototypeOf(value) in a try/catch. If it throws, objectName 
  silently stays as 'Object' and execution continues normally.

## How To Reproduce

1. Bootstrap a fresh Vite + React 19.2.5 app
2. Replace App.tsx with:

function App() {
  const iframeRef = useRef(null);
  const [win, setWin] = useState(null);

  useEffect(() => {
    setWin(iframeRef.current?.contentWindow ?? null);
  }, []);

  return (
    <>
      <iframe ref={iframeRef} srcDoc="<p>hi</p>" title="x" />
      <Child win={win} />
    </>
  );
}

function Child({ win }) {
  return <div>{win ? 'has window' : 'no window'}</div>;
}

3. Run npm run dev
4. Page freezes immediately after mount
5. Console shows SecurityError then Should not already be working

## Before This Fix

- SecurityError thrown inside commit phase
- Fiber tree left in broken state
- App permanently frozen after first mount
- Error message "Should not already be working" is completely misleading

## After This Fix

- Cross-origin objects are safely skipped with a [cross-origin object] placeholder
- Fiber tree stays intact
- App renders and works normally
- DEV performance logger continues working for all normal props

## Notes

- Only DEV builds are affected. Production is completely unaffected.
- This is NOT related to DevTools extension issue #29011
- readReactElementTypeof was already correctly guarded with 'in' check — 
  this PR guards the two remaining unprotected call sites in the same file
- Real world impact: Plotly, Vega, marimo HTML widgets, Jupyter widget 
  conversions, embedded notebook editors and dashboards all hit this bug
  when storing Window or DOM refs in component state

## Test

Tested manually with Vite + React 19.2.5 in Chrome.
Before patch: app freezes on mount.
After patch: app renders correctly, no errors in console.