### PR TITLE
docs: fix argument to download-experimental-build.js

### DIFF
--- a/packages/react-devtools-extensions/README.md
+++ b/packages/react-devtools-extensions/README.md
@@ -31,7 +31,7 @@ To use the latest build from CI, run the following commands starting from the ro
 ```sh
 cd scripts/release
 yarn install
-./download-experimental-build.js
+./download-experimental-build.js --commit $(git rev-parse origin/main)
 ```
 ### Build steps
 Once the above packages have been built or downloaded, you can build the extension by running:


### PR DESCRIPTION
[download-experimental-build.js](https://github.com/react/react/blob/ad78e251e2f64638a326c038fe130b5ed00a2726/scripts/release/shared-commands/download-build-artifacts.js) requires a positional argument commit. The code example in [README.md](https://github.com/doehyunbaek/react/blob/65b3449c89870dbce9c8ca01c892825dc9d74ca3/packages/react-devtools-extensions/README.md) omits it. This pull request fixes it by passing --commit argument to the code example in README.md.