### PR TITLE
 Update useActionState action refresh timing 

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -41,6 +41,7 @@ describe('ReactDOMForm', () => {
   let Suspense;
   let startTransition;
   let useTransition;
+  let useLayoutEffect;
   let use;
   let textCache;
   let useFormStatus;
@@ -62,6 +63,7 @@ describe('ReactDOMForm', () => {
     Suspense = React.Suspense;
     startTransition = React.startTransition;
     useTransition = React.useTransition;
+    useLayoutEffect = React.useLayoutEffect;
     use = React.use;
     useFormStatus = ReactDOM.useFormStatus;
     requestFormReset = ReactDOM.requestFormReset;
@@ -1079,6 +1081,30 @@ describe('ReactDOMForm', () => {
     // Increment again. The state should increase by 10.
     await act(() => startTransition(() => increment()));
     assertLog(['Pending 1', '11']);
+  });
+
+  it('useActionState updates inline actions before layout effects', async () => {
+    function App({stepSize}) {
+      const [state, dispatch] = useActionState(prevState => {
+        return prevState + stepSize;
+      }, 0);
+
+      useLayoutEffect(() => {
+        if (stepSize === 10) {
+          dispatch();
+        }
+      }, [dispatch, stepSize]);
+
+      return <Text text={state} />;
+    }
+
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<App stepSize={1} />));
+    assertLog([0]);
+
+    await act(() => root.render(<App stepSize={10} />));
+    assertLog([0, 10]);
+    expect(container.textContent).toBe('10');
   });
 
   it('useActionState: dispatch throws if called during render', async () => {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2500,9 +2500,9 @@ function updateActionStateImpl<S, P>(
   // Check if a new action was passed. If so, update it in an effect.
   const prevAction = actionQueueHook.memoizedState;
   if (action !== prevAction) {
-    currentlyRenderingFiber.flags |= PassiveEffect;
+    currentlyRenderingFiber.flags |= UpdateEffect;
     pushSimpleEffect(
-      HookHasEffect | HookPassive,
+      HookHasEffect | HookLayout,
       createEffectInstance(),
       actionStateActionEffect.bind(null, actionQueue, action),
       null,


### PR DESCRIPTION
  Update useActionState action refresh timing to avoid stale dispatches from layout effects.

  Details
  useActionState refreshed changed inline action implementations in a passive effect, which allowed layout effects in the same commit to dispatch using the previous action closure. This change moves the
  action queue update to the layout phase so layout effects observe the latest committed action implementation.

  Tests
  Existing tests
  New regression test covering useActionState dispatch from a layout effect after the inline action changes.
