### PR TITLE
[Fiber] Mark no-change ancestors during context propagation

### DIFF
--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -487,6 +487,23 @@ function propagateParentContextChanges(
       renderLanes,
       forcePropagateEntireTree,
     );
+  } else {
+    // If we looked and saw that there are no changed providers in the
+    // ancestors, mark it so that siblings can bail out early when walking
+    // through parents to check for provider changes.
+    for (
+      let ancestor = workInProgress.return;
+      ancestor !== null;
+      ancestor = ancestor.return
+    ) {
+      if (
+        (ancestor.flags & NeedsPropagation) !== NoFlags ||
+        (ancestor.flags & DidPropagateContext) !== NoFlags
+      ) {
+        break;
+      }
+      ancestor.flags |= DidPropagateContext;
+    }
   }
 
   // This is an optimization so that we only propagate once per subtree. If a

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -419,21 +419,11 @@ function propagateParentContextChanges(
   let contexts = null;
   let parent: null | Fiber = workInProgress;
   let isInsidePropagationBailout = false;
-  let walkSteps = 0;
-  let didEarlyBailout = false;
-  let stepsSavedThisWalk = 0;
-  const walkStartTime = performance.now();
   while (parent !== null) {
     if (!isInsidePropagationBailout) {
       if ((parent.flags & NeedsPropagation) !== NoFlags) {
         isInsidePropagationBailout = true;
       } else if ((parent.flags & DidPropagateContext) !== NoFlags) {
-        didEarlyBailout = true;
-        let remaining = parent.return;
-        while (remaining !== null) {
-          stepsSavedThisWalk++;
-          remaining = remaining.return;
-        }
         break;
       }
     }
@@ -485,25 +475,8 @@ function propagateParentContextChanges(
         }
       }
     }
-    walkSteps++;
     parent = parent.return;
   }
-
-  const walkDuration = performance.now() - walkStartTime;
-  const reachedRoot = parent === null && !didEarlyBailout;
-  console.log(
-    '[context propagation]',
-    didEarlyBailout
-      ? `early bailout, ${stepsSavedThisWalk} steps saved`
-      : reachedRoot
-        ? 'reached root'
-        : 'stopped',
-    `(walked ${walkSteps} steps, ${walkDuration.toFixed(3)} ms` +
-      (stepsSavedThisWalk > 0 && walkSteps > 0
-        ? `, ~${((walkDuration * stepsSavedThisWalk) / walkSteps).toFixed(3)} ms saved`
-        : '') +
-      ')',
-  );
 
   if (contexts !== null) {
     // If there were any changed providers, search through the children and

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -419,11 +419,21 @@ function propagateParentContextChanges(
   let contexts = null;
   let parent: null | Fiber = workInProgress;
   let isInsidePropagationBailout = false;
+  let walkSteps = 0;
+  let didEarlyBailout = false;
+  let stepsSavedThisWalk = 0;
+  const walkStartTime = performance.now();
   while (parent !== null) {
     if (!isInsidePropagationBailout) {
       if ((parent.flags & NeedsPropagation) !== NoFlags) {
         isInsidePropagationBailout = true;
       } else if ((parent.flags & DidPropagateContext) !== NoFlags) {
+        didEarlyBailout = true;
+        let remaining = parent.return;
+        while (remaining !== null) {
+          stepsSavedThisWalk++;
+          remaining = remaining.return;
+        }
         break;
       }
     }
@@ -475,8 +485,25 @@ function propagateParentContextChanges(
         }
       }
     }
+    walkSteps++;
     parent = parent.return;
   }
+
+  const walkDuration = performance.now() - walkStartTime;
+  const reachedRoot = parent === null && !didEarlyBailout;
+  console.log(
+    '[context propagation]',
+    didEarlyBailout
+      ? `early bailout, ${stepsSavedThisWalk} steps saved`
+      : reachedRoot
+        ? 'reached root'
+        : 'stopped',
+    `(walked ${walkSteps} steps, ${walkDuration.toFixed(3)} ms` +
+      (stepsSavedThisWalk > 0 && walkSteps > 0
+        ? `, ~${((walkDuration * stepsSavedThisWalk) / walkSteps).toFixed(3)} ms saved`
+        : '') +
+      ')',
+  );
 
   if (contexts !== null) {
     // If there were any changed providers, search through the children and


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

When React lazily propagates context changes, sibling fibers that bail out (because their own props/state didn't change, but they're siblings of a fiber that did update) each call propagateParentContextChanges, which walks up the fiber tree looking for changed context providers.

The `DidPropagateContext` flag already lets a fiber stop walking once it hits an ancestor that was previously checked, but only the current fiber was being marked, not the ancestors themselves. So every sibling still walked the full ancestor chain independently.

For ancestor chains that we've checked where there have been no context changes, siblings do not need to walk this full chain again as it's repeated work.

This change marks ancestors with `DidPropagateContext` when a walk confirms there are no changed providers above. Subsequent siblings can then bail out immediately when they hit a marked ancestor, instead of re-walking the same path.

This is a performance-only change; context propagation behavior is unchanged.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `yarn test ReactContextPropagation` -- clean, no regression
- `yarn prettier` -- clean
- `yarn flow dom-node ` -- clean

Temporarily applied the logging instrumentation below on top of the base react-native+0.81.5-wanderlog.17 patch in ReactNativeRenderer-prod.js. **Note:** the logging instrumentation was mostly auto-generated, although the PR implementation was manually written.

This is not included in the final PR:

<details>
<summary>Logging stub + fix diff (apply to ReactNativeRenderer-prod.js)</summary>

```
@@ after scheduleContextWorkOnParentPath
+var __propagateParentContextChangesTotalMs = 0;
+var __propagateParentContextChangesCallCount = 0;
+var __propagateParentEarlyBreakCount = 0;
+var __propagateParentReachedRootCount = 0;
+var __propagateParentNoopCount = 0;
+var __propagateParentDidPropagateCount = 0;
+setInterval(function () {
+  var propagateParentTotalMs = __propagateParentContextChangesTotalMs;
+  var propagateParentCount = __propagateParentContextChangesCallCount;
+  if (propagateParentCount === 0) return;
+  var earlyBreak = __propagateParentEarlyBreakCount;
+  var reachedRoot = __propagateParentReachedRootCount;
+  var noop = __propagateParentNoopCount;
+  var propagated = __propagateParentDidPropagateCount;
+  __propagateParentContextChangesTotalMs = 0;
+  __propagateParentContextChangesCallCount = 0;
+  __propagateParentEarlyBreakCount = 0;
+  __propagateParentReachedRootCount = 0;
+  __propagateParentNoopCount = 0;
+  __propagateParentDidPropagateCount = 0;
+  console.log(
+    "[propagateParentContextChanges] " +
+      propagateParentCount +
+      " calls, " +
+      propagateParentTotalMs.toFixed(1) +
+      "ms total, avg " +
+      (propagateParentTotalMs / propagateParentCount).toFixed(2) +
+      "ms | earlyBreak(262144): " +
+      earlyBreak +
+      ", reachedRoot: " +
+      reachedRoot +
+      ", noop: " +
+      noop +
+      ", propagated: " +
+      propagated,
+  );
+}, 5000);

@@ function propagateParentContextChanges
 function propagateParentContextChanges(
   workInProgress,
   current,
   renderLanes,
   forcePropagateEntireTree
 ) {
-  current = null;
-  for (
-    var parent = workInProgress, isInsidePropagationBailout = !1;
-    null !== parent;
-  ) {
-    if (!isInsidePropagationBailout)
-      if (0 !== (parent.flags & 524288)) isInsidePropagationBailout = !0;
-      else if (0 !== (parent.flags & 262144)) break;
-    if (10 === parent.tag) {
-      var currentParent = parent.alternate;
-      if (null === currentParent)
-        throw Error("Should have a current fiber. This is a bug in React.");
-      currentParent = currentParent.memoizedProps;
-      if (null !== currentParent) {
-        var context = parent.type;
-        objectIs(parent.pendingProps.value, currentParent.value) ||
-          (null !== current ? current.push(context) : (current = [context]));
+  var __propagateParentStart = now();
+  try {
+    current = null;
+    var __propagateParentExitReason = "reachedRoot";
+    for (
+      var parent = workInProgress, isInsidePropagationBailout = !1;
+      null !== parent;
+    ) {
+      if (!isInsidePropagationBailout)
+        if (0 !== (parent.flags & 524288)) isInsidePropagationBailout = !0;
+        else if (0 !== (parent.flags & 262144)) {
+          __propagateParentExitReason = "earlyBreak";
+          break;
+        }
+      if (10 === parent.tag) {
+        var currentParent = parent.alternate;
+        if (null === currentParent)
+          throw Error("Should have a current fiber. This is a bug in React.");
+        currentParent = currentParent.memoizedProps;
+        if (null !== currentParent) {
+          var context = parent.type;
+          objectIs(parent.pendingProps.value, currentParent.value) ||
+            (null !== current ? current.push(context) : (current = [context]));
+        }
+      } else if (parent === hostTransitionProviderCursor.current) {
+        currentParent = parent.alternate;
+        if (null === currentParent)
+          throw Error("Should have a current fiber. This is a bug in React.");
+        currentParent.memoizedState.memoizedState !==
+          parent.memoizedState.memoizedState &&
+          (null !== current
+            ? current.push(HostTransitionContext)
+            : (current = [HostTransitionContext]));
       }
-    } else if (parent === hostTransitionProviderCursor.current) {
-      currentParent = parent.alternate;
-      if (null === currentParent)
-        throw Error("Should have a current fiber. This is a bug in React.");
-      currentParent.memoizedState.memoizedState !==
-        parent.memoizedState.memoizedState &&
-        (null !== current
-          ? current.push(HostTransitionContext)
-          : (current = [HostTransitionContext]));
+      parent = parent.return;
     }
-    parent = parent.return;
+    if (__propagateParentExitReason === "earlyBreak") {
+      __propagateParentEarlyBreakCount += 1;
+    } else {
+      __propagateParentReachedRootCount += 1;
+    }
+    if (null !== current) {
+      __propagateParentDidPropagateCount += 1;
+      propagateContextChanges(
+        workInProgress,
+        current,
+        renderLanes,
+        forcePropagateEntireTree
+      );
+    } else {
+      __propagateParentNoopCount += 1;
+      // ← fix: mark ancestors so sibling subtrees bail out early. these numbers are equivalent to the flags in the PR
+      for (
+        var ancestor = workInProgress.return;
+        null !== ancestor;
+        ancestor = ancestor.return
+      ) {
+        if (0 !== (ancestor.flags & 262144)) break;
+        ancestor.flags |= 262144;
+      }
+    }
+    workInProgress.flags |= 262144;
+  } finally {
+    __propagateParentContextChangesTotalMs += now() - __propagateParentStart;
+    __propagateParentContextChangesCallCount += 1;
   }
-  null !== current &&
-    propagateContextChanges(
-      workInProgress,
-      current,
-      renderLanes,
-      forcePropagateEntireTree
-    );
-  workInProgress.flags |= 262144;
 }
```
</details>

To benchmark before vs after: run once with logging only (keep the original null !== current && propagateContextChanges(...) at the bottom, but remove the else block), then again with the full diff above.

## Steps:
1. Build the app with the logging stub applied
2. Open the app and scroll for about 30s
3. Tail logs (emitted every 5 seconds):
```
adb logcat | rg 'propagateParentContextChanges'
```
4. Aggregate stats across all log windows for each run.

| Metric | Before (15 windows) | After (27 windows) | Change |
|--------|--------------------:|-------------------:|--------|
| Total calls | 290,502 | 930,782 | — |
| Total time | 11,594 ms | 4,722 ms | −59% |
| Avg per call | ~0.040 ms | ~0.005 ms | ~8× faster |
| earlyBreak hits | 0 (0%) | ~857,000 (~92%) | added |
| reachedRoot | 290,502 (100%) | ~73,000 (~8%) | mostly skipped |
| noop exits | 0 (0%) | ~857,000 (~92%) | added |
| propagated | ~5,704 (~2.0%) | ~24,000 (~2.6%) | similar rate |

Original logs:

<details>
<summary>Before the change</summary>

```

06-30 01:21:17.917 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 1782 calls, 18.5ms total, avg 0.01ms | earlyBreak(262144): 1319, reachedRoot: 463, noop: 1505, propagated: 277
06-30 01:21:22.840 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 22596 calls, 75.2ms total, avg 0.00ms | earlyBreak(262144): 21423, reachedRoot: 1173, noop: 22430, propagated: 166
06-30 01:21:31.209 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 31396 calls, 438.4ms total, avg 0.01ms | earlyBreak(262144): 23465, reachedRoot: 7931, noop: 25297, propagated: 6099
06-30 01:21:33.629 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 8173 calls, 102.6ms total, avg 0.01ms | earlyBreak(262144): 6045, reachedRoot: 2128, noop: 6888, propagated: 1285
06-30 01:21:38.560 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 19377 calls, 244.5ms total, avg 0.01ms | earlyBreak(262144): 15320, reachedRoot: 4057, noop: 16656, propagated: 2721
06-30 01:21:42.964 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 31582 calls, 116.5ms total, avg 0.00ms | earlyBreak(262144): 30540, reachedRoot: 1042, noop: 31482, propagated: 100
06-30 01:21:48.019 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 51012 calls, 130.8ms total, avg 0.00ms | earlyBreak(262144): 49747, reachedRoot: 1265, noop: 50962, propagated: 50
06-30 01:22:49.530 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 71923 calls, 974.1ms total, avg 0.01ms | earlyBreak(262144): 66716, reachedRoot: 5207, noop: 71697, propagated: 226
06-30 01:22:57.374 26952 27159 I ReactNativeJS: [propagateParentContextChanges] 57999 calls, 514.0ms total, avg 0.01ms | earlyBreak(262144): 55450, reachedRoot: 2549, noop: 56854, propagated: 1145
06-30 01:24:15.183 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 1843 calls, 18.1ms total, avg 0.01ms | earlyBreak(262144): 1373, reachedRoot: 470, noop: 1566, propagated: 277
06-30 01:24:20.104 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 22639 calls, 73.7ms total, avg 0.00ms | earlyBreak(262144): 21432, reachedRoot: 1207, noop: 22473, propagated: 166
06-30 01:24:29.640 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 38554 calls, 466.1ms total, avg 0.01ms | earlyBreak(262144): 29685, reachedRoot: 8869, noop: 31640, propagated: 6914
06-30 01:24:31.940 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 9810 calls, 31.1ms total, avg 0.00ms | earlyBreak(262144): 9159, reachedRoot: 651, noop: 9810, propagated: 0
06-30 01:24:37.632 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 39107 calls, 170.5ms total, avg 0.00ms | earlyBreak(262144): 36663, reachedRoot: 2444, noop: 38111, propagated: 996
06-30 01:24:40.525 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 15979 calls, 73.4ms total, avg 0.00ms | earlyBreak(262144): 15144, reachedRoot: 835, noop: 15888, propagated: 91
06-30 01:24:45.655 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 39072 calls, 114.1ms total, avg 0.00ms | earlyBreak(262144): 37796, reachedRoot: 1276, noop: 39022, propagated: 50
06-30 01:24:51.998 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 40348 calls, 98.1ms total, avg 0.00ms | earlyBreak(262144): 38986, reachedRoot: 1362, noop: 40348, propagated: 0
06-30 01:24:56.434 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 26434 calls, 66.4ms total, avg 0.00ms | earlyBreak(262144): 25597, reachedRoot: 837, noop: 26434, propagated: 0
06-30 01:25:01.239 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 40262 calls, 87.0ms total, avg 0.00ms | earlyBreak(262144): 39308, reachedRoot: 954, noop: 40262, propagated: 0
06-30 01:25:06.427 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 45709 calls, 111.4ms total, avg 0.00ms | earlyBreak(262144): 44325, reachedRoot: 1384, noop: 45709, propagated: 0
06-30 01:25:11.345 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 55130 calls, 114.4ms total, avg 0.00ms | earlyBreak(262144): 53865, reachedRoot: 1265, noop: 55130, propagated: 0
06-30 01:25:16.530 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 54580 calls, 120.4ms total, avg 0.00ms | earlyBreak(262144): 53200, reachedRoot: 1380, noop: 54580, propagated: 0
06-30 01:25:21.332 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 55229 calls, 126.1ms total, avg 0.00ms | earlyBreak(262144): 53781, reachedRoot: 1448, noop: 55229, propagated: 0
06-30 01:25:26.302 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 48992 calls, 127.7ms total, avg 0.00ms | earlyBreak(262144): 47537, reachedRoot: 1455, noop: 48992, propagated: 0
06-30 01:25:31.875 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 62248 calls, 175.7ms total, avg 0.00ms | earlyBreak(262144): 59937, reachedRoot: 2311, noop: 62248, propagated: 0
06-30 01:25:36.504 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 53053 calls, 133.0ms total, avg 0.00ms | earlyBreak(262144): 51105, reachedRoot: 1948, noop: 53053, propagated: 0
06-30 01:25:41.465 28163 28378 I ReactNativeJS: [propagateParentContextChanges] 54001 calls, 82.2ms total, avg 0.00ms | earlyBreak(262144): 53739, reachedRoot: 262, noop: 54001, propagated: 0

```

</details>

<details>
<summary>After the change</summary>

```
06-30 01:28:25.531 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 732 calls, 17.0ms total, avg 0.02ms | earlyBreak(262144): 0, reachedRoot: 732, noop: 0, propagated: 154
06-30 01:28:30.917 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 11822 calls, 435.5ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 11822, noop: 0, propagated: 360
06-30 01:28:36.274 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 28806 calls, 950.3ms total, avg 0.03ms | earlyBreak(262144): 0, reachedRoot: 28806, noop: 0, propagated: 1651
06-30 01:28:41.810 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 6039 calls, 256.4ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 6039, noop: 0, propagated: 1991
06-30 01:28:46.607 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 19254 calls, 581.6ms total, avg 0.03ms | earlyBreak(262144): 0, reachedRoot: 19254, noop: 0, propagated: 312
06-30 01:28:51.960 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 16566 calls, 589.6ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 16566, noop: 0, propagated: 280
06-30 01:28:57.713 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 15515 calls, 592.0ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 15515, noop: 0, propagated: 906
06-30 01:29:03.084 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 28643 calls, 1106.2ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 28643, noop: 0, propagated: 50
06-30 01:29:06.574 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 23287 calls, 956.7ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 23287, noop: 0, propagated: 0
06-30 01:29:11.718 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 40801 calls, 1521.1ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 40801, noop: 0, propagated: 0
06-30 01:29:16.466 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 39349 calls, 1424.5ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 39349, noop: 0, propagated: 0
06-30 01:29:21.752 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 44382 calls, 1682.6ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 44382, noop: 0, propagated: 0
06-30 01:29:26.701 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 44976 calls, 1717.2ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 44976, noop: 0, propagated: 0
06-30 01:29:31.518 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 47184 calls, 1857.1ms total, avg 0.04ms | earlyBreak(262144): 0, reachedRoot: 47184, noop: 0, propagated: 0
06-30 01:29:36.514 28933 29147 I ReactNativeJS: [propagateParentContextChanges] 5666 calls, 326.8ms total, avg 0.06ms | earlyBreak(262144): 0, reachedRoot: 5666, noop: 0, propagated: 0
```

</details>