### PR TITLE
[Fiber] Rebase render phase updates on top of skipped updates

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1609,6 +1609,26 @@ function rerenderReducer<S, I, A>(
       // render's.
       const action = update.action;
       newState = reducer(newState, action);
+
+      const baseQueueLast = hook.baseQueue;
+      if (baseQueueLast !== null) {
+        // There are skipped updates in the base queue. This update needs to
+        // be rebased on top of them when the base queue is processed, so
+        // append a clone to the end. Use NoLane so it's never skipped.
+        const clone: Update<S, A> = {
+          lane: NoLane,
+          revertLane: NoLane,
+          gesture: null,
+          action,
+          hasEagerState: update.hasEagerState,
+          eagerState: update.eagerState,
+          next: null as any,
+        };
+        clone.next = baseQueueLast.next;
+        baseQueueLast.next = clone;
+        hook.baseQueue = clone;
+      }
+
       update = update.next;
     } while (update !== firstRenderPhaseUpdate);
 
@@ -1620,9 +1640,9 @@ function rerenderReducer<S, I, A>(
 
     hook.memoizedState = newState;
     // Don't persist the state accumulated from the render phase updates to
-    // the base state unless the queue is empty.
-    // TODO: Not sure if this is the desired semantics, but it's what we
-    // do for gDSFP. I can't remember why.
+    // the base state unless the queue is empty. If it's not empty, the
+    // render phase updates were appended to the base queue above so that
+    // they're replayed when it's processed.
     if (hook.baseQueue === null) {
       hook.baseState = newState;
     }

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -824,6 +824,89 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(root).toMatchRenderedOutput(<span prop="Down" />);
     });
 
+    it('rebases a skipped eagerly bailed-out update on top of a render phase update', async () => {
+      let setState;
+
+      function App({step}) {
+        const [state, _setState] = useState(0);
+        setState = _setState;
+        Scheduler.log(`Render step=${step} state=${state}`);
+        if (state < step) {
+          _setState(step);
+        }
+        return <Text text={state} />;
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(() => root.render(<App step={0} />));
+      assertLog(['Render step=0 state=0', 0]);
+
+      // Set state to the same value. This bails out eagerly: nothing is
+      // scheduled, but the update is left in the queue (at DefaultLane) in
+      // case it needs to be rebased later.
+      await act(() => setState(0));
+      assertLog([]);
+
+      // Render at higher priority (SyncLane). The pending DefaultLane
+      // update is skipped and kept in the base queue.
+      await act(() => {
+        ReactNoop.flushSync(() => root.render(<App step={1} />));
+      });
+      assertLog([
+        'Render step=1 state=0',
+        // Render phase update:
+        'Render step=1 state=1',
+        1,
+        // Extra render at DefaultLane to process the skipped update, with
+        // the render phase update rebased on top of it. The state doesn't
+        // change, so the children bail out and nothing new is committed:
+        'Render step=1 state=1',
+      ]);
+      expect(root).toMatchRenderedOutput(<span prop={1} />);
+    });
+
+    it('regression: render phase update lost when rebasing a skipped update', async () => {
+      // Same as above, except the render phase update is guarded by a
+      // prevTarget state (the getDerivedStateFromProps pattern), so it does
+      // not re-fire during the rebase render. Previously the render phase
+      // update was dropped from the queue, so the rebase replayed only the
+      // stale bailed-out update and the committed state regressed to 'A'.
+      let setValue;
+
+      function App({target}) {
+        const [value, _setValue] = useState('A');
+        const [prevTarget, setPrevTarget] = useState(target);
+        setValue = _setValue;
+        Scheduler.log(`Render target=${target} value=${value}`);
+        if (target !== prevTarget) {
+          setPrevTarget(target);
+          _setValue(target);
+        }
+        return <Text text={value} />;
+      }
+
+      const root = ReactNoop.createRoot();
+      await act(() => root.render(<App target="A" />));
+      assertLog(['Render target=A value=A', 'A']);
+
+      // Eagerly bails out but stays in the queue at DefaultLane.
+      await act(() => setValue('A'));
+      assertLog([]);
+
+      await act(() => {
+        ReactNoop.flushSync(() => root.render(<App target="B" />));
+      });
+      assertLog([
+        'Render target=B value=A',
+        'Render target=B value=B',
+        'B',
+        // Rebase render at DefaultLane; the state doesn't change, so the
+        // children bail out and nothing new is committed:
+        'Render target=B value=B',
+      ]);
+      expect(root).toMatchRenderedOutput(<span prop="B" />);
+    });
+
     // TODO: This should probably warn
     it('calling startTransition inside render phase', async () => {
       function App() {


### PR DESCRIPTION
If a render phase update is done at a time when the same useState Hook has some skipped (lower priority) updates in its queue, we were previously not recording the render phase updates in the queue and they would not be carried over to when we when we render at the lower priority and reprocess the entire queue.

It's not _entirely_ intuitive to me that this behavior is wrong -- you might argue that render phase updates can be re-derived in the later renders and that they're not really stateful... but I think the test cases here are pretty persuasive. In particular, given that render phase updates to a different useState (that doesn't have an parallel low-priority update in the queue) are retained, it's quite surprising to drop one and not the other.

The first test previously committed twice unnecessarily:

```js
assertLog([
  'Render step=1 state=0',
  'Render step=1 state=1',
  1,
  // Rebase render: the render phase update was dropped from the queue, so
  // replaying the base queue regresses the state...
  'Render step=1 state=0',
  // ...which re-fires the render phase update...
  'Render step=1 state=1',
  // ...and since the first rebase pass saw a changed state, the children
  // re-render and re-commit:
  1,
]);
expect(root).toMatchRenderedOutput(<span prop={1} />);
```

whereas the second test clearly ends in an incorrect-seeming state (`target`, `value`, and the committed result should always match):

```js
assertLog([
  'Render target=B value=A',
  'Render target=B value=B',
  'B',
  // Rebase render: value's render phase update was dropped, but prevTarget
  // kept its render phase value 'B', so the guard doesn't re-fire and the
  // stale bailed-out update wins:
  'Render target=B value=A',
  'A',
]);
expect(root).toMatchRenderedOutput(<span prop="A" />); // regressed!
```

Fix this by appending render phase updates to the base queue as NoLane clones when there are skipped updates to rebase, the same way updateReducerImpl does. This also resolves an old TODO questioning these semantics.

Fixes #36372.
