### PR TITLE
Fix typo: preceeding -> preceding in comments

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -5258,7 +5258,7 @@ export function processStringChunk(
       // We found the last chunk of the row
       if (buffer.length > 0) {
         // If we had a buffer already, it means that this chunk was split up into
-        // binary chunks preceeding it.
+        // binary chunks preceding it.
         throw new Error(
           'String chunks need to be passed in their original shape. ' +
             'Not split into smaller string chunks. ' +

--- a/packages/react-server/src/ReactFlightAsyncSequence.js
+++ b/packages/react-server/src/ReactFlightAsyncSequence.js
@@ -31,7 +31,7 @@ export type IONode = {
   end: number, // we typically don't use this. only when there's no promise intermediate.
   promise: null, // not used on I/O
   awaited: null, // I/O is only blocked on external.
-  previous: null | AwaitNode | UnresolvedAwaitNode, // the preceeding await that spawned this new work
+  previous: null | AwaitNode | UnresolvedAwaitNode, // the preceding await that spawned this new work
 };
 
 export type PromiseNode = {


### PR DESCRIPTION
## Summary

Fixes a spelling typo in two code comments: preceeding → preceding.

The misspelling appears in:
- `packages/react-client/src/ReactFlightClient.js` — comment about binary chunks
- `packages/react-server/src/ReactFlightAsyncSequence.js` — comment on the `previous` field of `IONode`

## How did you test this change?

Comment-only change with no runtime impact. Verified with `git grep preceeding` that no other occurrences remain in the repository.