### PR TITLE
Fix zod-validation-error dependency range

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/package.json
+++ b/compiler/packages/babel-plugin-react-compiler/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "zod": "^3.25.0 || ^4.0.0",
-    "zod-validation-error": "^3.5.0 || ^4.0.0"
+    "zod-validation-error": ">=3.5.0 <3.5.4 || ^4.0.0"
   },
   "resolutions": {
     "./**/@babel/parser": "7.7.4",

--- a/compiler/packages/eslint-plugin-react-compiler/package.json
+++ b/compiler/packages/eslint-plugin-react-compiler/package.json
@@ -16,7 +16,7 @@
     "@babel/parser": "^7.24.4",
     "hermes-parser": "^0.25.1",
     "zod": "^3.25.0 || ^4.0.0",
-    "zod-validation-error": "^3.5.0 || ^4.0.0"
+    "zod-validation-error": ">=3.5.0 <3.5.4 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.22.4",

--- a/compiler/packages/react-compiler-healthcheck/package.json
+++ b/compiler/packages/react-compiler-healthcheck/package.json
@@ -18,7 +18,7 @@
     "ora": "5.4.1",
     "yargs": "^17.7.2",
     "zod": "^3.25.0 || ^4.0.0",
-    "zod-validation-error": "^3.5.0 || ^4.0.0"
+    "zod-validation-error": ">=3.5.0 <3.5.4 || ^4.0.0"
   },
   "devDependencies": {},
   "engines": {

--- a/compiler/packages/snap/package.json
+++ b/compiler/packages/snap/package.json
@@ -40,7 +40,7 @@
     "readline": "^1.3.0",
     "yargs": "^17.7.1",
     "zod": "^3.25.0 || ^4.0.0",
-    "zod-validation-error": "^3.5.0 || ^4.0.0"
+    "zod-validation-error": ">=3.5.0 <3.5.4 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -43,7 +43,7 @@
     "@babel/parser": "^7.24.4",
     "hermes-parser": "^0.25.1",
     "zod": "^3.25.0 || ^4.0.0",
-    "zod-validation-error": "^3.5.0 || ^4.0.0"
+    "zod-validation-error": ">=3.5.0 <3.5.4 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18111,7 +18111,7 @@ zip-stream@^2.1.2:
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
 
-"zod-validation-error@^3.5.0 || ^4.0.0":
+"zod-validation-error@>=3.5.0 <3.5.4 || ^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
   integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==


### PR DESCRIPTION
## Summary

This updates packages that import `zod-validation-error/v4` so they no longer accept `zod-validation-error@3.5.4`.

`3.5.4` satisfies the old `^3.5.0 || ^4.0.0` range, but it does not export `./v4`, which can make `require('eslint-plugin-react-hooks')` fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` when a package manager resolves that version. The new range keeps the currently locked `4.0.2` resolution while excluding only the known-broken `3.5.4` version from the 3.x side of the range.

Fixes #35045.

## How did you test this change?

- `git diff --check`
- parsed the changed `package.json` files with `jq empty`
- verified `>=3.5.0 <3.5.4 || ^4.0.0` allows `3.5.0`, `3.5.3`, `4.0.0`, and `4.0.2`, while excluding `3.5.4`
- installed `zod-validation-error@>=3.5.0 <3.5.4 || ^4.0.0` in a temp project and verified `require('zod-validation-error/v4')` succeeds
