### PR TITLE
Guard prop getter reads in DEV perf logger

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
@@ -629,4 +629,44 @@ describe('ReactPerformanceTracks', () => {
       ],
     ]);
   });
+
+  // @gate __DEV__ && enableComponentPerformanceTrack
+  it('does not crash on prop objects whose getters throw', async () => {
+    function makeThrowingProp() {
+      const o = {};
+      Object.defineProperty(o, 'boom', {
+        enumerable: true,
+        get() {
+          throw new Error('do not read');
+        },
+      });
+      return o;
+    }
+
+    const App = function App({data}) {
+      Scheduler.unstable_advanceTime(10);
+      React.useEffect(() => {}, [data]);
+    };
+
+    Scheduler.unstable_advanceTime(1);
+    await act(() => {
+      ReactNoop.render(<App data={makeThrowingProp()} />);
+    });
+    performanceMeasureCalls.length = 0;
+
+    Scheduler.unstable_advanceTime(10);
+    await act(() => {
+      // New prop object so the diff path walks both sides and reads `boom`.
+      ReactNoop.render(<App data={makeThrowingProp()} />);
+    });
+
+    // Should not throw. The throwing getter degrades to the omitted-value
+    // ellipsis instead of propagating out of the commit phase.
+    expect(performanceMeasureCalls).toHaveLength(1);
+    const [, options] = performanceMeasureCalls[0];
+    const props = options.detail.devtools.properties;
+    expect(props).not.toBeNull();
+    // The diff records the change but does not throw.
+    expect(props.some(([k]) => k.includes('data'))).toBe(true);
+  });
 });

--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -55,6 +55,18 @@ function getArrayKind(array: Object): 0 | 1 | 2 | 3 {
   return kind;
 }
 
+function safeRead(object: Object, key: string): mixed {
+  // Reading a prop's value can run a user-defined getter which may throw or
+  // have side effects. The DEV-only perf logger walks prop objects unconditionally,
+  // so the read has to be guarded — otherwise an arbitrary getter would throw
+  // out of the commit phase and corrupt the fiber tree (issue #35126).
+  try {
+    return object[key];
+  } catch (x) {
+    return OMITTED_PROP_ERROR;
+  }
+}
+
 export function addObjectToProperties(
   object: Object,
   properties: Array<[string, string]>,
@@ -65,7 +77,7 @@ export function addObjectToProperties(
   for (const key in object) {
     if (hasOwnProperty.call(object, key) && key[0] !== '_') {
       addedProperties++;
-      const value = object[key];
+      const value = safeRead(object, key);
       addValueToProperties(key, value, properties, indent, prefix);
       if (addedProperties >= OBJECT_WIDTH_LIMIT) {
         properties.push([
@@ -343,8 +355,8 @@ export function addObjectDiffToProperties(
     }
 
     if (key in prev) {
-      const prevValue = prev[key];
-      const nextValue = next[key];
+      const prevValue = safeRead(prev, key);
+      const nextValue = safeRead(next, key);
       if (prevValue !== nextValue) {
         if (indent === 0 && key === 'children') {
           // Omit any change inside the top level children prop since it's expected to change


### PR DESCRIPTION
## Summary

In DEV, \`logComponentRender\` walks every prop object via \`for...in\` and dereferences each enumerable own key with a plain \`object[key]\` read. If a prop has a user-defined getter that throws (or has a side effect that throws downstream), the exception escapes the commit phase and leaves the work-in-progress fiber tree in a corrupted state — \`Should not already be working\` — taking the whole app down.

This wraps the read in a small \`safeRead\` helper that catches and substitutes the existing \`OMITTED_PROP_ERROR\` sentinel, which \`addValueToProperties\` already renders as the \"…\" placeholder. Two call sites are covered:

- \`addObjectToProperties\` — the mount-time walk of \`fiber.memoizedProps\`.
- \`addObjectDiffToProperties\` — the update-time diff that reads both sides of each changed key.

This is complementary to #36829, which guards the \`in\` operator and the \`\$\$typeof\` probe for cross-origin Window props. That PR is necessary for the SecurityError surface (#36430); this PR covers the wider class of plain objects whose own getter throws or has side effects (#35126), which #36829's guards don't reach.

Fixes #35126.

## How did you test this change?

- New test in \`ReactPerformanceTrack-test.js\` that mounts and re-renders a component whose prop has a throwing getter, and verifies the commit phase doesn't throw.
- \`yarn test ReactPerformanceTrack\` — 7/7 pass.
- \`yarn linc\`, \`yarn prettier\`, \`yarn flow dom-node\` — clean.