### PR TITLE
fix: standardize contribution guide link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Want to contribute to React? There are a few things you need to know.  
 
-We wrote a **[contribution guide](https://reactjs.org/docs/how-to-contribute.html)** to help you get started.
+We wrote a **[contribution guide](https://legacy.reactjs.org/docs/how-to-contribute.html)** to help you get started.


### PR DESCRIPTION
## Summary

Standardizes the contribution guide URL in `CONTRIBUTING.md` to match `README.md`.

Fixes #36341

### Problem

The repo uses two different legacy domains for the same contribution guide:

| File | URL |
|---|---|
| `README.md` | `https://legacy.reactjs.org/docs/how-to-contribute.html` |
| `CONTRIBUTING.md` | `https://reactjs.org/docs/how-to-contribute.html` |

### Fix

Updated `CONTRIBUTING.md` to use `legacy.reactjs.org` consistently with `README.md`.

cc @rickhanlonii @poteto