### PR TITLE
[ReactDOM] Don't crash on bigint values for numeric attributes

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -818,7 +818,7 @@ function setProp(
         value != null &&
         typeof value !== 'function' &&
         typeof value !== 'symbol' &&
-        !isNaN(value) &&
+        (typeof value === 'bigint' || !isNaN(value)) &&
         (value as any) >= 1
       ) {
         if (__DEV__) {
@@ -837,7 +837,7 @@ function setProp(
         value != null &&
         typeof value !== 'function' &&
         typeof value !== 'symbol' &&
-        !isNaN(value)
+        (typeof value === 'bigint' || !isNaN(value))
       ) {
         if (__DEV__) {
           checkAttributeStringCoercion(value, key);
@@ -2281,7 +2281,7 @@ function hydrateNumericAttribute(
       case 'boolean':
         return;
       default:
-        if (isNaN(value)) {
+        if (typeof value !== 'bigint' && isNaN(value)) {
           return;
         }
     }
@@ -2296,7 +2296,7 @@ function hydrateNumericAttribute(
         case 'boolean':
           break;
         default: {
-          if (isNaN(value)) {
+          if (typeof value !== 'bigint' && isNaN(value)) {
             // We had an attribute but shouldn't have had one, so read it
             // for the error message.
             break;
@@ -2333,7 +2333,7 @@ function hydratePositiveNumericAttribute(
       case 'boolean':
         return;
       default:
-        if (isNaN(value) || value < 1) {
+        if ((typeof value !== 'bigint' && isNaN(value)) || value < 1) {
           return;
         }
     }
@@ -2348,7 +2348,7 @@ function hydratePositiveNumericAttribute(
         case 'boolean':
           break;
         default: {
-          if (isNaN(value) || value < 1) {
+          if ((typeof value !== 'bigint' && isNaN(value)) || value < 1) {
             // We had an attribute but shouldn't have had one, so read it
             // for the error message.
             break;

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1755,7 +1755,7 @@ function pushAttribute(
       if (
         typeof value !== 'function' &&
         typeof value !== 'symbol' &&
-        !isNaN(value) &&
+        (typeof value === 'bigint' || !isNaN(value)) &&
         (value as any) >= 1
       ) {
         target.push(
@@ -1774,7 +1774,7 @@ function pushAttribute(
       if (
         typeof value !== 'function' &&
         typeof value !== 'symbol' &&
-        !isNaN(value)
+        (typeof value === 'bigint' || !isNaN(value))
       ) {
         target.push(
           attributeSeparator,

--- a/packages/react-dom/src/__tests__/ReactDOMNumericAttributeBigInt-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNumericAttributeBigInt-test.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOMClient;
+let ReactDOMServer;
+let act;
+let container;
+
+describe('numeric attributes with bigint values', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    ReactDOMServer = require('react-dom/server');
+    act = require('internal-test-utils').act;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  // isNaN() throws a TypeError on a BigInt, so a bigint value for one of these
+  // numeric attributes used to crash the render. They are otherwise coerced to
+  // a string like every other attribute (setValueForAttribute path).
+  it('does not crash and coerces bigint on positive numeric attributes', async () => {
+    const root = ReactDOMClient.createRoot(container);
+    await act(() =>
+      root.render(<textarea cols={80n} rows={10n} defaultValue="" />),
+    );
+    const textarea = container.querySelector('textarea');
+    expect(textarea.getAttribute('cols')).toBe('80');
+    expect(textarea.getAttribute('rows')).toBe('10');
+  });
+
+  it('does not crash and coerces bigint on numeric attributes (start)', async () => {
+    const root = ReactDOMClient.createRoot(container);
+    await act(() =>
+      root.render(
+        <ol start={5n}>
+          <li />
+        </ol>,
+      ),
+    );
+    expect(container.querySelector('ol').getAttribute('start')).toBe('5');
+  });
+
+  it('removes a positive numeric attribute when the bigint is below 1', async () => {
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => root.render(<textarea cols={0n} defaultValue="" />));
+    expect(container.querySelector('textarea').hasAttribute('cols')).toBe(
+      false,
+    );
+  });
+
+  it('does not crash and coerces bigint when server rendering (Fizz)', () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <ol start={5n}>
+        <li />
+      </ol>,
+    );
+    expect(html).toContain('start="5"');
+  });
+
+  it('does not crash when hydrating bigint numeric attributes', async () => {
+    container.innerHTML = ReactDOMServer.renderToString(
+      <ol start={5n}>
+        <li />
+      </ol>,
+    );
+    await act(() =>
+      ReactDOMClient.hydrateRoot(
+        container,
+        <ol start={5n}>
+          <li />
+        </ol>,
+      ),
+    );
+    expect(container.querySelector('ol').getAttribute('start')).toBe('5');
+  });
+
+  it('does not crash and coerces bigint on the positive Fizz path (cols/rows)', () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <textarea cols={80n} rows={10n} defaultValue="" />,
+    );
+    expect(html).toContain('cols="80"');
+    expect(html).toContain('rows="10"');
+  });
+
+  it('does not crash hydrating the positive numeric path (cols/rows)', async () => {
+    container.innerHTML = ReactDOMServer.renderToString(
+      <textarea cols={80n} rows={10n} defaultValue="" />,
+    );
+    await act(() =>
+      ReactDOMClient.hydrateRoot(
+        container,
+        <textarea cols={80n} rows={10n} defaultValue="" />,
+      ),
+    );
+    const textarea = container.querySelector('textarea');
+    expect(textarea.getAttribute('cols')).toBe('80');
+    expect(textarea.getAttribute('rows')).toBe('10');
+  });
+});


### PR DESCRIPTION
## Summary

`isNaN()` throws a `TypeError: Cannot convert a BigInt value to a number` when
given a BigInt. The numeric HTML attributes (`cols`, `rows`, `size`, `span`,
`rowSpan`, `start`) are guarded with `!isNaN(value)` after only excluding
`function` and `symbol`, so passing a bigint value **crashes the render**:

```jsx
ReactDOM.createRoot(node).render(<ol start={5n}><li /></ol>);
// TypeError: Cannot convert a BigInt value to a number
```

This happens on client render, during hydration, and in Fizz server rendering.

It's also an inconsistency: every other attribute goes through
`setValueForAttribute`, which does **not** exclude bigint and coerces it to a
string, so `<div data-x={5n} />` already renders `data-x="5"` without crashing.
(BigInt is also supported as text children — see #24580.)

## Fix

Treat a bigint as a valid numeric value (it is never `NaN`) wherever these
attributes are handled, so it falls through to the normal string coercion:

- **client render** (`ReactDOMComponent` `setProp`)
- **hydration** property diffing (`hydrateNumericAttribute` /
  `hydratePositiveNumericAttribute`)
- **Fizz server rendering** (`ReactFizzConfigDOM`)

The `value >= 1` requirement for the positive attributes is preserved
(`<textarea cols={0n} />` removes the attribute, since `0n >= 1` is `false`).

## How did you test this change?

- Added `ReactDOMNumericAttributeBigInt-test.js` covering client render, Fizz
  SSR (`renderToStaticMarkup`), and hydration: `<ol start={5n}>` → `start="5"`,
  `<textarea cols={80n} rows={10n}>` → `cols="80" rows="10"`, `<textarea
  cols={0n}>` → no `cols`. All crashed before this change and pass after.
- Existing suites pass (`yarn test` and `yarn test --prod`): `ReactDOMComponent`,
  `ReactDOMServerIntegrationAttributes`, `ReactDOMFizzServer`, `ReactDOMInput`,
  `ReactDOMTextarea`, `ReactDOMOption`, `CSSPropertyOperations`.
- `yarn linc`, `yarn prettier-check`, and `yarn flow dom-node` pass.
