### PR TITLE
React DOM: Add support for Invoker Commands API

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -2023,6 +2023,56 @@
 | `colSpan=(null)`| (initial, ssr error, ssr mismatch)| `<number: 1>` |
 | `colSpan=(undefined)`| (initial, ssr error, ssr mismatch)| `<number: 1>` |
 
+## `commandFor` (on `<button>` inside `<div>`)
+| Test Case | Flags | Result |
+| --- | --- | --- |
+| `commandFor=(string)`| (changed)| `<HTMLDivElement>` |
+| `commandFor=(empty string)`| (initial)| `<null>` |
+| `commandFor=(array with string)`| (changed, warning, ssr warning)| `<HTMLDivElement>` |
+| `commandFor=(empty array)`| (initial, warning, ssr warning)| `<null>` |
+| `commandFor=(object)`| (initial, warning, ssr warning)| `<null>` |
+| `commandFor=(numeric string)`| (initial)| `<null>` |
+| `commandFor=(-1)`| (initial)| `<null>` |
+| `commandFor=(0)`| (initial)| `<null>` |
+| `commandFor=(integer)`| (initial)| `<null>` |
+| `commandFor=(NaN)`| (initial, warning)| `<null>` |
+| `commandFor=(float)`| (initial)| `<null>` |
+| `commandFor=(true)`| (initial, warning)| `<null>` |
+| `commandFor=(false)`| (initial, warning)| `<null>` |
+| `commandFor=(string 'true')`| (initial)| `<null>` |
+| `commandFor=(string 'false')`| (initial)| `<null>` |
+| `commandFor=(string 'on')`| (initial)| `<null>` |
+| `commandFor=(string 'off')`| (initial)| `<null>` |
+| `commandFor=(symbol)`| (initial, warning)| `<null>` |
+| `commandFor=(function)`| (initial, warning)| `<null>` |
+| `commandFor=(null)`| (initial)| `<null>` |
+| `commandFor=(undefined)`| (initial)| `<null>` |
+
+## `command` (on `<button>` inside `<div>`)
+| Test Case | Flags | Result |
+| --- | --- | --- |
+| `command=(string)`| (changed)| `"toggle-popover"` |
+| `command=(empty string)`| (initial)| `""` |
+| `command=(array with string)`| (changed)| `"toggle-popover"` |
+| `command=(empty array)`| (initial)| `""` |
+| `command=(object)`| (initial)| `""` |
+| `command=(numeric string)`| (initial)| `""` |
+| `command=(-1)`| (initial)| `""` |
+| `command=(0)`| (initial)| `""` |
+| `command=(integer)`| (initial)| `""` |
+| `command=(NaN)`| (initial, warning)| `""` |
+| `command=(float)`| (initial)| `""` |
+| `command=(true)`| (initial, warning)| `""` |
+| `command=(false)`| (initial, warning)| `""` |
+| `command=(string 'true')`| (initial)| `""` |
+| `command=(string 'false')`| (initial)| `""` |
+| `command=(string 'on')`| (initial)| `""` |
+| `command=(string 'off')`| (initial)| `""` |
+| `command=(symbol)`| (initial, warning)| `""` |
+| `command=(function)`| (initial, warning)| `""` |
+| `command=(null)`| (initial)| `""` |
+| `command=(undefined)`| (initial)| `""` |
+
 ## `content` (on `<meta>` inside `<head>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |

--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -357,6 +357,21 @@ const attributes = [
   },
   {name: 'cols', tagName: 'textarea'},
   {name: 'colSpan', containerTagName: 'tr', tagName: 'td'},
+  {
+    name: 'commandFor',
+    read: element => {
+      document.body.appendChild(element);
+      try {
+        // trigger and target need to be connected for `commandForElement` to read the actual value.
+        return element.commandForElement;
+      } finally {
+        document.body.removeChild(element);
+      }
+    },
+    overrideStringValue: 'popover-target',
+    tagName: 'button',
+  },
+  {name: 'command', overrideStringValue: 'toggle-popover', tagName: 'button'},
   {name: 'content', containerTagName: 'head', tagName: 'meta'},
   {name: 'contentEditable'},
   {

--- a/flow-typed/environments/dom.js
+++ b/flow-typed/environments/dom.js
@@ -233,6 +233,7 @@ type AnimationEventTypes =
   | 'animationend'
   | 'animationiteration';
 type ClipboardEventTypes = 'clipboardchange' | 'cut' | 'copy' | 'paste';
+type CommandEventTypes = 'command';
 type TransitionEventTypes =
   | 'transitionrun'
   | 'transitionstart'

--- a/flow-typed/environments/html.js
+++ b/flow-typed/environments/html.js
@@ -144,6 +144,20 @@ declare class ToggleEvent extends Event {
   +newState: string;
 }
 
+type CommandEvent$Init = {
+  ...Event$Init,
+  command?: string,
+  source?: Element | null,
+  ...
+};
+
+// https://html.spec.whatwg.org/multipage/interaction.html#commandevent
+declare class CommandEvent extends Event {
+  constructor(type: CommandEventTypes, eventInit?: CommandEvent$Init): void;
+  +command: string;
+  +source: Element | null;
+}
+
 // TODO: HTMLDocument
 type FocusOptions = {preventScroll?: boolean, ...};
 
@@ -244,6 +258,7 @@ declare class HTMLElement extends Element {
   ontimeupdate: ?Function;
   ontoggle: ?Function;
   onbeforetoggle: ?Function;
+  oncommand: ?Function;
   onvolumechange: ?Function;
   onwaiting: ?Function;
   properties: any;
@@ -1141,6 +1156,8 @@ declare class HTMLButtonElement extends HTMLElement {
   setCustomValidity(error: string): void;
   popoverTargetElement: Element | null;
   popoverTargetAction: 'toggle' | 'show' | 'hide';
+  commandForElement: Element | null;
+  command: string;
 }
 
 // https://w3c.github.io/html/sec-forms.html#the-textarea-element

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -88,6 +88,7 @@ let didWarnFormActionTarget = false;
 let didWarnFormActionMethod = false;
 let didWarnForNewBooleanPropsWithEmptyValue: {[string]: boolean};
 let didWarnPopoverTargetObject = false;
+let didWarnCommandForObject = false;
 if (__DEV__) {
   didWarnForNewBooleanPropsWithEmptyValue = {};
 }
@@ -647,6 +648,15 @@ function setProp(
       }
       return;
     }
+    case 'onCommand': {
+      if (value != null) {
+        if (__DEV__ && typeof value !== 'function') {
+          warnForInvalidEventListener(key, value);
+        }
+        listenToNonDelegatedEvent('command', domElement);
+      }
+      return;
+    }
     case 'dangerouslySetInnerHTML': {
       if (value != null) {
         if (typeof value !== 'object' || !('__html' in value)) {
@@ -972,6 +982,22 @@ function setProp(
           );
         }
       }
+      break;
+    case 'commandFor':
+      if (__DEV__) {
+        if (
+          !didWarnCommandForObject &&
+          value != null &&
+          typeof value === 'object'
+        ) {
+          didWarnCommandForObject = true;
+          console.error(
+            'The `commandFor` prop expects the ID of an Element as a string. Received %s instead.',
+            value,
+          );
+        }
+      }
+      break;
     // Fall through
     default: {
       if (
@@ -1067,6 +1093,15 @@ function setPropOnCustomElement(
           // For use by the polyfill.
           listenToNonDelegatedEvent('scroll', domElement);
         }
+      }
+      return;
+    }
+    case 'onCommand': {
+      if (value != null) {
+        if (__DEV__ && typeof value !== 'function') {
+          warnForInvalidEventListener(key, value);
+        }
+        listenToNonDelegatedEvent('command', domElement);
       }
       return;
     }
@@ -3301,6 +3336,10 @@ export function hydrateProperties(
       // For use by the polyfill.
       listenToNonDelegatedEvent('scroll', domElement);
     }
+  }
+
+  if (props.onCommand != null) {
+    listenToNonDelegatedEvent('command', domElement);
   }
 
   if (props.onClick != null) {

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -982,10 +982,11 @@ function setProp(
           );
         }
       }
-      break;
+    // Fall through
     case 'commandFor':
       if (__DEV__) {
         if (
+          key === 'commandFor' &&
           !didWarnCommandForObject &&
           value != null &&
           typeof value === 'object'
@@ -997,7 +998,6 @@ function setProp(
           );
         }
       }
-      break;
     // Fall through
     default: {
       if (

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -982,11 +982,11 @@ function setProp(
           );
         }
       }
-    // Fall through
+      setValueForAttribute(domElement, getAttributeAlias(key), value);
+      break;
     case 'commandFor':
       if (__DEV__) {
         if (
-          key === 'commandFor' &&
           !didWarnCommandForObject &&
           value != null &&
           typeof value === 'object'
@@ -998,7 +998,8 @@ function setProp(
           );
         }
       }
-    // Fall through
+      setValueForAttribute(domElement, getAttributeAlias(key), value);
+      break;
     default: {
       if (
         key.length > 2 &&

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -982,11 +982,11 @@ function setProp(
           );
         }
       }
-      setValueForAttribute(domElement, getAttributeAlias(key), value);
-      break;
+    // Fall through
     case 'commandFor':
       if (__DEV__) {
         if (
+          key === 'commandFor' &&
           !didWarnCommandForObject &&
           value != null &&
           typeof value === 'object'
@@ -998,8 +998,7 @@ function setProp(
           );
         }
       }
-      setValueForAttribute(domElement, getAttributeAlias(key), value);
-      break;
+    // Fall through
     default: {
       if (
         key.length > 2 &&

--- a/packages/react-dom-bindings/src/events/DOMEventNames.js
+++ b/packages/react-dom-bindings/src/events/DOMEventNames.js
@@ -26,6 +26,7 @@ export type DOMEventName =
   | 'change'
   | 'click'
   | 'close'
+  | 'command'
   | 'compositionend'
   | 'compositionstart'
   | 'compositionupdate'

--- a/packages/react-dom-bindings/src/events/DOMEventProperties.js
+++ b/packages/react-dom-bindings/src/events/DOMEventProperties.js
@@ -46,6 +46,7 @@ const simpleEventPluginEvents = [
   'canPlayThrough',
   'click',
   'close',
+  'command',
   'contextMenu',
   'copy',
   'cut',

--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -237,6 +237,7 @@ export const nonDelegatedEvents: Set<DOMEventName> = new Set([
   'beforetoggle',
   'cancel',
   'close',
+  'command',
   'invalid',
   'load',
   'scroll',

--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -316,6 +316,7 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
     case 'cancel':
     case 'click':
     case 'close':
+    case 'command':
     case 'contextmenu':
     case 'copy':
     case 'cut':

--- a/packages/react-dom-bindings/src/events/SyntheticEvent.js
+++ b/packages/react-dom-bindings/src/events/SyntheticEvent.js
@@ -612,3 +612,16 @@ const ToggleEventInterface: EventInterfaceType = {
 };
 export const SyntheticToggleEvent: $FlowFixMe =
   createSyntheticEvent(ToggleEventInterface);
+
+/**
+ * @interface CommandEvent
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#commandevent
+ */
+const CommandEventInterface: EventInterfaceType = {
+  ...EventInterface,
+  command: 0,
+  source: 0,
+};
+export const SyntheticCommandEvent: $FlowFixMe = createSyntheticEvent(
+  CommandEventInterface,
+);

--- a/packages/react-dom-bindings/src/events/SyntheticEvent.js
+++ b/packages/react-dom-bindings/src/events/SyntheticEvent.js
@@ -613,3 +613,16 @@ const ToggleEventInterface: EventInterfaceType = {
 };
 export const SyntheticToggleEvent: $FlowFixMe =
   createSyntheticEvent(ToggleEventInterface);
+
+/**
+ * @interface CommandEvent
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#commandevent
+ */
+const CommandEventInterface: EventInterfaceType = {
+  ...EventInterface,
+  command: 0,
+  source: 0,
+};
+export const SyntheticCommandEvent: $FlowFixMe = createSyntheticEvent(
+  CommandEventInterface,
+);

--- a/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
@@ -29,6 +29,7 @@ import {
   SyntheticPointerEvent,
   SyntheticSubmitEvent,
   SyntheticToggleEvent,
+  SyntheticCommandEvent,
 } from '../../events/SyntheticEvent';
 
 import {
@@ -171,6 +172,9 @@ function extractEvents(
       // MDN claims <details> should not receive ToggleEvent contradicting the spec: https://html.spec.whatwg.org/multipage/indices.html#event-toggle
       SyntheticEventCtor = SyntheticToggleEvent;
       break;
+    case 'command':
+      SyntheticEventCtor = SyntheticCommandEvent;
+      break;
     default:
       // Unknown event. This is used by createEventHandle.
       break;
@@ -210,7 +214,9 @@ function extractEvents(
       // nonDelegatedEvents list in DOMPluginEventSystem.
       // Then we can remove this special list.
       // This is a breaking change that can wait until React 18.
-      (domEventName === 'scroll' || domEventName === 'scrollend');
+      (domEventName === 'scroll' ||
+        domEventName === 'scrollend' ||
+        domEventName === 'command');
 
     const listeners = accumulateSinglePhaseListeners(
       targetInst,

--- a/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
@@ -208,6 +208,8 @@ function extractEvents(
     // In the past, React has always bubbled them, but this can be surprising.
     // We're going to try aligning closer to the browser behavior by not bubbling
     // them in React either. We'll start by not bubbling onScroll, and then expand.
+    // Unlike toggle/beforetoggle (which still emulate bubbling for back-compat),
+    // command is new so we match the platform and do not emulate bubbling.
     const accumulateTargetOnly =
       !inCapturePhase &&
       // TODO: ideally, we'd eventually add all events from

--- a/packages/react-dom-bindings/src/shared/getAttributeAlias.js
+++ b/packages/react-dom-bindings/src/shared/getAttributeAlias.js
@@ -13,6 +13,7 @@ const aliases = new Map([
   ['httpEquiv', 'http-equiv'],
   // HTML and SVG attributes, but the SVG attribute is case sensitive.],
   ['crossOrigin', 'crossorigin'],
+  ['commandFor', 'commandfor'],
   // This is a list of all SVG attributes that need special casing.
   // Regular attributes that just accept strings.],
   ['accentHeight', 'accent-height'],

--- a/packages/react-dom-bindings/src/shared/possibleStandardNames.js
+++ b/packages/react-dom-bindings/src/shared/possibleStandardNames.js
@@ -38,6 +38,8 @@ const possibleStandardNames = {
   classname: 'className',
   cols: 'cols',
   colspan: 'colSpan',
+  command: 'command',
+  commandfor: 'commandFor',
   content: 'content',
   contenteditable: 'contentEditable',
   contextmenu: 'contextMenu',

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -1374,6 +1374,34 @@ describe('DOMPropertyOperations', () => {
         );
       });
     });
+
+    it('warns when using commandFor={HTMLElement}', async () => {
+      const commandTarget = document.createElement('div');
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <button key="one" commandFor={commandTarget}>
+            Invoke command
+          </button>,
+        );
+      });
+
+      assertConsoleErrorDev([
+        'The `commandFor` prop expects the ID of an Element as a string. Received HTMLDivElement {} instead.\n' +
+          '    in button (at **)',
+      ]);
+
+      // Dedupe warning
+      await act(() => {
+        root.render(
+          <button key="two" commandFor={commandTarget}>
+            Invoke command
+          </button>,
+        );
+      });
+    });
   });
 
   describe('deleteValueForProperty', () => {

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -1375,6 +1375,23 @@ describe('DOMPropertyOperations', () => {
       });
     });
 
+    it('sets commandFor attribute on button', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+
+      await act(() => {
+        root.render(
+          <button commandFor="demo-popover" command="show-popover">
+            show-popover
+          </button>,
+        );
+      });
+
+      const button = container.querySelector('button');
+      expect(button.getAttribute('commandfor')).toBe('demo-popover');
+      expect(button.getAttribute('command')).toBe('show-popover');
+    });
+
     it('warns when using commandFor={HTMLElement}', async () => {
       const commandTarget = document.createElement('div');
       const container = document.createElement('div');

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -730,6 +730,33 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
+  it('should not emulate bubbling of command events', async () => {
+    const container = document.createElement('div');
+    const ref = React.createRef();
+    const onCommand = jest.fn();
+    document.body.appendChild(container);
+    try {
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <div onCommand={onCommand}>
+            <img ref={ref} alt="" onCommand={onCommand} />
+          </div>,
+        );
+      });
+      await act(() => {
+        ref.current.dispatchEvent(
+          new Event('command', {
+            bubbles: false,
+          }),
+        );
+      });
+      expect(onCommand).toHaveBeenCalledTimes(1);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
   it('should bubble non-native bubbling cancel/close events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -734,14 +734,20 @@ describe('ReactDOMEventListener', () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onCommand = jest.fn();
+    const onParentCommand = jest.fn();
     document.body.appendChild(container);
     try {
       const root = ReactDOMClient.createRoot(container);
       await act(() => {
         root.render(
-          <div onCommand={onCommand}>
-            <img ref={ref} alt="" onCommand={onCommand} />
-          </div>,
+          <>
+            <button commandFor="target" command="--rotate-left">
+              Rotate left
+            </button>
+            <div onCommand={onParentCommand}>
+              <img id="target" ref={ref} alt="" onCommand={onCommand} />
+            </div>
+          </>,
         );
       });
       await act(() => {
@@ -752,6 +758,7 @@ describe('ReactDOMEventListener', () => {
         );
       });
       expect(onCommand).toHaveBeenCalledTimes(1);
+      expect(onParentCommand).not.toHaveBeenCalled();
     } finally {
       document.body.removeChild(container);
     }

--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -1434,6 +1434,38 @@ describe('ReactDOMEventListener', () => {
         },
       });
     });
+
+    it('onCommand', async () => {
+      await testNonBubblingEvent({
+        type: 'img',
+        reactEvent: 'onCommand',
+        reactEventType: 'command',
+        nativeEvent: 'command',
+        dispatch(node) {
+          const e = new Event('command', {
+            bubbles: false,
+            cancelable: true,
+          });
+          node.dispatchEvent(e);
+        },
+      });
+    });
+
+    it('onCommand Invoker Commands API', async () => {
+      await testNonBubblingEvent({
+        type: 'div',
+        reactEvent: 'onCommand',
+        reactEventType: 'command',
+        nativeEvent: 'command',
+        dispatch(node) {
+          const e = new Event('command', {
+            bubbles: false,
+            cancelable: true,
+          });
+          node.dispatchEvent(e);
+        },
+      });
+    });
   });
 
   // The tests for these events are currently very limited

--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -1437,22 +1437,6 @@ describe('ReactDOMEventListener', () => {
 
     it('onCommand', async () => {
       await testNonBubblingEvent({
-        type: 'img',
-        reactEvent: 'onCommand',
-        reactEventType: 'command',
-        nativeEvent: 'command',
-        dispatch(node) {
-          const e = new Event('command', {
-            bubbles: false,
-            cancelable: true,
-          });
-          node.dispatchEvent(e);
-        },
-      });
-    });
-
-    it('onCommand Invoker Commands API', async () => {
-      await testNonBubblingEvent({
         type: 'div',
         reactEvent: 'onCommand',
         reactEventType: 'command',

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -333,6 +333,26 @@ describe('ReactDOMServerIntegration', () => {
       });
     });
 
+    describe('commandFor property', function () {
+      itRenders('commandFor with string value', async render => {
+        const e = await render(<button commandFor="target" />);
+        expect(e.getAttribute('commandfor')).toBe('target');
+      });
+
+      itRenders('command with string value', async render => {
+        const e = await render(<button command="show-popover" />);
+        expect(e.getAttribute('command')).toBe('show-popover');
+      });
+
+      itRenders('commandFor and command together', async render => {
+        const e = await render(
+          <button commandFor="target" command="toggle-popover" />,
+        );
+        expect(e.getAttribute('commandfor')).toBe('target');
+        expect(e.getAttribute('command')).toBe('toggle-popover');
+      });
+    });
+
     describe('numeric properties', function () {
       itRenders(
         'positive numeric property with positive value',

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -852,4 +852,41 @@ describe('ReactDOMServerHydration', () => {
 
     expect(ref.current).toBe(button);
   });
+
+  it('should hydrate Invoker Commands API attributes and onCommand', async () => {
+    const onCommand = jest.fn();
+    const jsx = (
+      <>
+        <button commandFor="target" command="show-popover">
+          Show
+        </button>
+        <div id="target" onCommand={onCommand} />
+      </>
+    );
+
+    const element = document.createElement('div');
+    element.innerHTML = ReactDOMServer.renderToString(jsx);
+
+    const button = element.querySelector('button');
+    const target = element.querySelector('#target');
+    expect(button.getAttribute('commandfor')).toBe('target');
+    expect(button.getAttribute('command')).toBe('show-popover');
+
+    await act(() => {
+      ReactDOMClient.hydrateRoot(element, jsx);
+    });
+
+    expect(button.getAttribute('commandfor')).toBe('target');
+    expect(button.getAttribute('command')).toBe('show-popover');
+
+    await act(() => {
+      target.dispatchEvent(
+        new window.Event('command', {
+          bubbles: false,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(onCommand).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -864,17 +864,28 @@ describe('ReactDOMServerHydration', () => {
       </>
     );
 
+    const markup = ReactDOMServer.renderToString(jsx);
+    expect(markup).toContain('commandfor="target"');
+    expect(markup).toContain('command="show-popover"');
+    expect(markup).not.toContain('commandFor=');
+
     const element = document.createElement('div');
-    element.innerHTML = ReactDOMServer.renderToString(jsx);
+    element.innerHTML = markup;
 
     const button = element.querySelector('button');
     const target = element.querySelector('#target');
     expect(button.getAttribute('commandfor')).toBe('target');
     expect(button.getAttribute('command')).toBe('show-popover');
 
+    const recoverableErrors = [];
     await act(() => {
-      ReactDOMClient.hydrateRoot(element, jsx);
+      ReactDOMClient.hydrateRoot(element, jsx, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error);
+        },
+      });
     });
+    expect(recoverableErrors).toEqual([]);
 
     expect(button.getAttribute('commandfor')).toBe('target');
     expect(button.getAttribute('command')).toBe('show-popover');

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -18,6 +18,14 @@ class ToggleEvent extends Event {
   }
 }
 
+class CommandEvent extends Event {
+  constructor(type, eventInit) {
+    super(type, eventInit);
+    this.command = eventInit.command;
+    this.source = eventInit.source;
+  }
+}
+
 describe('SimpleEventPlugin', function () {
   let React;
   let ReactDOMClient;
@@ -587,6 +595,43 @@ describe('SimpleEventPlugin', function () {
         expect.objectContaining({
           oldState: 'open',
           newState: 'closed',
+        }),
+      );
+    });
+
+    it('dispatches synthetic command events when the Invoker Commands API is used', async () => {
+      container = document.createElement('div');
+
+      const onCommand = jest.fn();
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <>
+            <button commandFor="target" command="--rotate-left">
+              Rotate left
+            </button>
+            <img id="target" alt="" onCommand={onCommand} />
+          </>,
+        );
+      });
+
+      const target = container.querySelector('#target');
+      const source = container.querySelector('button');
+      target.dispatchEvent(
+        new CommandEvent('command', {
+          bubbles: false,
+          cancelable: true,
+          command: '--rotate-left',
+          source: source,
+        }),
+      );
+
+      expect(onCommand).toHaveBeenCalledTimes(1);
+      const event = onCommand.mock.calls[0][0];
+      expect(event).toEqual(
+        expect.objectContaining({
+          command: '--rotate-left',
+          source: source,
         }),
       );
     });

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -19,6 +19,14 @@ class ToggleEvent extends Event {
   }
 }
 
+class CommandEvent extends Event {
+  constructor(type, eventInit) {
+    super(type, eventInit);
+    this.command = eventInit.command;
+    this.source = eventInit.source;
+  }
+}
+
 describe('SimpleEventPlugin', function () {
   let React;
   let ReactDOMClient;
@@ -588,6 +596,43 @@ describe('SimpleEventPlugin', function () {
         expect.objectContaining({
           oldState: 'open',
           newState: 'closed',
+        }),
+      );
+    });
+
+    it('dispatches synthetic command events when the Invoker Commands API is used', async () => {
+      container = document.createElement('div');
+
+      const onCommand = jest.fn();
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(
+          <>
+            <button commandFor="target" command="--rotate-left">
+              Rotate left
+            </button>
+            <img id="target" alt="" onCommand={onCommand} />
+          </>,
+        );
+      });
+
+      const target = container.querySelector('#target');
+      const source = container.querySelector('button');
+      target.dispatchEvent(
+        new CommandEvent('command', {
+          bubbles: false,
+          cancelable: true,
+          command: '--rotate-left',
+          source: source,
+        }),
+      );
+
+      expect(onCommand).toHaveBeenCalledTimes(1);
+      const event = onCommand.mock.calls[0][0];
+      expect(event).toEqual(
+        expect.objectContaining({
+          command: '--rotate-left',
+          source: source,
         }),
       );
     });


### PR DESCRIPTION

## Summary

This includes support for [commandfor](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor), [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command), and  [oncommand event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/command_event). The events are only triggered by elements that match the Invoker Commands API.

The [Invoker Commands API is currently supported in all major browsers](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API#browser_compatibility) (Chrome, Safari, Firefox)

I designed this PR to match [React DOM: Add support for Popover API #27981](https://github.com/facebook/react/pull/27981) as closely as possible, with as few changes as possible. 

Fixes: #32478  


## How did you test this change?

1) Created tests, and all relevant tests passed (locally on Node v20.19.0, but 1 unrelated snapshot fails on Node v24.15.0  ) 
2) [Sandbox demo](https://codesandbox.io/p/sandbox/ngqx5c) 
3) [SSR repo demo](https://github.com/MaxwellCohen/react-vite-test-command)
 
## Open Questions/Concerns
1) I tried my best to place the invoker command code in the proper places in large, relevant files; if they are not, please let me know so I can match coding standards.
2) This is adding a new synthetic event. I want to make sure I am adding all necessary code, types, and other things to support React synthetic events. If I am missing something, please let me know so I can add it.
3) What is the process for updating the DefinitelyTyped package for React to add support for Invoker Commands?

I leveraged various LLMs to help me create this PR and reviewed every line
