### PR TITLE
[Perf Tracks] Don't crash on cross-origin Window props

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
@@ -629,4 +629,167 @@ describe('ReactPerformanceTracks', () => {
       ],
     ]);
   });
+
+  // A faithful model of a cross-origin (opaque origin) Window. Unlike a plain
+  // object, *any* property access throws a SecurityError — including the `in`
+  // operator (the `has` trap), getOwnPropertyDescriptor and walking the
+  // prototype. Only the handful of symbols the JS engine itself probes are
+  // allowed. A real cross-origin Window's *only* enumerable own properties are
+  // the numeric indices of its child frames, so `childFrameCount` models those.
+  // The previous fixture only trapped `get`, which let `'$$typeof' in value`
+  // slip through and so never reproduced the real crash.
+  function createCrossOriginWindow(childFrameCount = 0) {
+    const allowed = new Set([
+      Symbol.toStringTag,
+      Symbol.hasInstance,
+      Symbol.isConcatSpreadable,
+    ]);
+    const indices = [];
+    for (let i = 0; i < childFrameCount; i++) {
+      indices.push(String(i));
+    }
+    const isChildFrameIndex = prop =>
+      typeof prop === 'string' && indices.includes(prop);
+    const guard = prop => {
+      if (typeof prop === 'symbol' && allowed.has(prop)) {
+        return;
+      }
+      if (prop === 'then') {
+        return;
+      }
+      // An existing child-frame index is readable; everything else (including
+      // the `in` check for a *missing* index) throws.
+      if (isChildFrameIndex(prop)) {
+        return;
+      }
+      throw new Error(
+        `Failed to read a named property '${String(prop)}' from 'Window'`,
+      );
+    };
+    return new Proxy(
+      {},
+      {
+        get(target, prop) {
+          guard(prop);
+          // A child-frame index resolves to a (childless) cross-origin Window.
+          return isChildFrameIndex(prop)
+            ? createCrossOriginWindow(0)
+            : undefined;
+        },
+        has(target, prop) {
+          guard(prop);
+          return isChildFrameIndex(prop);
+        },
+        getOwnPropertyDescriptor(target, prop) {
+          guard(prop);
+          if (isChildFrameIndex(prop)) {
+            return {
+              enumerable: true,
+              configurable: true,
+              value: createCrossOriginWindow(0),
+            };
+          }
+          return undefined;
+        },
+        ownKeys() {
+          return indices;
+        },
+        getPrototypeOf() {
+          return null;
+        },
+      },
+    );
+  }
+
+  // @gate __DEV__ && enableComponentPerformanceTrack
+  it('does not crash diffing cross-origin Window props (opaque origin)', async () => {
+    const App = function App({win}) {
+      Scheduler.unstable_advanceTime(10);
+      React.useEffect(() => {}, [win]);
+    };
+
+    Scheduler.unstable_advanceTime(1);
+    await act(() => {
+      ReactNoop.render(<App win={createCrossOriginWindow()} />);
+    });
+    performanceMeasureCalls.length = 0;
+
+    Scheduler.unstable_advanceTime(10);
+    await act(() => {
+      // Re-render with a *different* cross-origin Window so the prop diffs and
+      // the perf-track logger walks it.
+      ReactNoop.render(<App win={createCrossOriginWindow()} />);
+    });
+
+    expect(performanceMeasureCalls).toEqual([
+      [
+        '​App',
+        {
+          detail: {
+            devtools: {
+              color: 'primary-dark',
+              properties: [
+                ['Changed Props', ''],
+                [
+                  ' \xa0win',
+                  'Referentially unequal but deeply equal objects. Consider memoization.',
+                ],
+              ],
+              tooltipText: 'App',
+              track: 'Components ⚛',
+            },
+          },
+          end: 31,
+          start: 21,
+        },
+      ],
+    ]);
+  });
+
+  // @gate __DEV__ && enableComponentPerformanceTrack
+  it('does not crash diffing cross-origin Windows that contain child frames', async () => {
+    const App = function App({win}) {
+      Scheduler.unstable_advanceTime(10);
+      React.useEffect(() => {}, [win]);
+    };
+
+    Scheduler.unstable_advanceTime(1);
+    await act(() => {
+      // A cross-origin Window that contains a nested iframe exposes the child
+      // frame as an enumerable numeric index ('0'), so `for...in` walks it.
+      ReactNoop.render(<App win={createCrossOriginWindow(1)} />);
+    });
+    performanceMeasureCalls.length = 0;
+
+    Scheduler.unstable_advanceTime(10);
+    await act(() => {
+      // The new Window has no child frame, so the diff checks `'0' in next` on a
+      // cross-origin Window that doesn't have it — which throws a SecurityError
+      // unless the `in` check is guarded.
+      ReactNoop.render(<App win={createCrossOriginWindow(0)} />);
+    });
+
+    // Should not throw. The removed '0' child frame is reported in the diff.
+    expect(performanceMeasureCalls).toEqual([
+      [
+        '​App',
+        {
+          detail: {
+            devtools: {
+              color: 'primary-dark',
+              properties: [
+                ['Changed Props', ''],
+                [' \xa0win', ''],
+                ['-\xa0\xa0\xa00', '…'],
+              ],
+              tooltipText: 'App',
+              track: 'Components ⚛',
+            },
+          },
+          end: 31,
+          start: 21,
+        },
+      ],
+    ]);
+  });
 });

--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -83,10 +83,30 @@ export function addObjectToProperties(
 }
 
 function readReactElementTypeof(value: Object): mixed {
-  // Prevents dotting into $$typeof in opaque origin windows.
-  return '$$typeof' in value && hasOwnProperty.call(value, '$$typeof')
-    ? value.$$typeof
-    : undefined;
+  // Prevents dotting into $$typeof in opaque origin windows. Reading any
+  // property of a cross-origin Window throws a SecurityError, and that includes
+  // the `in` operator below (it triggers the [[HasProperty]] internal method),
+  // so the whole access has to be guarded — otherwise the DEV-only perf logger
+  // would throw out of the commit phase and corrupt the fiber tree.
+  try {
+    return '$$typeof' in value && hasOwnProperty.call(value, '$$typeof')
+      ? value.$$typeof
+      : undefined;
+  } catch (x) {
+    return undefined;
+  }
+}
+
+function safeHas(key: string, object: Object): boolean {
+  // `key in object` triggers the [[HasProperty]] internal method, which throws
+  // a SecurityError for a cross-origin Window — including for an enumerable
+  // child-frame index that is present on one side of a diff but not the other.
+  // An unreadable key is treated as absent so the DEV-only logger never throws.
+  try {
+    return key in object;
+  } catch (x) {
+    return false;
+  }
 }
 
 export function addValueToProperties(
@@ -322,7 +342,7 @@ export function addObjectDiffToProperties(
       break;
     }
 
-    if (!(key in next)) {
+    if (!safeHas(key, next)) {
       properties.push([REMOVED + '\xa0\xa0'.repeat(indent) + key, '\u2026']);
       isDeeplyEqual = false;
     }
@@ -342,7 +362,7 @@ export function addObjectDiffToProperties(
       break;
     }
 
-    if (key in prev) {
+    if (safeHas(key, prev)) {
       const prevValue = prev[key];
       const nextValue = next[key];
       if (prevValue !== nextValue) {


### PR DESCRIPTION
> **Note on existing PRs:** #36430 already has a PR — #36451 (@sleitor) — which guards the property-enumeration path (`addObjectToProperties`'s `for…in`) and emits a `[CrossOriginObject]` placeholder. I'm opening this as an alternative because I think guarding the **prop-diff path** is the more complete fix: the `key in next` / `key in prev` checks in `addObjectDiffToProperties` trigger `[[HasProperty]]`, which itself throws a `SecurityError` on a cross-origin `Window` — a failure mode the enumeration-only guard doesn't cover (and which a `get`-only test fixture doesn't reproduce). Happy to fold this into #36451 — deferring to the maintainers on which direction to take.

---

## Summary

Fixes #36430.

In DEV builds, the component performance-track logger walks a component's props
on every update (`logComponentRender` → `addObjectDiffToProperties`) and reads
`value.$$typeof` to detect React elements. When a prop is a **cross-origin
`Window`** — e.g. the `contentWindow` of an `<iframe srcdoc="">`, whose origin is
`"null"` — *any* property access throws a `SecurityError`. Because the logger runs
inside the commit phase (`commitPassiveMountOnFiber`), the throw escapes the
commit, corrupts the work-in-progress fiber, and every later render fails with
`Should not already be working`, freezing the whole UI. Production builds are
unaffected (the logger is DEV-only).

```jsx
function App() {
  const [win, setWin] = useState(null);
  useEffect(() => setWin(iframeRef.current.contentWindow), []);
  return (
    <>
      <iframe ref={iframeRef} srcDoc="<p>hi</p>" />
      <Child win={win} /> {/* cross-origin Window prop crashes the DEV logger */}
    </>
  );
}
```

`readReactElementTypeof` already carried a comment about "opaque origin windows",
but its guard was `'$$typeof' in value` — and the `in` operator itself triggers
`[[HasProperty]]` → `[[GetOwnProperty]]`, which throws for a cross-origin Window,
so the guard never actually held.

The DEV logger must never throw while iterating props, so this guards the two
property accesses that can reach a cross-origin Window:

- **`readReactElementTypeof`** wraps the `$$typeof` access (including the `in`
  check) in `try/catch`, returning `undefined` ("not a React element") on throw.
- **`safeHas`** (new) guards the prop diff's `key in next` / `key in prev`. A
  cross-origin Window exposes its child frames as *enumerable* numeric indices,
  so `for...in` can yield `"0"`, and the `in` check then throws for an index that
  exists on only one side of the diff. An unreadable key is treated as absent.

Both paths degrade gracefully — an unreadable value is logged as a plain object
or a removed/added key instead of crashing.

## How did you test this change?

- Added two regression tests in `ReactPerformanceTrack-test.js` that model a
  cross-origin `Window` faithfully with a `Proxy` (throws on `get` / `has` /
  `getOwnPropertyDescriptor` for everything except the symbols the engine itself
  probes; `null` prototype). The existing fixture only trapped `get`, so
  `'$$typeof' in value` slipped through and never reproduced the crash.
  - `does not crash diffing cross-origin Window props (opaque origin)` — a
    childless Window (covers the `readReactElementTypeof` guard).
  - `does not crash diffing cross-origin Windows that contain child frames` — a
    Window exposing an enumerable child-frame index (covers the `safeHas` guard).

  Both tests crash before this change and pass after.
- `yarn test packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js`
  → 8/8 pass (the 6 existing perf-track tests still pass).
- `yarn test --prod` of the same file → 8/8 (the tests are `@gate`d to DEV +
  `enableComponentPerformanceTrack`, so they are correctly gated out in prod).
- `yarn linc`, `yarn prettier-check`, and `yarn flow dom-node` pass.
</content>

