### PR TITLE
Fix exhaustive-deps autofixer suggesting redundant dependencies

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -2866,8 +2866,8 @@ const tests = {
       ],
     },
     {
-      // Effects are allowed to over-specify deps. We'll complain about missing
-      // 'local', but we won't remove the already-specified 'local.id' from your list.
+      // When adding a missing parent dep like 'local', we remove the
+      // now-redundant child dep 'local.id' from the suggestion.
       code: normalizeIndent`
         function MyComponent() {
           const local = {id: 42};
@@ -2883,13 +2883,13 @@ const tests = {
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [local, local.id]',
+              desc: 'Update the dependencies array to be: [local]',
               output: normalizeIndent`
                 function MyComponent() {
                   const local = {id: 42};
                   useEffect(() => {
                     console.log(local);
-                  }, [local, local.id]);
+                  }, [local]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -1677,10 +1677,36 @@ function collectRecommendations({
         duplicateDependencies.add(key);
       }
     } else {
+      // Check if this declared dep is made redundant by a broader
+      // missing dependency. For example, 'local.id' is unnecessary
+      // if 'local' is being added as a missing dependency AND the
+      // code only uses 'local' directly (not any sub-properties).
+      // However, if the code uses sub-properties like 'props.isEditMode'
+      // alongside a missing 'props', we keep declared sub-property deps
+      // because they document the user's intent.
+      let isCoveredByMissing = false;
+      missingDependencies.forEach(missingKey => {
+        if (key === missingKey || key.startsWith(missingKey + '.')) {
+          // Only remove if the code doesn't use any sub-properties
+          // of the missing dep. If it does, the user likely listed
+          // sub-property deps intentionally.
+          let hasSubPropertyUsage = false;
+          dependencies.forEach((_, depKey) => {
+            if (depKey !== missingKey && depKey.startsWith(missingKey + '.')) {
+              hasSubPropertyUsage = true;
+            }
+          });
+          if (!hasSubPropertyUsage) {
+            isCoveredByMissing = true;
+          }
+        }
+      });
+
       if (
         isEffect &&
         !key.endsWith('.current') &&
-        !externalDependencies.has(key)
+        !externalDependencies.has(key) &&
+        !isCoveredByMissing
       ) {
         // Effects are allowed extra "unnecessary" deps.
         // Such as resetting scroll when ID changes.


### PR DESCRIPTION
### Summary
When a React hook's dependency array is missing a broader/parent dependency (e.g., `local`) but already includes a declared specific child/sub-property dependency (e.g., `local.id`), the autofixer/suggestion was proposing to add both, resulting in a redundant array like `[local, local.id]`. This is unnecessary because tracking the parent object `local` already covers changes to its sub-properties.

### Changes
* **Updated `collectRecommendations` in `ExhaustiveDeps.ts`:**
  * Added logic (`isCoveredByMissing`) to check if a declared dependency is a sub-property of (or matches) any dependency in `missingDependencies`.
  * If the declared dependency is covered by a missing parent dependency and there are no other sub-property usages of the parent dependency in the code, the redundant child dependency is filtered out of the suggestions.
  * Preserved the child dependency if the parent object has other sub-property usages in the component (e.g., `props.isEditMode` and `props.toggleEditMode`), to avoid breaking intentional sub-property tracking.
* **Updated test assertions in `ESLintRuleExhaustiveDeps-test.js`** to assert that the suggestion correctly narrows down `[local, local.id]` to just `[local]`.

### How did you test this change?
* **Unit Tests:** Updated the test case in `packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js` to verify that when adding the missing `local` parent dependency, the autofixer removes the redundant `local.id` child dependency from the recommended array.
* **Test Suite Verification:** Ran the entire test suite for the ESLint plugin locally:
  ```bash
  cd packages/eslint-plugin-react-hooks
  npx jest --config jest.config.js --no-watchman