### PR TITLE
Permit non-DEV Async Dispatchers in JSX Runtime w/ DEV

### DIFF
--- a/packages/react/src/__tests__/ReactJSXRuntime-test.js
+++ b/packages/react/src/__tests__/ReactJSXRuntime-test.js
@@ -376,4 +376,38 @@ describe('ReactJSXRuntime', () => {
     ]);
     expect(elementWithSpreadKey.props).not.toBe(configWithKey);
   });
+
+  it('does not throw when the current dispatcher lacks DEV-only methods', () => {
+    // A production-built renderer (e.g. a precompiled react-reconciler
+    // embedded in a third-party library) installs an async dispatcher that
+    // does not implement DEV-only methods such as `getOwner` while it
+    // renders. Creating elements during such a render pass should treat the
+    // owner as unknown instead of crashing.
+    const ReactSharedInternals =
+      React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+    const previousDispatcher = ReactSharedInternals.A;
+    ReactSharedInternals.A = {
+      getCacheForType() {
+        return null;
+      },
+    };
+    try {
+      const elements = [
+        JSXRuntime.jsx('div', {}),
+        JSXRuntime.jsxs('div', {children: []}),
+        React.createElement('div', {}),
+      ];
+      if (__DEV__) {
+        elements.push(JSXDEVRuntime.jsxDEV('div', {}, undefined, false));
+      }
+      elements.forEach(element => {
+        expect(element.type).toBe('div');
+        if (__DEV__) {
+          expect(element._owner == null).toBe(true);
+        }
+      });
+    } finally {
+      ReactSharedInternals.A = previousDispatcher;
+    }
+  });
 });

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -50,7 +50,10 @@ function getTaskName(type) {
 function getOwner() {
   if (__DEV__) {
     const dispatcher = ReactSharedInternals.A;
-    if (dispatcher === null) {
+    if (dispatcher === null || typeof dispatcher.getOwner !== 'function') {
+      // The current dispatcher may have been installed by a production-built
+      // renderer (e.g. a precompiled react-reconciler embedded in a library),
+      // which does not implement DEV-only methods. The owner is unknown.
       return null;
     }
     return dispatcher.getOwner();


### PR DESCRIPTION
## Summary

The DEV-only `getOwner()` helper in `ReactJSXElement.js` assumes any non-`null` async dispatcher on `ReactSharedInternals.A` implements `getOwner()`. That holds when every renderer on the page is built in the same mode as the `react` package — but a production-built renderer installs a dispatcher without DEV-only methods while it renders. Any element created during such a render pass (via `jsx`, `jsxs`, `jsxDEV`, or `createElement` from a DEV-mode `react`) then crashes:

```
TypeError: dispatcher.getOwner is not a function
```

This is the renderer-flavored version of the situation addressed in #32117 ("Permit non-`DEV` Elements in `React.Children` w/ `DEV`"): third-party artifacts frequently ship a single entrypoint compiled for production — including precompiled copies of `react-reconciler` embedded in libraries or module-federation remotes — and end up running inside an application whose `react` is the development build. The element-shaped side of that mix was made graceful in #32117; the dispatcher-shaped side still crashes.

Concrete reproduction from a real app: a Vite dev-server host shares its development `react` / `react/jsx-runtime` as module-federation singletons with a production-built remote that renders a `@react-three/fiber` scene. The remote's bundled production `react-reconciler` sets `ReactSharedInternals.A = DefaultAsyncDispatcher` (production build — `getCacheForType` only) for the duration of its render pass, and the first JSX element created through the shared DEV jsx-runtime throws. The same app built for production works, since the production jsx-runtime never calls `getOwner`.

Treat such dispatchers the same as no dispatcher: the owner is unknown, return `null`, and owner stacks degrade gracefully (exactly what already happens for elements created outside a render pass).

@gnoff For your reference, the original change was introduced in https://github.com/react/react/pull/28912/changes#diff-dbd72a473871eeddbe00ceed54a59bff33e6324ffdea15cb4ee3abbdad988cfbR35

## How did you test this change?

- Added a test to `ReactJSXRuntime-test.js` that installs a production-shaped async dispatcher (only `getCacheForType`) on `ReactSharedInternals.A` and creates elements via `jsx`, `jsxs`, `createElement`, and (in DEV) `jsxDEV`. Without the fix it fails with `TypeError: dispatcher.getOwner is not a function`; with the fix all elements are created with a `null` owner.
- `yarn test packages/react/src/__tests__/ReactJSXRuntime-test.js` — 16 passed (DEV)
- `yarn test --prod packages/react/src/__tests__/ReactJSXRuntime-test.js` — 16 passed
- `yarn linc` / prettier — clean

Note: `ReactFlightClient.js` has one analogous call site (`ReactSharedInteralsServer.A.getOwner()` in the Flight debug-info path); left untouched to keep this minimal, but happy to apply the same guard if desired.
