### PR TITLE
fix: fix typos in comments

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -264,7 +264,7 @@ export type ResumableState = {
   nextFormID: number,
   streamingFormat: StreamingFormat,
 
-  // We carry the bootstrap intializers in resumable state in case we postpone in the shell
+  // We carry the bootstrap initializers in resumable state in case we postpone in the shell
   // of a prerender. On resume we will reinitialize the bootstrap scripts if necessary.
   // If we end up flushing the bootstrap scripts we void these on the resumable state
   bootstrapScriptContent?: string | void,
@@ -329,7 +329,7 @@ const startInlineStyle = stringToPrecomputedChunk('<style');
  * This escaping function is designed to work with with inline scripts where the entire
  * contents are escaped. Because we know we are escaping the entire script we can avoid for instance
  * escaping html comment string sequences that are valid javascript as well because
- * if there are no sebsequent <script sequences the html parser will never enter
+ * if there are no subsequent <script sequences the html parser will never enter
  * script data double escaped state (see: https://www.w3.org/TR/html53/syntax.html#script-data-double-escaped-state)
  *
  * While untrusted script content should be made safe before using this api it will
@@ -2812,7 +2812,7 @@ function pushMeta(
 
     if (isFallback) {
       // Hoistable Elements for fallbacks are simply omitted. we don't want to emit them early
-      // because they are likely superceded by primary content and we want to avoid needing to clean
+      // because they are likely superseded by primary content and we want to avoid needing to clean
       // them up when the primary content is ready. They are never hydrated on the client anyway because
       // boundaries in fallback are awaited or client render, in either case there is never hydration
       return null;
@@ -2948,7 +2948,7 @@ function pushLink(
         };
 
         if (resourceState) {
-          // When resourceState is truty it is a Preload state. We cast it for clarity
+          // When resourceState is truthy it is a Preload state. We cast it for clarity
           const preloadState: Preloaded | PreloadedWithCredentials =
             resourceState;
           if (preloadState.length === 2) {
@@ -3015,7 +3015,7 @@ function pushLink(
 
     if (isFallback) {
       // Hoistable Elements for fallbacks are simply omitted. we don't want to emit them early
-      // because they are likely superceded by primary content and we want to avoid needing to clean
+      // because they are likely superseded by primary content and we want to avoid needing to clean
       // them up when the primary content is ready. They are never hydrated on the client anyway because
       // boundaries in fallback are awaited or client render, in either case there is never hydration
       return null;
@@ -3086,7 +3086,7 @@ function pushStyle(
           typeof child === 'function'
             ? 'a Function'
             : typeof child === 'symbol'
-              ? 'a Sybmol'
+              ? 'a Symbol'
               : 'an Array';
         console.error(
           'React expect children of <style> tags to be a string, number, or object with a `toString` method but found %s instead. ' +
@@ -3554,7 +3554,7 @@ function pushTitle(
         );
       } else if (typeof child === 'function' || typeof child === 'symbol') {
         const childType =
-          typeof child === 'function' ? 'a Function' : 'a Sybmol';
+          typeof child === 'function' ? 'a Function' : 'a Symbol';
         console.error(
           'React expect children of <title> tags to be a string, number, bigint, or object with a novel `toString` method but found %s instead.' +
             ' Browsers treat all child Nodes of <title> tags as Text content and React expects to be able to convert children of <title>' +
@@ -3590,7 +3590,7 @@ function pushTitle(
   ) {
     if (isFallback) {
       // Hoistable Elements for fallbacks are simply omitted. we don't want to emit them early
-      // because they are likely superceded by primary content and we want to avoid needing to clean
+      // because they are likely superseded by primary content and we want to avoid needing to clean
       // them up when the primary content is ready. They are never hydrated on the client anyway because
       // boundaries in fallback are awaited or client render, in either case there is never hydration
       return null;
@@ -3686,7 +3686,7 @@ function pushStartHead(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is the wrong spot.
     return pushStartGenericElement(target, props, 'head', formatContext);
   }
 }
@@ -3720,7 +3720,7 @@ function pushStartBody(
     );
   } else {
     // This <head> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is the wrong spot.
     return pushStartGenericElement(target, props, 'body', formatContext);
   }
 }
@@ -3754,7 +3754,7 @@ function pushStartHtml(
     );
   } else {
     // This <html> is deep and is likely just an error. we emit it inline though.
-    // Validation should warn that this tag is the the wrong spot.
+    // Validation should warn that this tag is the wrong spot.
     return pushStartGenericElement(target, props, 'html', formatContext);
   }
 }
@@ -3808,7 +3808,7 @@ function pushScript(
 
     let scriptProps = props;
     if (resourceState) {
-      // When resourceState is truty it is a Preload state. We cast it for clarity
+      // When resourceState is truthy it is a Preload state. We cast it for clarity
       const preloadState: Preloaded | PreloadedWithCredentials = resourceState;
       if (preloadState.length === 2) {
         scriptProps = {...props};
@@ -3894,7 +3894,7 @@ function pushScriptImpl(
 }
 
 // This is a fork of pushStartGenericElement because we don't ever want to do
-// the children as strign optimization on that path when rendering singletons.
+// the children as string optimization on that path when rendering singletons.
 // When we eliminate that special path we can delete this fork and unify it again
 function pushStartSingletonElement(
   target: Array<Chunk | PrecomputedChunk>,
@@ -4041,7 +4041,7 @@ function pushStartCustomElement(
     }
   }
 
-  // TODO: ViewTransition attributes gets observed by the Custom Element which is a bit sketchy.
+  // TODO: ViewTransition attributes get observed by the Custom Element which is a bit sketchy.
   pushViewTransitionAttributes(target, formatContext);
 
   target.push(endOfStartTag);
@@ -6641,7 +6641,7 @@ function preinitStyle(
       };
 
       if (resourceState) {
-        // When resourceState is truty it is a Preload state. We cast it for clarity
+        // When resourceState is truthy it is a Preload state. We cast it for clarity
         const preloadState: Preloaded | PreloadedWithCredentials =
           resourceState;
         if (preloadState.length === 2) {
@@ -6707,7 +6707,7 @@ function preinitScript(src: string, options?: ?PreinitScriptOptions): void {
         options,
       );
       if (resourceState) {
-        // When resourceState is truty it is a Preload state. We cast it for clarity
+        // When resourceState is truthy it is a Preload state. We cast it for clarity
         const preloadState: Preloaded | PreloadedWithCredentials =
           resourceState;
         if (preloadState.length === 2) {
@@ -6770,7 +6770,7 @@ function preinitModuleScript(
         options,
       );
       if (resourceState) {
-        // When resourceState is truty it is a Preload state. We cast it for clarity
+        // When resourceState is truthy it is a Preload state. We cast it for clarity
         const preloadState: Preloaded | PreloadedWithCredentials =
           resourceState;
         if (preloadState.length === 2) {

--- a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
+++ b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
@@ -181,7 +181,7 @@ export function revealCompletedBoundariesWithViewTransitions(
         // this if it's just in a hidden tree in general.
         // TODO: Should we skip it if it's out of viewport? It's possible that it gets
         // brought into the viewport by changing size.
-        // TODO: There's a another case where an inner boundary is inside a fallback that
+        // TODO: There's another case where an inner boundary is inside a fallback that
         // is about to be deleted. In that case we should not run exit animations on the inner.
         continue;
       }

--- a/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyMount-test.js
@@ -145,7 +145,7 @@ describe('ReactMount', () => {
     const iFrame = document.createElement('iframe');
     document.body.appendChild(iFrame);
 
-    // HostSingletons make the warning for document.body unecessary
+    // HostSingletons make the warning for document.body unnecessary
     ReactDOM.render(<div />, iFrame.contentDocument.body);
   });
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1925,7 +1925,7 @@ export function flushSyncFromReconciler<R>(fn: (() => R) | void): R | void {
 }
 
 // If called outside of a render or commit will flush all sync work on all roots
-// Returns whether the the call was during a render or not
+// Returns whether the call was during a render or not
 export function flushSyncWork(): boolean {
   if ((executionContext & (RenderContext | CommitContext)) === NoContext) {
     flushSyncWorkOnAllRoots();

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -595,7 +595,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
 
     // Unblock the low-pri text and finish. Nothing in the UI changes because
-    // the update was overriden
+    // the update was overridden
     await act(() => resolveText('2'));
     assertLog(['2']);
     expect(ReactNoop).toMatchRenderedOutput(


### PR DESCRIPTION
## Summary

  Fix typos in comments across React DOM, React Reconciler, and related tests.

## How did you test this change?

  - yarn
  - yarn prettier
  - yarn linc
  - git diff --check
