### PR TITLE
[compiler] Add ESM build for react-compiler-runtime

### DIFF
--- a/compiler/packages/react-compiler-runtime/package.json
+++ b/compiler/packages/react-compiler-runtime/package.json
@@ -4,6 +4,33 @@
   "description": "Runtime for React Compiler",
   "license": "MIT",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "default": "./dist/index.js"
+    },
+    "./dist/index.js": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "default": "./dist/index.js"
+    },
+    "./src/*": "./src/*",
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
@@ -14,6 +41,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsup",
+    "postbuild": "node scripts/postbuild.js",
     "test": "echo 'no tests'",
     "watch": "yarn build --watch"
   },

--- a/compiler/packages/react-compiler-runtime/scripts/postbuild.js
+++ b/compiler/packages/react-compiler-runtime/scripts/postbuild.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {access, copyFile} = require('fs/promises');
+const {join} = require('path');
+
+const packageRoot = join(__dirname, '..');
+
+async function copyIfExists(source, target) {
+  try {
+    await access(source);
+  } catch {
+    return;
+  }
+  await copyFile(source, target);
+}
+
+async function main() {
+  await copyIfExists(
+    join(packageRoot, 'dist/index.d.ts'),
+    join(packageRoot, 'dist/index.d.cts')
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/compiler/packages/react-compiler-runtime/src/index.ts
+++ b/compiler/packages/react-compiler-runtime/src/index.ts
@@ -415,3 +415,14 @@ export function $structuralCheck(
   }
   recur(oldValue, newValue, '', 0);
 }
+
+export default {
+  $dispatcherGuard,
+  $makeReadOnly,
+  $reset,
+  $structuralCheck,
+  c,
+  clearRenderCounterRegistry,
+  renderCounterRegistry,
+  useRenderCounter,
+};

--- a/compiler/packages/react-compiler-runtime/tsup.config.ts
+++ b/compiler/packages/react-compiler-runtime/tsup.config.ts
@@ -5,7 +5,31 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {readFile, writeFile} from 'node:fs/promises';
 import {defineConfig} from 'tsup';
+
+async function copyLegacyCommonJSOutput() {
+  const source = './dist/index.cjs';
+  const sourceMap = './dist/index.cjs.map';
+  const legacy = './dist/index.js';
+  const legacyMap = './dist/index.js.map';
+
+  const [sourceText, sourceMapText] = await Promise.all([
+    readFile(source, 'utf8'),
+    readFile(sourceMap, 'utf8'),
+  ]);
+
+  await Promise.all([
+    writeFile(
+      legacy,
+      sourceText.replace(
+        '//# sourceMappingURL=index.cjs.map',
+        '//# sourceMappingURL=index.js.map',
+      ),
+    ),
+    writeFile(legacyMap, sourceMapText),
+  ]);
+}
 
 export default defineConfig({
   entry: ['./src/index.ts'],
@@ -15,9 +39,15 @@ export default defineConfig({
   sourcemap: true,
   dts: false,
   bundle: true,
-  format: 'cjs',
+  format: ['cjs', 'esm'],
+  outExtension({format}) {
+    return {
+      js: format === 'esm' ? '.mjs' : '.cjs',
+    };
+  },
   platform: 'node',
   target: 'es2015',
+  onSuccess: copyLegacyCommonJSOutput,
   banner: {
     js: `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/scripts/ci/download_devtools_regression_build.js
+++ b/scripts/ci/download_devtools_regression_build.js
@@ -126,8 +126,11 @@ async function downloadRegressionBuild() {
         `Moving react-compiler-runtime to react/compiler-runtime.js\n`
       )
     );
+    const reactCompilerRuntimePath = require.resolve('react-compiler-runtime', {
+      paths: [regressionBuildPath],
+    });
     await exec(
-      `mv ${REGRESSION_FOLDER}/node_modules/react-compiler-runtime/dist/index.js ${buildPath}/react/compiler-runtime.js`
+      `mv ${reactCompilerRuntimePath} ${buildPath}/react/compiler-runtime.js`
     );
   }
 }


### PR DESCRIPTION
## Summary

`react-compiler-runtime` is intentionally CJS today. It was switched back to CJS in #31993 after the esbuild migration caused CJS consumers such as `esbuild-register`, Jest, and Vite SSR to load an ESM `dist/index.js` and fail with `Cannot use import statement outside a module`. #32091 then made the package consistently target Node/CJS to address the remaining Node 20 path.

This keeps that CJS behavior while adding an explicit ESM build for ESM consumers:

- tsup now emits `dist/index.cjs` as the canonical CommonJS build and `dist/index.mjs` as the ESM build.
- `dist/index.js` is still generated as a CommonJS legacy file for consumers that directly reference the previous physical file path. The package `main` field is also left on `dist/index.js` for tools that do not use package `exports`.
- `package.json` uses conditional exports so modern `require('react-compiler-runtime')` resolves to `dist/index.cjs` and modern `import ... from 'react-compiler-runtime'` resolves to `dist/index.mjs`.
- Type declarations are split across `dist/index.d.cts` for the CJS entry, `dist/index.d.mts` for the ESM entry, and the existing `dist/index.d.ts` legacy typings entry.
- `./dist/index.js` is kept as a compatibility export for Node consumers that used the old subpath; it redirects to the CJS or ESM file based on the resolver condition. Consumers that bypass package resolution and read the physical file still receive CommonJS.
- The runtime now also has a default export so existing native ESM default imports that worked through Node's CJS interop do not regress when they receive the new ESM entry.
- The DevTools regression build downloader uses `require.resolve` to move the downloaded runtime's CommonJS entry, so it works with both the current npm package's `dist/index.js` and this PR's `dist/index.cjs`.

## How did you test this change?

Commands run:

- `cd compiler && yarn install --frozen-lockfile`
- `cd compiler && yarn workspace react-compiler-runtime build --dts`
  - Verified tsup emits `dist/index.cjs`, `dist/index.js`, `dist/index.mjs`, `dist/index.d.cts`, `dist/index.d.mts`, and `dist/index.d.ts`.
- `cd compiler && yarn workspace react-compiler-runtime build`
  - Verified non-DTS builds still pass and the postbuild declaration step is a no-op when `dist/index.d.ts` is absent.
- `cd compiler && yarn workspace react-compiler-runtime test`
  - This package currently has no test suite; the script prints `no tests`.
- `node --check scripts/ci/download_devtools_regression_build.js`
- `node --check compiler/packages/react-compiler-runtime/scripts/postbuild.js`
- `yarn prettier`
- `git diff --check`
- `cd compiler/packages/react-compiler-runtime && npm pack --dry-run --json`
  - Verified the package tarball contains `dist/index.cjs`, the legacy CJS `dist/index.js`, `dist/index.mjs`, `dist/index.d.cts`, `dist/index.d.mts`, and `dist/index.d.ts`.

CJS compatibility checks:

- `node -e "const runtime = require('react-compiler-runtime'); console.log(require.resolve('react-compiler-runtime')); console.log(typeof runtime.c, typeof runtime.default.c);"`
  - Resolves to `compiler/packages/react-compiler-runtime/dist/index.cjs` and prints `function function`.
- Verified `package.json#main` remains `dist/index.js` for tools that ignore package `exports`.
- `node -e "const runtime = require('react-compiler-runtime/dist/index.js'); console.log(require.resolve('react-compiler-runtime/dist/index.js')); console.log(typeof runtime.c);"`
  - Verifies the old `dist/index.js` subpath compatibility export resolves to `dist/index.cjs` and prints `function`.
- `node -e "const runtime = require('./compiler/packages/react-compiler-runtime/dist/index.js'); console.log(typeof runtime.c);"`
  - Verifies direct physical-file access to the legacy `dist/index.js` file still returns CommonJS and prints `function`.

ESM configuration checks:

- `node --input-type=module -e "import runtime, {c} from 'react-compiler-runtime'; console.log(await import.meta.resolve('react-compiler-runtime')); console.log(typeof c, typeof runtime.c);"`
  - Resolves to `compiler/packages/react-compiler-runtime/dist/index.mjs` and prints `function function`.
- `node --input-type=module -e "import {c} from 'react-compiler-runtime/dist/index.js'; console.log(await import.meta.resolve('react-compiler-runtime/dist/index.js')); console.log(typeof c);"`
  - Verifies the old `dist/index.js` subpath compatibility export resolves to `dist/index.mjs` for ESM and prints `function`.
- `node --input-type=module -e "import runtime, {c} from './compiler/packages/react-compiler-runtime/dist/index.js'; console.log(typeof c, typeof runtime.c);"`
  - Verifies direct physical-file ESM import of the legacy CommonJS file still exposes the named and default interop exports and prints `function function`.

TypeScript declaration resolution checks:

- Created a temporary TypeScript `moduleResolution: Node16` project with an `.mts` importer and verified `react-compiler-runtime` resolves to `dist/index.d.mts`.
- Created a temporary TypeScript `moduleResolution: Node16` project with a `.cts` require importer and verified `react-compiler-runtime` resolves to `dist/index.d.cts`.
- Repeated the same Node16 checks for `react-compiler-runtime/dist/index.js`; ESM resolves to `dist/index.d.mts` and CJS resolves to `dist/index.d.cts`.
- Created a temporary TypeScript `moduleResolution: Node10` project and verified the package root resolves through the legacy `typings` field to `dist/index.d.ts`.

DevTools regression downloader compatibility checks:

- Installed `react-compiler-runtime@1.0.0` into a temporary prefix and verified `require.resolve('react-compiler-runtime', {paths: [prefix]})` resolves to the current npm package's `dist/index.js`.
- Verified the same resolver against the local workspace resolves to this PR's `dist/index.cjs`.
