### PR TITLE
[Fiber] Propagate context to dehydrated Suspense boundaries before bailout

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -476,6 +476,115 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  it('does not produce a hydration mismatch when context updates in an already-hydrated ancestor before a streamed boundary hydrates', async () => {
+    // Regression test: Updating a context value in an already-hydrated ancestor
+    // (via a state update on a provider with referentially stable children)
+    // before a streamed Suspense child that reads that context finishes
+    // streaming used to cause a hydration mismatch. The streamed segment was
+    // rendered on the server with the initial context value, but the client
+    // hydrated it against the updated context. React should recover without a
+    // mismatch error.
+
+    const NumberContext = React.createContext(0);
+    let setNumberExternal = null;
+
+    function NumberProvider({children}) {
+      const [number, setNumber] = React.useState(0);
+      setNumberExternal = setNumber;
+      return (
+        <NumberContext.Provider value={number}>
+          {children}
+        </NumberContext.Provider>
+      );
+    }
+
+    function DisplayNumber() {
+      const number = React.useContext(NumberContext);
+      readText('display');
+      return <div>Number: {number}</div>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <NumberProvider>
+            <Suspense fallback={<div>Loading...</div>}>
+              <DisplayNumber />
+            </Suspense>
+          </NumberProvider>
+        </div>
+      );
+    }
+
+    // The same context object is shared by the Fizz server and the client
+    // renderer in this single-process test, which trips the "multiple
+    // renderers" dev warning. That doesn't happen in real apps where server and
+    // client are separate processes, so filter it out here.
+    const realConsoleError = console.error;
+    console.error = (...args) => {
+      if (
+        typeof args[0] === 'string' &&
+        args[0].includes('Detected multiple renderers')
+      ) {
+        return;
+      }
+      realConsoleError.apply(console, args);
+    };
+
+    try {
+      await act(() => {
+        const {pipe} = renderToPipeableStream(<App />);
+        pipe(writable);
+      });
+
+      expect(getVisibleChildren(container)).toEqual(
+        <div>
+          <div>Loading...</div>
+        </div>,
+      );
+
+      const errors = [];
+      ReactDOMClient.hydrateRoot(container, <App />, {
+        onRecoverableError(error) {
+          errors.push(normalizeError(error.message));
+        },
+      });
+      await waitForAll([]);
+
+      // Shell hydrated, boundary still pending.
+      expect(getVisibleChildren(container)).toEqual(
+        <div>
+          <div>Loading...</div>
+        </div>,
+      );
+
+      // Update the context value in the already-hydrated ancestor BEFORE the
+      // streamed boundary content arrives and hydrates.
+      await clientAct(() => {
+        React.startTransition(() => {
+          setNumberExternal(1);
+        });
+      });
+
+      // Now the boundary content becomes available.
+      await act(() => {
+        resolveText('display');
+      });
+      await clientAct(async () => {});
+
+      // No hydration mismatch error should have been reported, and the boundary
+      // should reflect the updated context value.
+      expect(errors).toEqual([]);
+      expect(getVisibleChildren(container)).toEqual(
+        <div>
+          <div>Number: {'1'}</div>
+        </div>,
+      );
+    } finally {
+      console.error = realConsoleError;
+    }
+  });
+
   it('#23331: does not warn about hydration mismatches if something suspended in an earlier sibling', async () => {
     const makeApp = () => {
       let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -516,73 +516,59 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    // The same context object is shared by the Fizz server and the client
-    // renderer in this single-process test, which trips the "multiple
-    // renderers" dev warning. That doesn't happen in real apps where server and
-    // client are separate processes, so filter it out here.
-    const realConsoleError = console.error;
-    console.error = (...args) => {
-      if (
-        typeof args[0] === 'string' &&
-        args[0].includes('Detected multiple renderers')
-      ) {
-        return;
-      }
-      realConsoleError.apply(console, args);
-    };
+    await act(() => {
+      const {pipe} = renderToPipeableStream(<App />);
+      pipe(writable);
+    });
 
-    try {
-      await act(() => {
-        const {pipe} = renderToPipeableStream(<App />);
-        pipe(writable);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Loading...</div>
+      </div>,
+    );
+
+    // Hydration uses a different renderer runtime (Fiber instead of Fizz).
+    // We reset _currentRenderer here to not trigger a warning about multiple
+    // renderers concurrently using these contexts
+    NumberContext._currentRenderer = null;
+
+    const errors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        errors.push(normalizeError(error.message));
+      },
+    });
+    await waitForAll([]);
+
+    // Shell hydrated, boundary still pending.
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Loading...</div>
+      </div>,
+    );
+
+    // Update the context value in the already-hydrated ancestor BEFORE the
+    // streamed boundary content arrives and hydrates.
+    await clientAct(() => {
+      React.startTransition(() => {
+        setNumberExternal(1);
       });
+    });
 
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <div>Loading...</div>
-        </div>,
-      );
+    // Now the boundary content becomes available.
+    await act(() => {
+      resolveText('display');
+    });
+    await clientAct(async () => {});
 
-      const errors = [];
-      ReactDOMClient.hydrateRoot(container, <App />, {
-        onRecoverableError(error) {
-          errors.push(normalizeError(error.message));
-        },
-      });
-      await waitForAll([]);
-
-      // Shell hydrated, boundary still pending.
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <div>Loading...</div>
-        </div>,
-      );
-
-      // Update the context value in the already-hydrated ancestor BEFORE the
-      // streamed boundary content arrives and hydrates.
-      await clientAct(() => {
-        React.startTransition(() => {
-          setNumberExternal(1);
-        });
-      });
-
-      // Now the boundary content becomes available.
-      await act(() => {
-        resolveText('display');
-      });
-      await clientAct(async () => {});
-
-      // No hydration mismatch error should have been reported, and the boundary
-      // should reflect the updated context value.
-      expect(errors).toEqual([]);
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <div>Number: {'1'}</div>
-        </div>,
-      );
-    } finally {
-      console.error = realConsoleError;
-    }
+    // No hydration mismatch error should have been reported, and the boundary
+    // should reflect the updated context value.
+    expect(errors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Number: {'1'}</div>
+      </div>,
+    );
   });
 
   it('#23331: does not warn about hydration mismatches if something suspended in an earlier sibling', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1279,73 +1279,59 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    // The same context object is shared by the Fizz server and the client
-    // renderer in this single-process test, which trips the "multiple
-    // renderers" dev warning. That doesn't happen in real apps where server and
-    // client are separate processes, so filter it out here.
-    const realConsoleError = console.error;
-    console.error = (...args) => {
-      if (
-        typeof args[0] === 'string' &&
-        args[0].includes('Detected multiple renderers')
-      ) {
-        return;
-      }
-      realConsoleError.apply(console, args);
-    };
+    await act(() => {
+      const {pipe} = renderToPipeableStream(<App />);
+      pipe(writable);
+    });
 
-    try {
-      await act(() => {
-        const {pipe} = renderToPipeableStream(<App />);
-        pipe(writable);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Loading...</div>
+      </div>,
+    );
+
+    // Hydration uses a different renderer runtime (Fiber instead of Fizz).
+    // We reset _currentRenderer here to not trigger a warning about multiple
+    // renderers concurrently using these contexts
+    NumberContext._currentRenderer = null;
+
+    const errors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        errors.push(normalizeError(error.message));
+      },
+    });
+    await waitForAll([]);
+
+    // Shell hydrated, boundary still pending.
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Loading...</div>
+      </div>,
+    );
+
+    // Update the context value in the already-hydrated ancestor BEFORE the
+    // streamed boundary content arrives and hydrates.
+    await clientAct(() => {
+      React.startTransition(() => {
+        setNumberExternal(1);
       });
+    });
 
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <div>Loading...</div>
-        </div>,
-      );
+    // Now the boundary content becomes available.
+    await act(() => {
+      resolveText('display');
+    });
+    await clientAct(async () => {});
 
-      const errors = [];
-      ReactDOMClient.hydrateRoot(container, <App />, {
-        onRecoverableError(error) {
-          errors.push(normalizeError(error.message));
-        },
-      });
-      await waitForAll([]);
-
-      // Shell hydrated, boundary still pending.
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <div>Loading...</div>
-        </div>,
-      );
-
-      // Update the context value in the already-hydrated ancestor BEFORE the
-      // streamed boundary content arrives and hydrates.
-      await clientAct(() => {
-        React.startTransition(() => {
-          setNumberExternal(1);
-        });
-      });
-
-      // Now the boundary content becomes available.
-      await act(() => {
-        resolveText('display');
-      });
-      await clientAct(async () => {});
-
-      // No hydration mismatch error should have been reported, and the boundary
-      // should reflect the updated context value.
-      expect(errors).toEqual([]);
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <div>Number: {'1'}</div>
-        </div>,
-      );
-    } finally {
-      console.error = realConsoleError;
-    }
+    // No hydration mismatch error should have been reported, and the boundary
+    // should reflect the updated context value.
+    expect(errors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Number: {'1'}</div>
+      </div>,
+    );
   });
 
   it('#23331: does not warn about hydration mismatches if something suspended in an earlier sibling', async () => {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1330,6 +1330,103 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  it('updates context in the fallback while a Suspense boundary is still streaming', async () => {
+    const NumberContext = React.createContext(0);
+    let setNumberExternal = null;
+
+    function NumberProvider({children}) {
+      const [number, setNumber] = React.useState(0);
+      setNumberExternal = setNumber;
+      return (
+        <NumberContext.Provider value={number}>
+          <div>Number: {number}</div>
+          {children}
+        </NumberContext.Provider>
+      );
+    }
+
+    function Fallback() {
+      const number = React.useContext(NumberContext);
+      return <div>Loading: {number}</div>;
+    }
+
+    function Content() {
+      readText('content');
+      return <div>Content</div>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <NumberProvider>
+            <Suspense fallback={<Fallback />}>
+              <Content />
+            </Suspense>
+          </NumberProvider>
+        </div>
+      );
+    }
+
+    await act(() => {
+      const {pipe} = renderToPipeableStream(<App />);
+      pipe(writable);
+    });
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Number: {'0'}</div>
+        <div>Loading: {'0'}</div>
+      </div>,
+    );
+
+    // Hydration uses Fiber instead of Fizz. Avoid the warning about multiple
+    // renderers concurrently using this context.
+    NumberContext._currentRenderer = null;
+
+    const errors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error) {
+        errors.push(normalizeError(error.message));
+      },
+    });
+    await waitForAll([]);
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Number: {'0'}</div>
+        <div>Loading: {'0'}</div>
+      </div>,
+    );
+
+    // The shell is hydrated, but the boundary is still streaming. Its props
+    // stay the same because NumberProvider reuses its children. An urgent
+    // context update should client-render the fallback with the new value.
+    await clientAct(() => {
+      setNumberExternal(1);
+    });
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Number: {'1'}</div>
+        <div>Loading: {'1'}</div>
+      </div>,
+    );
+    expect(errors).toEqual([]);
+
+    await act(() => {
+      resolveText('content');
+    });
+    await clientAct(async () => {});
+
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <div>Number: {'1'}</div>
+        <div>Content</div>
+      </div>,
+    );
+    expect(errors).toEqual([]);
+  });
+
   it('#23331: does not warn about hydration mismatches if something suspended in an earlier sibling', async () => {
     const makeApp = () => {
       let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1239,6 +1239,115 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  it('does not produce a hydration mismatch when context updates in an already-hydrated ancestor before a streamed boundary hydrates', async () => {
+    // Regression test: Updating a context value in an already-hydrated ancestor
+    // (via a state update on a provider with referentially stable children)
+    // before a streamed Suspense child that reads that context finishes
+    // streaming used to cause a hydration mismatch. The streamed segment was
+    // rendered on the server with the initial context value, but the client
+    // hydrated it against the updated context. React should recover without a
+    // mismatch error.
+
+    const NumberContext = React.createContext(0);
+    let setNumberExternal = null;
+
+    function NumberProvider({children}) {
+      const [number, setNumber] = React.useState(0);
+      setNumberExternal = setNumber;
+      return (
+        <NumberContext.Provider value={number}>
+          {children}
+        </NumberContext.Provider>
+      );
+    }
+
+    function DisplayNumber() {
+      const number = React.useContext(NumberContext);
+      readText('display');
+      return <div>Number: {number}</div>;
+    }
+
+    function App() {
+      return (
+        <div>
+          <NumberProvider>
+            <Suspense fallback={<div>Loading...</div>}>
+              <DisplayNumber />
+            </Suspense>
+          </NumberProvider>
+        </div>
+      );
+    }
+
+    // The same context object is shared by the Fizz server and the client
+    // renderer in this single-process test, which trips the "multiple
+    // renderers" dev warning. That doesn't happen in real apps where server and
+    // client are separate processes, so filter it out here.
+    const realConsoleError = console.error;
+    console.error = (...args) => {
+      if (
+        typeof args[0] === 'string' &&
+        args[0].includes('Detected multiple renderers')
+      ) {
+        return;
+      }
+      realConsoleError.apply(console, args);
+    };
+
+    try {
+      await act(() => {
+        const {pipe} = renderToPipeableStream(<App />);
+        pipe(writable);
+      });
+
+      expect(getVisibleChildren(container)).toEqual(
+        <div>
+          <div>Loading...</div>
+        </div>,
+      );
+
+      const errors = [];
+      ReactDOMClient.hydrateRoot(container, <App />, {
+        onRecoverableError(error) {
+          errors.push(normalizeError(error.message));
+        },
+      });
+      await waitForAll([]);
+
+      // Shell hydrated, boundary still pending.
+      expect(getVisibleChildren(container)).toEqual(
+        <div>
+          <div>Loading...</div>
+        </div>,
+      );
+
+      // Update the context value in the already-hydrated ancestor BEFORE the
+      // streamed boundary content arrives and hydrates.
+      await clientAct(() => {
+        React.startTransition(() => {
+          setNumberExternal(1);
+        });
+      });
+
+      // Now the boundary content becomes available.
+      await act(() => {
+        resolveText('display');
+      });
+      await clientAct(async () => {});
+
+      // No hydration mismatch error should have been reported, and the boundary
+      // should reflect the updated context value.
+      expect(errors).toEqual([]);
+      expect(getVisibleChildren(container)).toEqual(
+        <div>
+          <div>Number: {'1'}</div>
+        </div>,
+      );
+    } finally {
+      console.error = realConsoleError;
+    }
+  });
+
   it('#23331: does not warn about hydration mismatches if something suspended in an earlier sibling', async () => {
     const makeApp = () => {
       let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1239,14 +1239,10 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  it('does not produce a hydration mismatch when context updates in an already-hydrated ancestor before a streamed boundary hydrates', async () => {
-    // Regression test: Updating a context value in an already-hydrated ancestor
-    // (via a state update on a provider with referentially stable children)
-    // before a streamed Suspense child that reads that context finishes
-    // streaming used to cause a hydration mismatch. The streamed segment was
-    // rendered on the server with the initial context value, but the client
-    // hydrated it against the updated context. React should recover without a
-    // mismatch error.
+  it('hydrates without a mismatch when context updates before a streamed boundary resolves', async () => {
+    // If a context provider updates after the shell hydrates but before a
+    // streamed Suspense boundary resolves, the boundary should client-render
+    // with the new value instead of hydrating against the server snapshot.
 
     const NumberContext = React.createContext(0);
     let setNumberExternal = null;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3982,6 +3982,30 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       const state: SuspenseState | null = workInProgress.memoizedState;
       if (state !== null) {
         if (state.dehydrated !== null) {
+          // Before we bail out on a dehydrated boundary, we need to check
+          // whether a parent provider's context changed. The boundary's
+          // children only exist as server-rendered HTML, so normal propagation
+          // can't find context consumers inside it. If we bail out without
+          // propagating, a context change in an already-hydrated ancestor
+          // (e.g. a `useState` update in a provider with referentially stable
+          // children) will never be recorded on this boundary. When the
+          // streamed content later arrives and hydrates, it would read the
+          // updated context value and mismatch the server HTML. By propagating
+          // now, the boundary's childLanes records the change and
+          // `updateDehydratedSuspenseComponent` can recover instead of
+          // producing a hydration mismatch.
+          const contextChanged = lazilyPropagateParentContextChanges(
+            current,
+            workInProgress,
+            renderLanes,
+          );
+          if (contextChanged) {
+            return updateSuspenseComponent(
+              current,
+              workInProgress,
+              renderLanes,
+            );
+          }
           // We're not going to render the children, so this is just to maintain
           // push/pop symmetry
           pushPrimaryTreeSuspenseHandler(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -4040,6 +4040,30 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       const state: SuspenseState | null = workInProgress.memoizedState;
       if (state !== null) {
         if (state.dehydrated !== null) {
+          // Before we bail out on a dehydrated boundary, we need to check
+          // whether a parent provider's context changed. The boundary's
+          // children only exist as server-rendered HTML, so normal propagation
+          // can't find context consumers inside it. If we bail out without
+          // propagating, a context change in an already-hydrated ancestor
+          // (e.g. a `useState` update in a provider with referentially stable
+          // children) will never be recorded on this boundary. When the
+          // streamed content later arrives and hydrates, it would read the
+          // updated context value and mismatch the server HTML. By propagating
+          // now, the boundary's childLanes records the change and
+          // `updateDehydratedSuspenseComponent` can recover instead of
+          // producing a hydration mismatch.
+          const contextChanged = lazilyPropagateParentContextChanges(
+            current,
+            workInProgress,
+            renderLanes,
+          );
+          if (contextChanged) {
+            return updateSuspenseComponent(
+              current,
+              workInProgress,
+              renderLanes,
+            );
+          }
           // We're not going to render the children, so this is just to maintain
           // push/pop symmetry
           pushPrimaryTreeSuspenseHandler(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -4039,31 +4039,32 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
     case SuspenseComponent: {
       const state: SuspenseState | null = workInProgress.memoizedState;
       if (state !== null) {
+        // Context changes may not have been propagated yet. We need to do
+        // that before deciding whether to bail out. A dehydrated boundary's
+        // consumers aren't available, so propagation conservatively marks its
+        // child lanes when a parent context changes. A client-rendered boundary
+        // may have discarded its primary children's consumer fibers when they
+        // suspended during initial mount. Use the return value to conservatively
+        // retry in that case, even without child lanes, so the re-mounted
+        // children read the updated context value.
+        const contextChanged = lazilyPropagateParentContextChanges(
+          current,
+          workInProgress,
+          renderLanes,
+        );
+
         if (state.dehydrated !== null) {
-          // Before we bail out on a dehydrated boundary, we need to check
-          // whether a parent provider's context changed. The boundary's
-          // children only exist as server-rendered HTML, so normal propagation
-          // can't find context consumers inside it. If we bail out without
-          // propagating, a context change in an already-hydrated ancestor
-          // (e.g. a `useState` update in a provider with referentially stable
-          // children) will never be recorded on this boundary. When the
-          // streamed content later arrives and hydrates, it would read the
-          // updated context value and mismatch the server HTML. By propagating
-          // now, the boundary's childLanes records the change and
-          // `updateDehydratedSuspenseComponent` can recover instead of
-          // producing a hydration mismatch.
-          const contextChanged = lazilyPropagateParentContextChanges(
-            current,
-            workInProgress,
-            renderLanes,
-          );
-          if (contextChanged) {
+          // Context propagation marks child lanes when this boundary's inputs
+          // may have changed. Enter the update path to hydrate first or switch
+          // to client rendering instead of bailing out with stale inputs.
+          if (includesSomeLane(renderLanes, workInProgress.childLanes)) {
             return updateSuspenseComponent(
               current,
               workInProgress,
               renderLanes,
             );
           }
+
           // We're not going to render the children, so this is just to maintain
           // push/pop symmetry
           pushPrimaryTreeSuspenseHandler(workInProgress);
@@ -4080,17 +4081,6 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
         // whether to retry the primary children, or to skip over it and
         // go straight to the fallback. Check the priority of the primary
         // child fragment.
-        //
-        // Propagate context changes first. If a parent context changed
-        // and the primary children's consumer fibers were discarded
-        // during initial mount suspension, normal propagation can't find
-        // them. In that case we conservatively retry the boundary — the
-        // re-mounted children will read the updated context value.
-        const contextChanged = lazilyPropagateParentContextChanges(
-          current,
-          workInProgress,
-          renderLanes,
-        );
         const primaryChildFragment: Fiber = workInProgress.child as any;
         const primaryChildLanes = primaryChildFragment.childLanes;
         if (


### PR DESCRIPTION
_Disclaimer: These code changes and the description below were written with the help of AI. However, it was guided to the best of my ability rather than purely vibed._

## Summary

Fixes #36594. 

**Motivation:** A context update in an already-hydrated provider can occur while a descendant `Suspense` boundary is still waiting for streamed content. When the content arrived, React attempted to hydrate HTML rendered with the initial context value using the updated value, causing a hydration mismatch. 

**Expected Behavior**: There is no hydration mismatch, and when the primary children of a boundary are revealed, any context consumers are using/showing the latest values.

**Fix:** Propagate parent context changes before Suspense’s early bailout decisions. If the dehydrated boundary’s `childLanes` indicate work for the current render, enter `updateSuspenseComponent`. This lets the existing logic hydrate before applying the update or switch to client rendering when hydration cannot finish. The shared propagation call also preserves retries for client-rendered boundaries whose consumer fibers were discarded during initial suspension.

**Alternatives considered:**

- **Maintain current behavior for urgent updates, but delay transition updates until the subtree hydrates.** I thought maybe to improve performance, we could preserve and hydrate against the server-rendered HTML in the case of non-blocking context updates. However, this changed the existing behavior that allows transitions to progress while streamed fallbacks are showing. Moreover, I was unconvinced it provided any meaningful performance improvement, and from a user experience perspective, the delay didn't appear to make sense either.

## How did you test this change?

A Fizz regression test covers the scenario: context updates in the hydrated shell before the streamed boundary resolves, with no mismatch error and the boundary showing the updated value.

<img width="479" height="114" alt="image" src="https://github.com/user-attachments/assets/d33c27ff-819a-4caf-b30c-c10b2b015abf" />


### Visual Test
No hydration error!

https://github.com/user-attachments/assets/fb35b1e5-1423-49e3-af2b-06de871bfa4b
