### PR TITLE
Fix #36525: DevTools Profiler 'What changed' context scrolls out of view

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.css
@@ -26,6 +26,10 @@
   text-overflow: ellipsis;
 }
 
+.CommitListContainer {
+  flex: 0 0 auto;
+}
+
 .Label {
   font-weight: bold;
   margin-bottom: 0.5rem;

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -136,7 +136,7 @@ export default function SidebarSelectedFiberInfo(): React.Node {
         )}
         <WhatChanged fiberID={((selectedFiberID: any): number)} />
         {listItems.length > 0 && (
-          <div>
+          <div className={styles.CommitListContainer}>
             <label className={styles.Label}>Rendered at: </label>
             {listItems}
           </div>


### PR DESCRIPTION
## Bug Description
When inspecting a fiber with a long render history (many commits) in the React DevTools Profiler, scrolling through the commit list to inspect individual renders causes the 'Why did this render?' (WhatChanged) section to scroll out of view. This makes it difficult to reference why a component rendered while navigating through commits.

## Root Cause
The 'Rendered at:' commit list and the 'Why did this render?' section are both placed in a scrollable column container. When the commit list grows long, it pushes the WhatChanged content out of the visible area.

## Fix
Wrap the commit list in a container with `flex: 0 0 auto` so it takes only the space it needs and doesn't push the WhatChanged section out of view. The WhatChanged section stays fixed at the top while users navigate commits below.

**Before:** The commit list and WhatChanged content compete for the same flex space, causing WhatChanged to scroll away.

**After:** The commit list is self-sizing and doesn't push WhatChanged out of view.

Closes facebook/react#36525