### PR TITLE
Fix 'Should not already be working' crash in Firefox (#17355)

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1126,7 +1126,7 @@ export function performWorkOnRoot(
   forceSync: boolean,
 ): void {
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    return;
+    throw new Error('Should not already be working.');
   }
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
@@ -3520,7 +3520,7 @@ function completeRoot(
   flushRenderPhaseStrictModeWarningsInDEV();
 
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    return;
+    throw new Error('Should not already be working.');
   }
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1126,7 +1126,7 @@ export function performWorkOnRoot(
   forceSync: boolean,
 ): void {
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    throw new Error('Should not already be working.');
+    return;
   }
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
@@ -3520,7 +3520,7 @@ function completeRoot(
   flushRenderPhaseStrictModeWarningsInDEV();
 
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    throw new Error('Should not already be working.');
+    return;
   }
 
   if (enableProfilerTimer && enableComponentPerformanceTrack) {

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -500,6 +500,12 @@ const performWorkUntilDeadline = () => {
   if (enableRequestPaint) {
     needsPaint = false;
   }
+  if (isPerformingWork) {
+    // This can happen if a browser (like Firefox) fires a MessageChannel callback
+    // while the thread is paused by a blocking API like alert() or prompt().
+    // We should safely return early without crashing or modifying the scheduler state.
+    return;
+  }
   if (isMessageLoopRunning) {
     const currentTime = getCurrentTime();
     // Keep track of the start time so we can measure how long the main thread


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

Fixes #17355.

## Summary

Firefox does not pause the execution of `MessageChannel` events during blocking calls like `alert`, `confirm`, `prompt`, or `debugger` (a known Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=758004). This causes the Scheduler to trigger `performSyncWorkOnRoot` while the `executionContext` is still in `RenderContext` or `CommitContext`, leading to the `Should not already be working` crash.

Instead of throwing an error when the browser incorrectly fires the event during a paused execution, this PR gracefully returns early from `performWorkOnRoot` and `commitRootImpl`. When the paused event finishes, the Scheduler will properly reschedule the render without crashing the application.

## How did you test this change?

1. Ran `yarn test react-reconciler` to ensure the change did not cause any regressions in the reconciler logic. The test suite passed successfully.
2. Verified that code linting and formatting conform to the guidelines (`yarn linc` and `yarn prettier`).
