### PR TITLE
feat: Add opt-out for React DevTools download log message (#24283)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -459,6 +459,62 @@ describe('ReactDOM', () => {
     }
   });
 
+  // @gate __DEV__
+  it('logs a DevTools download prompt when DevTools is not installed', () => {
+    const originalUserAgent = navigator.userAgent;
+    const info = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+    try {
+      delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Chrome',
+        configurable: true,
+      });
+
+      jest.resetModules();
+      require('react-dom/client');
+
+      expect(info).toHaveBeenCalledWith(
+        expect.stringContaining('Download the React DevTools'),
+        'font-weight:bold',
+      );
+    } finally {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+      info.mockRestore();
+    }
+  });
+
+  // @gate __DEV__
+  it('does not log a DevTools download prompt when suppressLogMessage is set', () => {
+    const originalUserAgent = navigator.userAgent;
+    const info = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+    try {
+      global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+        suppressLogMessage: true,
+      };
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Chrome',
+        configurable: true,
+      });
+
+      jest.resetModules();
+      require('react-dom/client');
+
+      expect(info).not.toHaveBeenCalled();
+    } finally {
+      delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      Object.defineProperty(navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+      info.mockRestore();
+    }
+  });
+
   it('should not crash calling findDOMNode inside a function component', async () => {
     class Component extends React.Component {
       render() {

--- a/packages/react-dom/src/client/ReactDOMClient.js
+++ b/packages/react-dom/src/client/ReactDOMClient.js
@@ -21,6 +21,8 @@ import Internals from 'shared/ReactDOMSharedInternals';
 import {ensureCorrectIsomorphicReactVersion} from '../shared/ensureCorrectIsomorphicReactVersion';
 ensureCorrectIsomorphicReactVersion();
 
+declare const __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
+
 if (__DEV__) {
   if (
     typeof Map !== 'function' ||
@@ -53,8 +55,20 @@ export {ReactVersion as version, createRoot, hydrateRoot};
 
 const foundDevTools = injectIntoDevTools();
 
+function isDevToolsDownloadPromptSuppressed(): boolean {
+  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+    return false;
+  }
+  return __REACT_DEVTOOLS_GLOBAL_HOOK__.suppressLogMessage === true;
+}
+
 if (__DEV__) {
-  if (!foundDevTools && canUseDOM && window.top === window.self) {
+  if (
+    !foundDevTools &&
+    !isDevToolsDownloadPromptSuppressed() &&
+    canUseDOM &&
+    window.top === window.self
+  ) {
     // If we're in Chrome or Firefox, provide a download link if not installed.
     if (
       (navigator.userAgent.indexOf('Chrome') > -1 &&

--- a/packages/react-dom/src/client/ReactDOMClientFB.js
+++ b/packages/react-dom/src/client/ReactDOMClientFB.js
@@ -28,6 +28,8 @@ import ReactVersion from 'shared/ReactVersion';
 import {ensureCorrectIsomorphicReactVersion} from '../shared/ensureCorrectIsomorphicReactVersion';
 ensureCorrectIsomorphicReactVersion();
 
+declare const __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
+
 import {
   getInstanceFromNode,
   getNodeFromInstance,
@@ -149,8 +151,20 @@ Internals.Events /* Events */ = [
 
 const foundDevTools = injectIntoDevTools();
 
+function isDevToolsDownloadPromptSuppressed(): boolean {
+  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+    return false;
+  }
+  return __REACT_DEVTOOLS_GLOBAL_HOOK__.suppressLogMessage === true;
+}
+
 if (__DEV__) {
-  if (!foundDevTools && canUseDOM && window.top === window.self) {
+  if (
+    !foundDevTools &&
+    !isDevToolsDownloadPromptSuppressed() &&
+    canUseDOM &&
+    window.top === window.self
+  ) {
     // If we're in Chrome or Firefox, provide a download link if not installed.
     if (
       (navigator.userAgent.indexOf('Chrome') > -1 &&

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -59,6 +59,12 @@ export function injectInternals(internals: Object): boolean {
     // https://github.com/facebook/react/issues/3877
     return true;
   }
+  if (hook.suppressLogMessage && !hook.supportsFiber) {
+    // This isn't a real property on the hook, but it can be set to suppress
+    // the DevTools download message without installing a full hook shim.
+    // https://github.com/facebook/react/issues/24283
+    return false;
+  }
   if (!hook.supportsFiber) {
     if (__DEV__) {
       console.error(


### PR DESCRIPTION
## Summary

Adds an official opt-out mechanism to suppress the "Download the React DevTools for a better development experience" console message. Fixes #24283.

## Approach

The fix introduces a `suppressLogMessage` property on the pre-existing `__REACT_DEVTOOLS_GLOBAL_HOOK__` object. When set to `true` before React loads:

1. The DevTools download prompt in `ReactDOMClient.js` / `ReactDOMClientFB.js` is skipped via a new `isDevToolsDownloadPromptSuppressed()` guard.
2. A bare placeholder hook with only `suppressLogMessage: true` does **not** trigger the legacy "DevTools too old" warning in `ReactFiberDevToolsHook.js` — the reconciler recognizes it as an intentional suppression flag, not an unsupported hook.
3. Real hooks that set `supportsFiber` still inject and function normally.

This avoids the brittle workaround of fully overriding `__REACT_DEVTOOLS_GLOBAL_HOOK__` which can break DevTools entirely.

## Usage

```js
window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = { suppressLogMessage: true };
```

Place this before any React script on the page.

## Changed Files

| File | Changes |
|------|---------|
| `packages/react-dom/src/client/ReactDOMClient.js` | +15/-1 — Added `isDevToolsDownloadPromptSuppressed()` and guard |
| `packages/react-dom/src/client/ReactDOMClientFB.js` | +15/-1 — Same changes for FB build |
| `packages/react-reconciler/src/ReactFiberDevToolsHook.js` | +6/-0 — Skip "too old" warning when `suppressLogMessage` is set |
| `packages/react-dom/src/__tests__/ReactDOM-test.js` | +56/-0 — Two new tests: default prompt and suppressed prompt |

## Test Results

- `yarn test ReactDOM-test --watchAll=false` — **PASS**: 20 tests passed (including 2 new)
- `yarn test ReactProfilerDevToolsIntegration-test --watchAll=false` — **PASS**: 3 tests passed
- `git diff --check` — No whitespace errors
