### PR TITLE
[DevTools] Sort numeric keys before non-numeric keys

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/devtoolsViewsUtils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/devtoolsViewsUtils-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+describe('devtools/views/utils', () => {
+  let alphaSortEntries;
+
+  beforeEach(() => {
+    alphaSortEntries =
+      require('react-devtools-shared/src/devtools/views/utils').alphaSortEntries;
+  });
+
+  describe('alphaSortEntries', () => {
+    it('should sort numeric keys numerically and before non-numeric keys', () => {
+      const entries: Array<[string, mixed]> = [
+        ['2', null],
+        ['foo', null],
+        ['10', null],
+        ['1', null],
+      ];
+      entries.sort(alphaSortEntries);
+      expect(entries.map(entry => entry[0])).toEqual(['1', '2', '10', 'foo']);
+    });
+
+    it('should sort numeric keys before non-numeric keys that start with punctuation', () => {
+      // '$' (char code 36) and '#' (35) are less than '0' (48), so comparing a
+      // punctuation-prefixed key against a numeric key must not fall back to a
+      // plain string comparison; numeric keys always sort first.
+      const entries: Array<[string, mixed]> = [
+        ['$ref', null],
+        ['0', null],
+        ['#id', null],
+      ];
+      entries.sort(alphaSortEntries);
+      expect(entries.map(entry => entry[0])).toEqual(['0', '#id', '$ref']);
+    });
+
+    it('should be antisymmetric for numeric and non-numeric keys', () => {
+      const numeric: [string, mixed] = ['5', null];
+      const nonNumeric: [string, mixed] = ['$ref', null];
+      expect(alphaSortEntries(numeric, nonNumeric)).toBe(
+        -alphaSortEntries(nonNumeric, numeric),
+      );
+    });
+  });
+});

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -29,6 +29,9 @@ export function alphaSortEntries(
     }
     return +a < +b ? -1 : 1;
   }
+  if (String(+b) === b) {
+    return 1;
+  }
   return a < b ? -1 : 1;
 }
 


### PR DESCRIPTION
## Summary
alphaSortEntries orders the entries shown in DevTools' inspected element Props, State and Context panels. When it compared a non-numeric key against a numeric one it fell through to a plain string comparison, so a key starting with a character below "0" (like "$ref" or "#id") sorted before numeric keys instead of after them, and the comparator became asymmetric, which could produce inconsistent orderings. This returns 1 when the other key is numeric so numeric keys always sort first.

## Testing
Added devtoolsViewsUtils-test.js covering numeric ordering, numeric keys sorting before punctuation-prefixed keys, and comparator antisymmetry. The new tests fail on the old implementation and pass with the fix. Verified with yarn test --build --project devtools; yarn prettier and yarn linc pass.

## Checklist
- [x] Bug reproduced before the fix
- [x] Root cause identified
- [x] Fix implemented
- [x] Tests passed
- [x] Final diff reviewed
