### PR TITLE
Fix typos in comments, test names, DEV warnings, and identifiers

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -5260,7 +5260,7 @@ export function processStringChunk(
       // We found the last chunk of the row
       if (buffer.length > 0) {
         // If we had a buffer already, it means that this chunk was split up into
-        // binary chunks preceeding it.
+        // binary chunks preceding it.
         throw new Error(
           'String chunks need to be passed in their original shape. ' +
             'Not split into smaller string chunks. ' +

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -1080,7 +1080,7 @@ export default class Agent extends EventEmitter<{
 
       // Due to the component filters changing, we might be able
       // to select a closer match for the currently selected host element.
-      // The store will already select a suitable parent if the the current
+      // The store will already select a suitable parent if the current
       // selection is now filtered out in which cases this will be a no-op.
       const target = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0;
       if (target != null) {

--- a/packages/react-devtools-shared/src/backend/fiber/DevToolsFiberComponentStack.js
+++ b/packages/react-devtools-shared/src/backend/fiber/DevToolsFiberComponentStack.js
@@ -204,7 +204,7 @@ export function getOwnerStackByFiberInDev(
         // In a real app it's typically not useful since the root app is always controlled
         // by the framework. These also tend to have noisy stacks because they're not rooted
         // in a React render but in some imperative bootstrapping code. It could be useful
-        // if the element was created in module scope. E.g. hoisted. We could add a a single
+        // if the element was created in module scope. E.g. hoisted. We could add a single
         // stack frame for context for example but it doesn't say much if that's a wrapper.
         if (owner && debugStack) {
           if (typeof debugStack !== 'string') {

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -330,7 +330,7 @@ const hostResourceToDevToolsInstanceMap: Map<
   Set<DevToolsInstance>,
 > = new Map();
 
-function aquireHostInstance(
+function acquireHostInstance(
   nearestInstance: DevToolsInstance,
   hostInstance: HostInstance,
 ): void {
@@ -350,7 +350,7 @@ function releaseHostInstance(
   }
 }
 
-function aquireHostResource(
+function acquireHostResource(
   nearestInstance: DevToolsInstance,
   resource: ?{instance?: HostInstance},
 ): void {
@@ -3497,7 +3497,7 @@ export function attach(
         if (nearestInstance === null) {
           throw new Error('Did not expect a host hoistable to be the root');
         }
-        aquireHostResource(nearestInstance, fiber.memoizedState);
+        acquireHostResource(nearestInstance, fiber.memoizedState);
         trackDebugInfoFromHostResource(nearestInstance, fiber);
       } else if (
         fiber.tag === HostComponent ||
@@ -3508,7 +3508,7 @@ export function attach(
         if (nearestInstance === null) {
           throw new Error('Did not expect a host hoistable to be the root');
         }
-        aquireHostInstance(nearestInstance, fiber.stateNode);
+        acquireHostInstance(nearestInstance, fiber.stateNode);
         trackDebugInfoFromHostComponent(nearestInstance, fiber);
       }
 
@@ -4485,7 +4485,7 @@ export function attach(
         }
         if (prevFiber.memoizedState !== nextFiber.memoizedState) {
           releaseHostResource(nearestInstance, prevFiber.memoizedState);
-          aquireHostResource(nearestInstance, nextFiber.memoizedState);
+          acquireHostResource(nearestInstance, nextFiber.memoizedState);
         }
         trackDebugInfoFromHostResource(nearestInstance, nextFiber);
       } else if (
@@ -4499,10 +4499,10 @@ export function attach(
         }
         if (prevFiber.stateNode !== nextFiber.stateNode) {
           // In persistent mode, it's possible for the stateNode to update with
-          // a new clone. In that case we need to release the old one and aquire
+          // a new clone. In that case we need to release the old one and acquire
           // new one instead.
           releaseHostInstance(nearestInstance, prevFiber.stateNode);
-          aquireHostInstance(nearestInstance, nextFiber.stateNode);
+          acquireHostInstance(nearestInstance, nextFiber.stateNode);
         }
         trackDebugInfoFromHostComponent(nearestInstance, nextFiber);
       }

--- a/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberTypes.js
+++ b/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberTypes.js
@@ -90,7 +90,7 @@ export type SuspenseNode = {
   suspendedBy: Map<ReactIOInfo, Set<DevToolsInstance>>, // Tracks which data we're suspended by and the children that suspend it.
   environments: Map<string, number>, // Tracks the Flight environment names that suspended this. I.e. if the server blocked this.
   endTime: number, // Track a short cut to the maximum end time value within the suspendedBy set.
-  // Track whether any of the items in suspendedBy are unique this this Suspense boundaries or if they're all
+  // Track whether any of the items in suspendedBy are unique to this Suspense boundary or if they're all
   // also in the parent sets. This determine whether this could contribute in the loading sequence.
   hasUniqueSuspenders: boolean,
   // Track whether anything suspended in this boundary that we can't track either because it was using throw

--- a/packages/react-devtools-timeline/src/content-views/SnapshotsView.js
+++ b/packages/react-devtools-timeline/src/content-views/SnapshotsView.js
@@ -70,7 +70,7 @@ export class SnapshotsView extends View {
     while (x < visibleArea.origin.x + visibleArea.size.width) {
       const snapshot = this._findClosestSnapshot(x);
       if (snapshot === null) {
-        // This shold never happen.
+        // This should never happen.
         break;
       }
 

--- a/packages/react-devtools-timeline/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-timeline/src/import-worker/preprocessData.js
@@ -1050,7 +1050,7 @@ export default async function preprocessData(
   // We'll thus expect there to be a 'Profile' event; if there is not one, we
   // can deduce that there are no flame chart events. As we expect React
   // scheduling profiling user timing marks to be recorded together with browser
-  // flame chart events, we can futher deduce that the data is invalid and we
+  // flame chart events, we can further deduce that the data is invalid and we
   // don't bother finding React events.
   const indexOfProfileEvent = timeline.findIndex(
     event => event.name === 'Profile',

--- a/packages/react-devtools-timeline/src/view-base/Surface.js
+++ b/packages/react-devtools-timeline/src/view-base/Surface.js
@@ -54,8 +54,8 @@ const getCanvasContext = memoize(
 type ResetHoveredEventFn = () => void;
 
 /**
- * Represents the canvas surface and a view heirarchy. A surface is also the
- * place where all interactions enter the view heirarchy.
+ * Represents the canvas surface and a view hierarchy. A surface is also the
+ * place where all interactions enter the view hierarchy.
  */
 export class Surface {
   rootView: ?View;

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -4717,7 +4717,7 @@ export function acquireSingletonInstance(
       // aligned with the actual fix you need to make so we omit the warning in this case
       !isContainerMarkedAsRoot(instance) &&
       // If this instance isn't the root but is currently owned by a different HostSingleton instance then
-      // we we need to warn that you are rendering more than one singleton at a time.
+      // we need to warn that you are rendering more than one singleton at a time.
       getInstanceFromNodeDOMTree(instance)
     ) {
       const tagName = instance.tagName.toLowerCase();

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -326,10 +326,10 @@ const endAsyncScript = stringToPrecomputedChunk(' async=""></script>');
 const startInlineStyle = stringToPrecomputedChunk('<style');
 
 /**
- * This escaping function is designed to work with with inline scripts where the entire
+ * This escaping function is designed to work with inline scripts where the entire
  * contents are escaped. Because we know we are escaping the entire script we can avoid for instance
  * escaping html comment string sequences that are valid javascript as well because
- * if there are no sebsequent <script sequences the html parser will never enter
+ * if there are no subsequent <script sequences the html parser will never enter
  * script data double escaped state (see: https://www.w3.org/TR/html53/syntax.html#script-data-double-escaped-state)
  *
  * While untrusted script content should be made safe before using this api it will
@@ -2812,7 +2812,7 @@ function pushMeta(
 
     if (isFallback) {
       // Hoistable Elements for fallbacks are simply omitted. we don't want to emit them early
-      // because they are likely superceded by primary content and we want to avoid needing to clean
+      // because they are likely superseded by primary content and we want to avoid needing to clean
       // them up when the primary content is ready. They are never hydrated on the client anyway because
       // boundaries in fallback are awaited or client render, in either case there is never hydration
       return null;
@@ -3015,7 +3015,7 @@ function pushLink(
 
     if (isFallback) {
       // Hoistable Elements for fallbacks are simply omitted. we don't want to emit them early
-      // because they are likely superceded by primary content and we want to avoid needing to clean
+      // because they are likely superseded by primary content and we want to avoid needing to clean
       // them up when the primary content is ready. They are never hydrated on the client anyway because
       // boundaries in fallback are awaited or client render, in either case there is never hydration
       return null;
@@ -3590,7 +3590,7 @@ function pushTitle(
   ) {
     if (isFallback) {
       // Hoistable Elements for fallbacks are simply omitted. we don't want to emit them early
-      // because they are likely superceded by primary content and we want to avoid needing to clean
+      // because they are likely superseded by primary content and we want to avoid needing to clean
       // them up when the primary content is ready. They are never hydrated on the client anyway because
       // boundaries in fallback are awaited or client render, in either case there is never hydration
       return null;
@@ -3686,7 +3686,7 @@ function pushStartHead(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is in the wrong spot.
     return pushStartGenericElement(target, props, 'head', formatContext);
   }
 }
@@ -3720,7 +3720,7 @@ function pushStartBody(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is in the wrong spot.
     return pushStartGenericElement(target, props, 'body', formatContext);
   }
 }
@@ -3754,7 +3754,7 @@ function pushStartHtml(
     );
   } else {
     // This <html> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is in the wrong spot.
     return pushStartGenericElement(target, props, 'html', formatContext);
   }
 }

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -2875,7 +2875,7 @@ function pushLink(
       if (rel === 'stylesheet' && typeof props.precedence === 'string') {
         if (typeof href !== 'string' || !href) {
           console.error(
-            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but ecountered %s instead. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
+            'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and expected the `href` prop to be a non-empty string but encountered %s instead. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop ensure there is a non-empty string `href` prop as well, otherwise remove the `precedence` prop.',
             getValueDescriptorExpectingObjectForWarning(href),
           );
         }
@@ -2901,7 +2901,7 @@ function pushLink(
         if (typeof precedence === 'string') {
           if (props.disabled != null) {
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the `disabled` prop, otherwise remove the `precedence` prop.',
             );
           } else if (props.onLoad || props.onError) {
             const propDescription =
@@ -2911,7 +2911,7 @@ function pushLink(
                   ? '`onLoad` prop'
                   : '`onError` prop';
             console.error(
-              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
+              'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and %s. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
               propDescription,
               propDescription,
             );
@@ -3115,7 +3115,7 @@ function pushStyle(
   if (__DEV__) {
     if (href.includes(' ')) {
       console.error(
-        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but ecountered spaces instead. using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this ocurred is "%s".',
+        'React expected the `href` prop for a <style> tag opting into hoisting semantics using the `precedence` prop to not have any spaces but encountered spaces instead. Using spaces in this prop will cause hydration of this style to fail on the client. The href for the <style> where this occurred is "%s".',
         href,
       );
     }

--- a/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
@@ -27,8 +27,8 @@ export function validateLinkPropsForStyleResource(props: any): boolean {
       console.error(
         'React encountered a <link rel="stylesheet" href="%s" ... /> with a `precedence` prop that' +
           ' also included %s. The presence of loading and error handlers indicates an intent to manage' +
-          ' the stylesheet loading state from your from your Component code and React will not hoist or' +
-          ' deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet' +
+          ' the stylesheet loading state from your Component code and React will not hoist or' +
+          ' deduplicate this stylesheet. If your intent was to have React hoist and deduplicate this stylesheet' +
           ' using the `precedence` prop remove the %s, otherwise remove the `precedence` prop.',
         href,
         withArticlePhrase,

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -234,7 +234,7 @@ describe('ReactDOMFizzServer', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 
@@ -4942,7 +4942,7 @@ describe('ReactDOMFizzServer', () => {
     await waitForAll([]);
   });
 
-  it('supresses hydration warnings when an error occurs within a Suspense boundary', async () => {
+  it('suppresses hydration warnings when an error occurs within a Suspense boundary', async () => {
     let isClient = false;
 
     function ThrowWhenHydrating({children}) {

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -154,7 +154,7 @@ describe('ReactDOMFloat', () => {
         bufferedContent.startsWith('<html ')
       ) {
         throw new Error(
-          'Recieved <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
+          'Received <html> without a <!DOCTYPE html> which is almost certainly a bug in React',
         );
       }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -8062,14 +8062,14 @@ body {
       assertConsoleErrorDev(
         [
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
-            'expected the `href` prop to be a non-empty string but ecountered `undefined` instead. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'expected the `href` prop to be a non-empty string but encountered `undefined` instead. ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop ensure there is a non-empty string `href` prop as well, ' +
             'otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
-            'expected the `href` prop to be a non-empty string but ecountered an empty string instead. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'expected the `href` prop to be a non-empty string but encountered an empty string instead. ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop ensure there is a non-empty string `href` prop as well, ' +
             'otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
@@ -8079,28 +8079,28 @@ body {
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
             '`onLoad` and `onError` props. The presence of loading and error handlers indicates ' +
-            'an intent to manage the stylesheet loading state from your from your Component code ' +
+            'an intent to manage the stylesheet loading state from your Component code ' +
             'and React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop remove the `onLoad` and `onError` props, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and ' +
             '`onLoad` prop. The presence of loading and error handlers indicates an intent to ' +
-            'manage the stylesheet loading state from your from your Component code and ' +
+            'manage the stylesheet loading state from your Component code and ' +
             'React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the ' +
             '`precedence` prop remove the `onLoad` prop, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and `onError` prop. ' +
             'The presence of loading and error handlers indicates an intent to manage the stylesheet loading state ' +
-            'from your from your Component code and React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` ' +
+            'from your Component code and React will not hoist or deduplicate this stylesheet. ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` ' +
             'prop remove the `onError` prop, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
           'React encountered a `<link rel="stylesheet" .../>` with a `precedence` prop and a `disabled` prop. ' +
             'The presence of the `disabled` prop indicates an intent to manage the stylesheet active state from ' +
-            'your from your Component code and React will not hoist or deduplicate this stylesheet. ' +
-            'If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` ' +
+            'your Component code and React will not hoist or deduplicate this stylesheet. ' +
+            'If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` ' +
             'prop remove the `disabled` prop, otherwise remove the `precedence` prop.\n' +
             '    in link (at **)',
         ].filter(Boolean),
@@ -8125,8 +8125,8 @@ body {
         'React encountered a <link rel="stylesheet" href="foo" ... /> with a `precedence` ' +
           'prop that also included the `onLoad` and `onError` props. ' +
           'The presence of loading and error handlers indicates an intent to manage the stylesheet ' +
-          'loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. ' +
-          'If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` ' +
+          'loading state from your Component code and React will not hoist or deduplicate this stylesheet. ' +
+          'If your intent was to have React hoist and deduplicate this stylesheet using the `precedence` ' +
           'prop remove the `onLoad` and `onError` props, otherwise remove the `precedence` prop.\n' +
           '    in body (at **)',
       ]);
@@ -8717,9 +8717,9 @@ background-color: green;
       });
       assertConsoleErrorDev([
         'React expected the `href` prop for a <style> tag opting into hoisting semantics ' +
-          'using the `precedence` prop to not have any spaces but ecountered spaces instead. ' +
-          'using spaces in this prop will cause hydration of this style to fail on the client. ' +
-          'The href for the <style> where this ocurred is "foo bar".\n' +
+          'using the `precedence` prop to not have any spaces but encountered spaces instead. ' +
+          'Using spaces in this prop will cause hydration of this style to fail on the client. ' +
+          'The href for the <style> where this occurred is "foo bar".\n' +
           '    in style (at **)',
       ]);
     });

--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -284,7 +284,7 @@ describe('useId', () => {
     // and 0s. In other words, they are all of the form 101010101.
     //
     // Because we use base 32 encoding, the resulting id should consist of
-    // alternating 'a' (01010) and 'l' (10101) characters, except for the the
+    // alternating 'a' (01010) and 'l' (10101) characters, except for the
     // 'R:' prefix, and the first character after that, which may not correspond
     // to a complete set of 5 bits.
     //

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -145,7 +145,7 @@ describe('ReactMount', () => {
     const iFrame = document.createElement('iframe');
     document.body.appendChild(iFrame);
 
-    // HostSingletons make the warning for document.body unecessary
+    // HostSingletons make the warning for document.body unnecessary
     ReactDOM.render(<div />, iFrame.contentDocument.body);
   });
 

--- a/packages/react-native-renderer/src/legacy-events/ResponderEventPlugin.js
+++ b/packages/react-native-renderer/src/legacy-events/ResponderEventPlugin.js
@@ -733,7 +733,7 @@ const ResponderEventPlugin = {
     // finger that move/start/end, dispatched directly to whoever is the
     // current responder at that moment, until the responder is "released".
     //
-    // These multiple individual change touch events are are always bookended
+    // These multiple individual change touch events are always bookended
     // by `onResponderGrant`, and one of
     // (`onResponderRelease/onResponderTerminate`).
     const isResponderTouchStart = responderInst && isStartish(topLevelType);

--- a/packages/react-reconciler/src/ReactFiberAsyncAction.js
+++ b/packages/react-reconciler/src/ReactFiberAsyncAction.js
@@ -143,7 +143,7 @@ export function chainThenableValue<T>(
   result: T,
 ): Thenable<T> {
   // Equivalent to: Promise.resolve(thenable).then(() => result), except we can
-  // cheat a bit since we know that that this thenable is only ever consumed
+  // cheat a bit since we know that this thenable is only ever consumed
   // by React.
   //
   // We don't technically require promise support on the client yet, hence this

--- a/packages/react-reconciler/src/ReactFiberComponentStack.js
+++ b/packages/react-reconciler/src/ReactFiberComponentStack.js
@@ -182,7 +182,7 @@ export function getOwnerStackByFiberInDev(workInProgress: Fiber): string {
         // In a real app it's typically not useful since the root app is always controlled
         // by the framework. These also tend to have noisy stacks because they're not rooted
         // in a React render but in some imperative bootstrapping code. It could be useful
-        // if the element was created in module scope. E.g. hoisted. We could add a a single
+        // if the element was created in module scope. E.g. hoisted. We could add a single
         // stack frame for context for example but it doesn't say much if that's a wrapper.
         if (owner && debugStack) {
           const formattedStack = formatOwnerStack(debugStack);

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -81,7 +81,7 @@ let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
-// This flag allows for warning supression when we expect there to be mismatches
+// This flag allows for warning suppression when we expect there to be mismatches
 // due to earlier mismatches or a suspended fiber.
 let didSuspendOrErrorDEV: boolean = false;
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1925,7 +1925,7 @@ export function flushSyncFromReconciler<R>(fn: (() => R) | void): R | void {
 }
 
 // If called outside of a render or commit will flush all sync work on all roots
-// Returns whether the the call was during a render or not
+// Returns whether the call was during a render or not
 export function flushSyncWork(): boolean {
   if ((executionContext & (RenderContext | CommitContext)) === NoContext) {
     flushSyncWorkOnAllRoots();

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -595,7 +595,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
 
     // Unblock the low-pri text and finish. Nothing in the UI changes because
-    // the update was overriden
+    // the update was overridden
     await act(() => resolveText('2'));
     assertLog(['2']);
     expect(ReactNoop).toMatchRenderedOutput(

--- a/packages/react-reconciler/src/__tests__/ReactUse-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactUse-test.js
@@ -2177,7 +2177,7 @@ describe('ReactUse', () => {
 
   it(
     'regression: does not get stuck in pending state after `use` suspends ' +
-      '(when `use` in in the middle of hook list)',
+      '(when `use` is in the middle of hook list)',
     async () => {
       // Same as previous test but `use` comes in between two hooks.
       let update;

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -146,7 +146,7 @@ createResponse(
 ```
 
 #### Server References
-Similarly When a React Server Component framework bundles an application and encounters a `"use server"` directive in a file or in a function body, including closures, it must implement that function as as a server entrypoint that can be called from the client. To make `Flight` aware that a function is a Server Reference the function should be registered with `registerServerReference()`.
+Similarly, when a React Server Component framework bundles an application and encounters a `"use server"` directive in a file or in a function body, including closures, it must implement that function as a server entrypoint that can be called from the client. To make `Flight` aware that a function is a Server Reference the function should be registered with `registerServerReference()`.
 
 ```js
 

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -188,7 +188,7 @@ export function getOwnerStackByComponentStackNodeInDev(
       // In a real app it's typically not useful since the root app is always controlled
       // by the framework. These also tend to have noisy stacks because they're not rooted
       // in a React render but in some imperative bootstrapping code. It could be useful
-      // if the element was created in module scope. E.g. hoisted. We could add a a single
+      // if the element was created in module scope. E.g. hoisted. We could add a single
       // stack frame for context for example but it doesn't say much if that's a wrapper.
       if (owner && ownerStack) {
         info += '\n' + ownerStack;

--- a/packages/react-server/src/ReactFlightAsyncSequence.js
+++ b/packages/react-server/src/ReactFlightAsyncSequence.js
@@ -31,7 +31,7 @@ export type IONode = {
   end: number, // we typically don't use this. only when there's no promise intermediate.
   promise: null, // not used on I/O
   awaited: null, // I/O is only blocked on external.
-  previous: null | AwaitNode | UnresolvedAwaitNode, // the preceeding await that spawned this new work
+  previous: null | AwaitNode | UnresolvedAwaitNode, // the preceding await that spawned this new work
 };
 
 export type PromiseNode = {


### PR DESCRIPTION
## Summary

Fixes typos across several packages: code comments, test names, user-facing DEV warning messages, and two misspelled module-private function names. The only behavior change is the corrected DEV warning text; the matching test assertions are updated in sync.

### DEV warning messages (`ReactFizzConfigDOM.js`, `ReactDOMResourceValidation.js`)

| Before | After |
|---|---|
| `ecountered` | `encountered` (2 occurrences) |
| `deduplciate` | `deduplicate` (4 occurrences) |
| `from your from your` | `from your` (3 occurrences) |
| `ocurred` | `occurred` |
| `…spaces instead. using spaces…` | `…spaces instead. Using spaces…` |

The assertions in `ReactDOMFloat-test.js` are updated to match.

### Misspelled identifiers (react-devtools-shared `renderer.js`)

| Before | After |
|---|---|
| `aquireHostInstance` | `acquireHostInstance` |
| `aquireHostResource` | `acquireHostResource` |

Both are module-private; all call sites are within the same file.

### Misspellings in comments, test names, and docs

| Before | After | Location |
|---|---|---|
| `superceded` | `superseded` | `ReactFizzConfigDOM.js` (3 occurrences) |
| `sebsequent` | `subsequent` | `ReactFizzConfigDOM.js` |
| `supression` | `suppression` | `ReactFiberHydrationContext.js` |
| `Recieved` | `Received` | `ReactDOMFizzServer-test.js`, `ReactDOMFloat-test.js` |
| `supresses` | `suppresses` | `ReactDOMFizzServer-test.js` (test name) |
| `preceeding` | `preceding` | `ReactFlightClient.js`, `ReactFlightAsyncSequence.js` |
| `heirarchy` | `hierarchy` | `Surface.js` (2 occurrences) |
| `overriden` | `overridden` | `ReactSuspenseWithNoopRenderer-test.js` |
| `unecessary` | `unnecessary` | `ReactLegacyMount-test.js` |
| `shold` | `should` | `SnapshotsView.js` |
| `futher` | `further` | `preprocessData.js` |

### Doubled / garbled words

| Before | After | Location |
|---|---|---|
| `work with with inline scripts` | `work with inline scripts` | `ReactFizzConfigDOM.js` |
| `this tag is the the wrong spot` | `this tag is in the wrong spot` | `ReactFizzConfigDOM.js` (3 occurrences) |
| `whether the the call` | `whether the call` | `ReactFiberWorkLoop.js` |
| `we know that that this thenable` | `we know that this thenable` | `ReactFiberAsyncAction.js` |
| `We could add a a single` | `We could add a single` | `ReactFiberComponentStack.js`, `ReactFizzComponentStack.js`, `DevToolsFiberComponentStack.js` |
| `unique this this Suspense boundaries` | `unique to this Suspense boundary` | `DevToolsFiberTypes.js` |
| `if the the current` | `if the current` | `agent.js` |
| `we we need to warn` | `we need to warn` | `ReactFiberConfigDOM.js` |
| `are are always bookended` | `are always bookended` | `ResponderEventPlugin.js` |
| `except for the the` | `except for the` | `ReactDOMUseId-test.js` |
| `(when \`use\` in in the middle…)` | `(when \`use\` is in the middle…)` | `ReactUse-test.js` (test name) |
| `Similarly When … as as a server entrypoint` | `Similarly, when … as a server entrypoint` | `react-server/README.md` |

## How did you test this change?

- `yarn prettier` — no changes
- `yarn linc` — passed
- `yarn flow dom-node` — passed
- `yarn test --silent --no-watchman 'ReactDOMFloat|ReactUse-test|ReactSuspenseWithNoopRenderer|ReactDOMUseId|ReactLegacyMount'` — passed (the only failures are two pre-existing Windows-only path-separator mismatches in `ReactUse-test.js` stack-trace assertions, reproduced identically on a clean checkout)
- `yarn test-www --silent --no-watchman` with the same pattern — same result

The warning-string changes are covered by the updated assertions in `ReactDOMFloat-test.js`, which pass on both the source and www channels.