### PR TITLE
[eslint-plugin-react-hooks] Treat useActionState dispatch as stable when isPending is destructured

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -613,6 +613,29 @@ const tests = {
       `,
     },
     {
+      // The dispatch function returned by useActionState is stable, including
+      // when destructuring the third `isPending` element:
+      // const [state, dispatch, isPending] = useActionState(...)
+      code: normalizeIndent`
+        function MyComponent() {
+          const [state, dispatch, isPending] = useActionState(action, 0);
+          useEffect(() => {
+            dispatch();
+          }, []);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const [state, dispatch, isPending] = React.useActionState(action, 0);
+          useEffect(() => {
+            dispatch();
+          }, []);
+        }
+      `,
+    },
+    {
       code: normalizeIndent`
         function MyComponent({ maybeRef2, foo }) {
           const definitelyRef1 = useRef();
@@ -1619,6 +1642,41 @@ const tests = {
                   useCallback(() => {
                     console.log(props.foo?.toString());
                   }, [props.foo]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      // The state and isPending values from useActionState are dynamic, so
+      // they still need to be listed as dependencies (only the dispatch
+      // function is stable).
+      code: normalizeIndent`
+        function MyComponent() {
+          const [state, dispatch, isPending] = useActionState(action, 0);
+          useEffect(() => {
+            console.log(state, isPending);
+            dispatch();
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has missing dependencies: 'isPending' and 'state'. " +
+            'Either include them or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [isPending, state]',
+              output: normalizeIndent`
+                function MyComponent() {
+                  const [state, dispatch, isPending] = useActionState(action, 0);
+                  useEffect(() => {
+                    console.log(state, isPending);
+                    dispatch();
+                  }, [isPending, state]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -351,9 +351,13 @@ const rule = {
           name === 'useActionState'
         ) {
           // Only consider second value in initializing tuple stable.
+          // useState and useReducer return a 2-element tuple, while
+          // useActionState additionally returns `isPending` as a third element:
+          // const [state, dispatch, isPending] = useActionState(...)
           if (
             id.type === 'ArrayPattern' &&
-            id.elements.length === 2 &&
+            (id.elements.length === 2 ||
+              (name === 'useActionState' && id.elements.length === 3)) &&
             isArray(resolved.identifiers)
           ) {
             // Is second tuple value the same reference we're checking?


### PR DESCRIPTION
## Summary

`exhaustive-deps` treats the dispatch/setter returned by `useState`/`useReducer`/`useActionState` as a stable value, so you don't have to list it in a dependency array. But the stability check only fired when the hook result was destructured into exactly two elements. `useActionState` returns three: `[state, dispatch, isPending]`. As soon as you destructure the `isPending` element, the rule stopped recognizing `dispatch` as stable and reported a false positive:

```jsx
const [state, dispatch, isPending] = useActionState(action, 0);
useEffect(() => {
  dispatch();
}, []); // ⚠️ React Hook useEffect has a missing dependency: 'dispatch'
```

The two-element form `[state, dispatch]` works fine, which is what made this easy to miss. Same false positive as #32062.

## Fix

Allow the three-element tuple form specifically for `useActionState` (`useState`/`useReducer` stay restricted to two). The existing branch logic already handles the rest correctly: `dispatch` is stable, while `state` and `isPending` stay dynamic and must still be listed.

## Test plan

Added valid cases for the `[state, dispatch, isPending]` form (both `useActionState` and `React.useActionState`) and an invalid case confirming `state`/`isPending` are still required. `jest` passes for the full `eslint-plugin-react-hooks` suite (3680 tests).
