### PR TITLE
[EnterLeaveEventPlugin] Create enter/leave events lazily

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -895,12 +895,12 @@ function getParent(inst: Fiber | null): Fiber | null {
 
 function accumulateEnterLeaveListenersForEvent(
   dispatchQueue: DispatchQueue,
-  event: KnownReactSyntheticEvent,
+  registrationName: string,
+  createEvent: () => KnownReactSyntheticEvent,
   target: Fiber,
   common: Fiber | null,
   inCapturePhase: boolean,
 ): void {
-  const registrationName = event._reactName;
   const listeners: Array<DispatchListener> = [];
 
   let instance: null | Fiber = target;
@@ -939,7 +939,9 @@ function accumulateEnterLeaveListenersForEvent(
     instance = instance.return;
   }
   if (listeners.length !== 0) {
-    dispatchQueue.push({event, listeners});
+    // Create the synthetic event lazily, only once we know there is at least
+    // one listener to dispatch it to.
+    dispatchQueue.push({event: createEvent(), listeners});
   }
 }
 
@@ -950,8 +952,10 @@ function accumulateEnterLeaveListenersForEvent(
 // phase event listeners.
 export function accumulateEnterLeaveTwoPhaseListeners(
   dispatchQueue: DispatchQueue,
-  leaveEvent: KnownReactSyntheticEvent,
-  enterEvent: null | KnownReactSyntheticEvent,
+  leaveRegistrationName: string,
+  createLeaveEvent: () => KnownReactSyntheticEvent,
+  enterRegistrationName: string,
+  createEnterEvent: null | (() => KnownReactSyntheticEvent),
   from: Fiber | null,
   to: Fiber | null,
 ): void {
@@ -961,16 +965,18 @@ export function accumulateEnterLeaveTwoPhaseListeners(
   if (from !== null) {
     accumulateEnterLeaveListenersForEvent(
       dispatchQueue,
-      leaveEvent,
+      leaveRegistrationName,
+      createLeaveEvent,
       from,
       common,
       false,
     );
   }
-  if (to !== null && enterEvent !== null) {
+  if (to !== null && createEnterEvent !== null) {
     accumulateEnterLeaveListenersForEvent(
       dispatchQueue,
-      enterEvent,
+      enterRegistrationName,
+      createEnterEvent,
       to,
       common,
       true,

--- a/packages/react-dom-bindings/src/events/plugins/EnterLeaveEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/EnterLeaveEventPlugin.js
@@ -139,35 +139,53 @@ function extractEvents(
   const fromNode = from == null ? win : getNodeFromInstance(from);
   const toNode = to == null ? win : getNodeFromInstance(to);
 
-  const leave: KnownReactSyntheticEvent = new SyntheticEventCtor(
-    leaveEventType,
-    eventTypePrefix + 'leave',
-    from,
-    nativeEvent,
-    nativeEventTarget,
-  );
-  leave.target = fromNode;
-  leave.relatedTarget = toNode;
-
-  let enter: KnownReactSyntheticEvent | null = null;
+  // Create the synthetic events lazily: they are only needed when a matching
+  // listener exists on the from/to path.
+  // accumulateEnterLeaveTwoPhaseListeners checks that before invoking these
+  // factories. mouseout/mouseover fire on every boundary crossing, so most
+  // dispatches have no listener and would otherwise allocate (and immediately
+  // discard) these events.
+  const createLeaveEvent = (): KnownReactSyntheticEvent => {
+    const leave: KnownReactSyntheticEvent = new SyntheticEventCtor(
+      leaveEventType,
+      eventTypePrefix + 'leave',
+      from,
+      nativeEvent,
+      nativeEventTarget,
+    );
+    leave.target = fromNode;
+    leave.relatedTarget = toNode;
+    return leave;
+  };
 
   // We should only process this nativeEvent if we are processing
   // the first ancestor. Next time, we will ignore the event.
   const nativeTargetInst = getClosestInstanceFromNode(nativeEventTarget as any);
-  if (nativeTargetInst === targetInst) {
-    const enterEvent: KnownReactSyntheticEvent = new SyntheticEventCtor(
-      enterEventType,
-      eventTypePrefix + 'enter',
-      to,
-      nativeEvent,
-      nativeEventTarget,
-    );
-    enterEvent.target = toNode;
-    enterEvent.relatedTarget = fromNode;
-    enter = enterEvent;
-  }
+  const createEnterEvent: null | (() => KnownReactSyntheticEvent) =
+    nativeTargetInst === targetInst
+      ? (): KnownReactSyntheticEvent => {
+          const enter: KnownReactSyntheticEvent = new SyntheticEventCtor(
+            enterEventType,
+            eventTypePrefix + 'enter',
+            to,
+            nativeEvent,
+            nativeEventTarget,
+          );
+          enter.target = toNode;
+          enter.relatedTarget = fromNode;
+          return enter;
+        }
+      : null;
 
-  accumulateEnterLeaveTwoPhaseListeners(dispatchQueue, leave, enter, from, to);
+  accumulateEnterLeaveTwoPhaseListeners(
+    dispatchQueue,
+    leaveEventType,
+    createLeaveEvent,
+    enterEventType,
+    createEnterEvent,
+    from,
+    to,
+  );
 }
 
 export {registerEvents, extractEvents};


### PR DESCRIPTION
## Summary

`EnterLeaveEventPlugin.extractEvents` builds the `mouseleave`/`mouseenter` (or
`pointerleave`/`pointerenter`) `SyntheticEvent` objects **eagerly**, before
`accumulateEnterLeaveTwoPhaseListeners` walks the from/to paths to determine
whether any matching listener actually exists (it only pushes to the dispatch
queue when `listeners.length !== 0`).

`mouseout`/`mouseover` fire on every element-boundary crossing, so an app with
no `onMouseEnter`/`onMouseLeave`/`onPointerEnter`/`onPointerLeave` listener on
the path allocates one or two `SyntheticEvent` objects per crossing and
immediately throws them away.

This PR defers construction behind factory callbacks, matching the
"Intentionally create event lazily" pattern already used by `SimpleEventPlugin`
and `ScrollEndEventPlugin`. `accumulateEnterLeaveListenersForEvent` now takes the
registration name and a factory, and only constructs the event inside the
`listeners.length !== 0` branch. Behavior is unchanged.

`accumulateEnterLeaveTwoPhaseListeners` is exported but has exactly one caller
(this plugin); `accumulateEnterLeaveListenersForEvent` is module-private.

## How did you test this change?

- Existing suites pass (`yarn test`): `EnterLeaveEventPlugin`,
  `DOMPluginEventSystem`, `ReactDOMEventListener`, `ReactDOMEventPropagation`,
  `ReactDOMComponent`, `ReactTreeTraversal`, `SyntheticMouseEvent`,
  `ReactDOMFiber` → **468 tests, 10 suites**.
- `yarn test --prod` on the enter/leave + event suites → **210 tests** pass.
- Measured the avoided allocation: instrumenting the native event's `screenX`
  getter (read once per `SyntheticMouseEvent` construction) during a `mouseout`
  dispatch on a `<span>` with no enter/leave listeners showed **2 constructions
  before** this change and **0 after**; `onMouseLeave` still fires when a
  listener is present.
- `yarn linc`, `yarn prettier-check`, and `yarn flow dom-node` all pass.
