### PR TITLE
[ChangeEventPlugin] Skip extractEvents work for unhandled events

### DIFF
--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -293,6 +293,26 @@ function extractEvents(
   eventSystemFlags: EventSystemFlags,
   targetContainer: null | EventTarget,
 ) {
+  switch (domEventName) {
+    // These are the only events this plugin responds to. Keep this list in
+    // sync with the events registered in `registerEvents` above.
+    case 'change':
+    case 'click':
+    case 'focusin':
+    case 'focusout':
+    case 'input':
+    case 'keydown':
+    case 'keyup':
+    case 'selectionchange':
+      break;
+    default:
+      // Bail out before the `getNodeFromInstance` lookup and the
+      // `nodeName.toLowerCase()` checks below. Those run for every dispatched
+      // event (including high-frequency ones like `mousemove`/`pointermove`)
+      // and are discarded for events this plugin doesn't handle.
+      return;
+  }
+
   const targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
 
   let getTargetInstFunc, handleEventFunc;


### PR DESCRIPTION
## Summary

`ChangeEventPlugin` only handles the events it registers in `registerEvents`:
`change`, `click`, `focusin`, `focusout`, `input`, `keydown`, `keyup`, and
`selectionchange`. However, `extractEvents` is invoked for **every** dispatched
event, and for unhandled ones it still called `getNodeFromInstance` and ran up
to three `nodeName.toLowerCase()` checks (`shouldUseChangeEvent`,
`isTextInputElement`, `shouldUseClickEvent`) before discarding the result. This
work happened on high-frequency events such as `mousemove`/`pointermove`.

This PR adds an early `switch` bail at the top of `extractEvents` for event
names the plugin doesn't handle, mirroring the pattern `SelectEventPlugin`
already uses. The guarded set is kept in sync with `registerEvents`. Behavior is
unchanged — it only avoids dead work on the event-dispatch hot path.

## How did you test this change?

- Existing suites pass (`yarn test`):
  `ChangeEventPlugin`, `ReactDOMInput`, `ReactDOMSelect`, `ReactDOMTextarea`,
  `SelectEventPlugin`, `ReactDOMEventListener`, `ReactDOMEventPropagation`,
  `ReactBrowserEventEmitter`, `DOMPluginEventSystem` → **504 tests, 11 suites**.
- `yarn test --prod` on the change/input/select suites → **212 tests** pass.
- Measured the avoided work: instrumenting `String.prototype.toLowerCase` during
  a single `mousemove` dispatch on a `<span>` showed **3 calls before** this
  change and **0 after**. Handled events (e.g. `click`) are unaffected.
- `yarn linc`, `yarn prettier-check`, and `yarn flow dom-node` all pass.
