### PR TITLE
[Fizz] Batch attribute and style serialization into single pushes

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1248,15 +1248,13 @@ function pushViewTransitionAttributes(
   }
 }
 
-const styleNameCache: Map<string, PrecomputedChunk> = new Map();
-function processStyleName(styleName: string): PrecomputedChunk {
-  const chunk = styleNameCache.get(styleName);
-  if (chunk !== undefined) {
-    return chunk;
+const styleNameCache: Map<string, string> = new Map();
+function processStyleName(styleName: string): string {
+  const cached = styleNameCache.get(styleName);
+  if (cached !== undefined) {
+    return cached;
   }
-  const result = stringToPrecomputedChunk(
-    escapeTextForBrowser(hyphenateStyleName(styleName)),
-  );
+  const result = escapeTextForBrowser(hyphenateStyleName(styleName));
   styleNameCache.set(styleName, result);
   return result;
 }
@@ -1277,7 +1275,7 @@ function pushStyleAttribute(
     );
   }
 
-  let isFirst = true;
+  let styleString = '';
   for (const styleName in style) {
     if (!hasOwnProperty.call(style, styleName)) {
       continue;
@@ -1299,48 +1297,42 @@ function pushStyleAttribute(
       continue;
     }
 
-    let nameChunk;
-    let valueChunk;
+    let nameStr;
+    let valueStr;
     const isCustomProperty = styleName.indexOf('--') === 0;
     if (isCustomProperty) {
-      nameChunk = stringToChunk(escapeTextForBrowser(styleName));
+      nameStr = escapeTextForBrowser(styleName);
       if (__DEV__) {
         checkCSSPropertyStringCoercion(styleValue, styleName);
       }
-      valueChunk = stringToChunk(
-        escapeTextForBrowser(('' + styleValue).trim()),
-      );
+      valueStr = escapeTextForBrowser(('' + styleValue).trim());
     } else {
       if (__DEV__) {
         warnValidStyle(styleName, styleValue);
       }
 
-      nameChunk = processStyleName(styleName);
+      nameStr = processStyleName(styleName);
       if (typeof styleValue === 'number') {
         if (styleValue !== 0 && !isUnitlessNumber(styleName)) {
-          valueChunk = stringToChunk(styleValue + 'px'); // Presumes implicit 'px' suffix for unitless numbers
+          valueStr = styleValue + 'px'; // Presumes implicit 'px' suffix for unitless numbers
         } else {
-          valueChunk = stringToChunk('' + styleValue);
+          valueStr = '' + styleValue;
         }
       } else {
         if (__DEV__) {
           checkCSSPropertyStringCoercion(styleValue, styleName);
         }
-        valueChunk = stringToChunk(
-          escapeTextForBrowser(('' + styleValue).trim()),
-        );
+        valueStr = escapeTextForBrowser(('' + styleValue).trim());
       }
     }
-    if (isFirst) {
-      isFirst = false;
-      // If it's first, we don't need any separators prefixed.
-      target.push(styleAttributeStart, nameChunk, styleAssign, valueChunk);
+    if (styleString === '') {
+      styleString = nameStr + ':' + valueStr;
     } else {
-      target.push(styleSeparator, nameChunk, styleAssign, valueChunk);
+      styleString += ';' + nameStr + ':' + valueStr;
     }
   }
-  if (!isFirst) {
-    target.push(attributeEnd);
+  if (styleString !== '') {
+    target.push(stringToChunk(' style="' + styleString + '"'));
   }
 }
 
@@ -1355,7 +1347,7 @@ function pushBooleanAttribute(
   value: string | boolean | number | Function | Object, // not null or undefined
 ): void {
   if (value && typeof value !== 'function' && typeof value !== 'symbol') {
-    target.push(attributeSeparator, stringToChunk(name), attributeEmptyString);
+    target.push(stringToChunk(' ' + name + '=""'));
   }
 }
 
@@ -1370,11 +1362,7 @@ function pushStringAttribute(
     typeof value !== 'boolean'
   ) {
     target.push(
-      attributeSeparator,
-      stringToChunk(name),
-      attributeAssign,
-      stringToChunk(escapeTextForBrowser(value)),
-      attributeEnd,
+      stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
     );
   }
 }
@@ -1679,11 +1667,9 @@ function pushAttribute(
       }
       const sanitizedValue = sanitizeURL('' + value);
       target.push(
-        attributeSeparator,
-        stringToChunk(name),
-        attributeAssign,
-        stringToChunk(escapeTextForBrowser(sanitizedValue)),
-        attributeEnd,
+        stringToChunk(
+          ' ' + name + '="' + escapeTextForBrowser(sanitizedValue) + '"',
+        ),
       );
       return;
     }
@@ -1714,11 +1700,9 @@ function pushAttribute(
       }
       const sanitizedValue = sanitizeURL('' + value);
       target.push(
-        attributeSeparator,
-        stringToChunk('xlink:href'),
-        attributeAssign,
-        stringToChunk(escapeTextForBrowser(sanitizedValue)),
-        attributeEnd,
+        stringToChunk(
+          ' xlink:href="' + escapeTextForBrowser(sanitizedValue) + '"',
+        ),
       );
       return;
     }
@@ -1736,11 +1720,9 @@ function pushAttribute(
       // these aren't boolean attributes (they are coerced to strings).
       if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1797,20 +1779,14 @@ function pushAttribute(
     case 'download': {
       // Overloaded Boolean
       if (value === true) {
-        target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeEmptyString,
-        );
+        target.push(stringToChunk(' ' + name + '=""'));
       } else if (value === false) {
         // Ignored
       } else if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1827,11 +1803,9 @@ function pushAttribute(
         (value as any) >= 1
       ) {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1845,11 +1819,9 @@ function pushAttribute(
         !isNaN(value)
       ) {
         target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
+          ),
         );
       }
       return;
@@ -1907,11 +1879,13 @@ function pushAttribute(
           }
         }
         target.push(
-          attributeSeparator,
-          stringToChunk(attributeName),
-          attributeAssign,
-          stringToChunk(escapeTextForBrowser(value)),
-          attributeEnd,
+          stringToChunk(
+            ' ' +
+              attributeName +
+              '="' +
+              escapeTextForBrowser(value) +
+              '"',
+          ),
         );
       }
   }
@@ -2026,14 +2000,12 @@ function pushStartAnchor(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  target.push(endOfStartTag);
-  pushInnerHTML(target, innerHTML, children);
-  if (typeof children === 'string') {
-    // Special case children as a string to avoid the unnecessary comment.
-    // TODO: Remove this special case after the general optimization is in place.
-    target.push(stringToChunk(encodeHTMLTextNode(children)));
+  if (innerHTML == null && typeof children === 'string') {
+    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
     return null;
   }
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 
@@ -4033,14 +4005,13 @@ function pushStartGenericElement(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  target.push(endOfStartTag);
-  pushInnerHTML(target, innerHTML, children);
-  if (typeof children === 'string') {
-    // Special case children as a string to avoid the unnecessary comment.
-    // TODO: Remove this special case after the general optimization is in place.
-    target.push(stringToChunk(encodeHTMLTextNode(children)));
+  if (innerHTML == null && typeof children === 'string') {
+    // Fast path: close tag and emit text child in a single push.
+    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
     return null;
   }
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1346,18 +1346,6 @@ function styleAttributeToString(style: Object): string {
   return '';
 }
 
-function pushStyleAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
-  style: Object,
-): void {
-  const attr = styleAttributeToString(style);
-  if (attr !== '') {
-    target.push(stringToChunk(attr));
-  }
-}
-
-const attributeSeparator = stringToPrecomputedChunk(' ');
-const attributeAssign = stringToPrecomputedChunk('="');
 const attributeEnd = stringToPrecomputedChunk('"');
 
 function booleanAttributeToString(
@@ -1368,17 +1356,6 @@ function booleanAttributeToString(
     return ' ' + name + '=""';
   }
   return '';
-}
-
-function pushBooleanAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
-  name: string,
-  value: string | boolean | number | Function | Object, // not null or undefined
-): void {
-  const attr = booleanAttributeToString(name, value);
-  if (attr !== '') {
-    target.push(stringToChunk(attr));
-  }
 }
 
 function stringAttributeToString(
@@ -1395,17 +1372,6 @@ function stringAttributeToString(
   return '';
 }
 
-function pushStringAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
-  name: string,
-  value: string | boolean | number | Function | Object, // not null or undefined
-): void {
-  const attr = stringAttributeToString(name, value);
-  if (attr !== '') {
-    target.push(stringToChunk(attr));
-  }
-}
-
 function makeFormFieldPrefix(resumableState: ResumableState): string {
   // TODO: Make this deterministic.
   const id = resumableState.nextFormID++;
@@ -1414,14 +1380,10 @@ function makeFormFieldPrefix(resumableState: ResumableState): string {
 
 // Since this will likely be repeated a lot in the HTML, we use a more concise message
 // than on the client and hopefully it's googleable.
-const actionJavaScriptURL = stringToPrecomputedChunk(
-  escapeTextForBrowser(
-    // eslint-disable-next-line no-script-url
-    "javascript:throw new Error('React form unexpectedly submitted.')",
-  ),
+const actionJavaScriptURL = escapeTextForBrowser(
+  // eslint-disable-next-line no-script-url
+  "javascript:throw new Error('React form unexpectedly submitted.')",
 );
-
-const startHiddenInputChunk = stringToPrecomputedChunk('<input type="hidden"');
 
 function pushAdditionalFormField(
   this: Array<Chunk | PrecomputedChunk>,
@@ -1429,11 +1391,15 @@ function pushAdditionalFormField(
   key: string,
 ): void {
   const target: Array<Chunk | PrecomputedChunk> = this;
-  target.push(startHiddenInputChunk);
   validateAdditionalFormField(value, key);
-  pushStringAttribute(target, 'name', key);
-  pushStringAttribute(target, 'value', value);
-  target.push(endOfStartTagSelfClosing);
+  target.push(
+    stringToChunk(
+      '<input type="hidden"' +
+        stringAttributeToString('name', key) +
+        stringAttributeToString('value', value) +
+        '/>',
+    ),
+  );
 }
 
 function pushAdditionalFormFields(
@@ -1496,17 +1462,20 @@ function getCustomFormFields(
   return null;
 }
 
-function pushFormActionAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
+// The caller resolves customFields itself (getCustomFormFields consumes a
+// form ID, so it can only be called once) and reads the FormData from
+// customFields.data; this only serializes the resulting attributes.
+function formActionAttributesToString(
   resumableState: ResumableState,
   renderState: RenderState,
+  customFields: null | ReactCustomFormAction,
   formAction: any,
   formEncType: any,
   formMethod: any,
   formTarget: any,
   name: any,
-): void | null | FormData {
-  let formData = null;
+): string {
+  let attributes = '';
   if (typeof formAction === 'function') {
     // Function form actions cannot control the form properties
     if (__DEV__) {
@@ -1535,7 +1504,6 @@ function pushFormActionAttribute(
         );
       }
     }
-    const customFields = getCustomFormFields(resumableState, formAction);
     if (customFields !== null) {
       // This action has a custom progressive enhancement form that can submit the form
       // back to the server if it's invoked before hydration. Such as a Server Action.
@@ -1544,20 +1512,13 @@ function pushFormActionAttribute(
       formEncType = customFields.encType;
       formMethod = customFields.method;
       formTarget = customFields.target;
-      formData = customFields.data;
     } else {
       // Set a javascript URL that doesn't do anything. We don't expect this to be invoked
       // because we'll preventDefault in the Fizz runtime, but it can happen if a form is
       // manually submitted or if someone calls stopPropagation before React gets the event.
       // If CSP is used to block javascript: URLs that's fine too. It just won't show this
       // error message but the URL will be logged.
-      target.push(
-        attributeSeparator,
-        stringToChunk('formAction'),
-        attributeAssign,
-        actionJavaScriptURL,
-        attributeEnd,
-      );
+      attributes += ' formAction="' + actionJavaScriptURL + '"';
       name = null;
       formAction = null;
       formEncType = null;
@@ -1567,21 +1528,21 @@ function pushFormActionAttribute(
     }
   }
   if (name != null) {
-    pushAttribute(target, 'name', name);
+    attributes += attributeToString('name', name);
   }
   if (formAction != null) {
-    pushAttribute(target, 'formAction', formAction);
+    attributes += attributeToString('formAction', formAction);
   }
   if (formEncType != null) {
-    pushAttribute(target, 'formEncType', formEncType);
+    attributes += attributeToString('formEncType', formEncType);
   }
   if (formMethod != null) {
-    pushAttribute(target, 'formMethod', formMethod);
+    attributes += attributeToString('formMethod', formMethod);
   }
   if (formTarget != null) {
-    pushAttribute(target, 'formTarget', formTarget);
+    attributes += attributeToString('formTarget', formTarget);
   }
-  return formData;
+  return attributes;
 }
 
 let blobCache: null | WeakMap<Blob, Thenable<string>> = null;
@@ -2003,7 +1964,7 @@ function pushStartObject(
   props: Object,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag('object'));
+  let open = startStringForTag('object');
 
   let children = null;
   let innerHTML = null;
@@ -2037,25 +1998,19 @@ function pushStartObject(
             }
             break;
           }
-          target.push(
-            attributeSeparator,
-            stringToChunk('data'),
-            attributeAssign,
-            stringToChunk(escapeTextForBrowser(sanitizedValue)),
-            attributeEnd,
-          );
+          open += ' data="' + escapeTextForBrowser(sanitizedValue) + '"';
           break;
         }
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   pushInnerHTML(target, innerHTML, children);
   if (typeof children === 'string') {
     // Special case children as a string to avoid the unnecessary comment.
@@ -2093,7 +2048,7 @@ function pushStartSelect(
     }
   }
 
-  target.push(startChunkForTag('select'));
+  let open = startStringForTag('select');
 
   let children = null;
   let innerHTML = null;
@@ -2117,15 +2072,15 @@ function pushStartSelect(
           // These are set on the Context instead and applied to the nested options.
           break;
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   pushInnerHTML(target, innerHTML, children);
   return children;
 }
@@ -2157,7 +2112,7 @@ function flattenOptionChildren(children: mixed): string {
   return content;
 }
 
-const selectedMarkerAttribute = stringToPrecomputedChunk(' selected=""');
+const selectedMarkerAttribute = ' selected=""';
 
 function pushStartOption(
   target: Array<Chunk | PrecomputedChunk>,
@@ -2166,7 +2121,7 @@ function pushStartOption(
 ): ReactNodeList {
   const selectedValue = formatContext.selectedValue;
 
-  target.push(startChunkForTag('option'));
+  let open = startStringForTag('option');
 
   let children = null;
   let value = null;
@@ -2203,7 +2158,7 @@ function pushStartOption(
           value = propValue;
         // We intentionally fallthrough to also set the attribute on the node.
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
@@ -2238,7 +2193,7 @@ function pushStartOption(
         }
         const v = '' + selectedValue[i];
         if (v === stringValue) {
-          target.push(selectedMarkerAttribute);
+          open += selectedMarkerAttribute;
           break;
         }
       }
@@ -2247,15 +2202,15 @@ function pushStartOption(
         checkAttributeStringCoercion(selectedValue, 'select.value');
       }
       if ('' + selectedValue === stringValue) {
-        target.push(selectedMarkerAttribute);
+        open += selectedMarkerAttribute;
       }
     }
   } else if (selected) {
-    target.push(selectedMarkerAttribute);
+    open += selectedMarkerAttribute;
   }
 
   // Options never participate as ViewTransitions.
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   pushInnerHTML(target, innerHTML, children);
   return children;
 }
@@ -2326,7 +2281,7 @@ function pushStartForm(
   renderState: RenderState,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag('form'));
+  let open = startStringForTag('form');
 
   let children = null;
   let innerHTML = null;
@@ -2361,7 +2316,7 @@ function pushStartForm(
           formTarget = propValue;
           break;
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
@@ -2407,13 +2362,7 @@ function pushStartForm(
       // manually submitted or if someone calls stopPropagation before React gets the event.
       // If CSP is used to block javascript: URLs that's fine too. It just won't show this
       // error message but the URL will be logged.
-      target.push(
-        attributeSeparator,
-        stringToChunk('action'),
-        attributeAssign,
-        actionJavaScriptURL,
-        attributeEnd,
-      );
+      open += ' action="' + actionJavaScriptURL + '"';
       formAction = null;
       formEncType = null;
       formMethod = null;
@@ -2422,26 +2371,30 @@ function pushStartForm(
     }
   }
   if (formAction != null) {
-    pushAttribute(target, 'action', formAction);
+    open += attributeToString('action', formAction);
   }
   if (formEncType != null) {
-    pushAttribute(target, 'encType', formEncType);
+    open += attributeToString('encType', formEncType);
   }
   if (formMethod != null) {
-    pushAttribute(target, 'method', formMethod);
+    open += attributeToString('method', formMethod);
   }
   if (formTarget != null) {
-    pushAttribute(target, 'target', formTarget);
+    open += attributeToString('target', formTarget);
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
 
   if (formActionName !== null) {
-    target.push(startHiddenInputChunk);
-    pushStringAttribute(target, 'name', formActionName);
-    target.push(endOfStartTagSelfClosing);
+    target.push(
+      stringToChunk(
+        '<input type="hidden"' +
+          stringAttributeToString('name', formActionName) +
+          '/>',
+      ),
+    );
     pushAdditionalFormFields(target, formData);
   }
 
@@ -2466,7 +2419,7 @@ function pushInput(
     checkControlledValueProps('input', props);
   }
 
-  target.push(startChunkForTag('input'));
+  let open = startStringForTag('input');
 
   let name = null;
   let formAction = null;
@@ -2519,7 +2472,7 @@ function pushInput(
           value = propValue;
           break;
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
@@ -2539,10 +2492,15 @@ function pushInput(
     }
   }
 
-  const formData = pushFormActionAttribute(
-    target,
+  const customFields =
+    typeof formAction === 'function'
+      ? getCustomFormFields(resumableState, formAction)
+      : null;
+  const formData = customFields !== null ? customFields.data : null;
+  open += formActionAttributesToString(
     resumableState,
     renderState,
+    customFields,
     formAction,
     formEncType,
     formMethod,
@@ -2580,19 +2538,19 @@ function pushInput(
   }
 
   if (checked !== null) {
-    pushBooleanAttribute(target, 'checked', checked);
+    open += booleanAttributeToString('checked', checked);
   } else if (defaultChecked !== null) {
-    pushBooleanAttribute(target, 'checked', defaultChecked);
+    open += booleanAttributeToString('checked', defaultChecked);
   }
   if (value !== null) {
-    pushAttribute(target, 'value', value);
+    open += attributeToString('value', value);
   } else if (defaultValue !== null) {
-    pushAttribute(target, 'value', defaultValue);
+    open += attributeToString('value', defaultValue);
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTagSelfClosing);
+  target.push(stringToChunk(open + '/>'));
 
   // We place any additional hidden form fields after the input.
   pushAdditionalFormFields(target, formData);
@@ -2607,7 +2565,7 @@ function pushStartButton(
   renderState: RenderState,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag('button'));
+  let open = startStringForTag('button');
 
   let children = null;
   let innerHTML = null;
@@ -2646,7 +2604,7 @@ function pushStartButton(
           formTarget = propValue;
           break;
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
@@ -2666,10 +2624,15 @@ function pushStartButton(
     }
   }
 
-  const formData = pushFormActionAttribute(
-    target,
+  const customFields =
+    typeof formAction === 'function'
+      ? getCustomFormFields(resumableState, formAction)
+      : null;
+  const formData = customFields !== null ? customFields.data : null;
+  open += formActionAttributesToString(
     resumableState,
     renderState,
+    customFields,
     formAction,
     formEncType,
     formMethod,
@@ -2677,9 +2640,9 @@ function pushStartButton(
     name,
   );
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
 
   // We place any additional hidden form fields we need to include inside the button itself.
   pushAdditionalFormFields(target, formData);
@@ -2718,7 +2681,7 @@ function pushStartTextArea(
     }
   }
 
-  target.push(startChunkForTag('textarea'));
+  let open = startStringForTag('textarea');
 
   let value = null;
   let defaultValue = null;
@@ -2744,7 +2707,7 @@ function pushStartTextArea(
             '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
           );
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
@@ -2753,9 +2716,9 @@ function pushStartTextArea(
     value = defaultValue;
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
 
   // TODO (yungsters): Remove support for children content in <textarea>.
   if (children != null) {
@@ -3528,7 +3491,7 @@ function pushStartMenuItem(
   props: Object,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag('menuitem'));
+  let open = startStringForTag('menuitem');
 
   for (const propKey in props) {
     if (hasOwnProperty.call(props, propKey)) {
@@ -3543,15 +3506,15 @@ function pushStartMenuItem(
             'menuitems cannot have `children` nor `dangerouslySetInnerHTML`.',
           );
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   return null;
 }
 
@@ -4016,7 +3979,7 @@ function pushStartCustomElement(
   tag: string,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag(tag));
+  let open = startStringForTag(tag);
 
   let children = null;
   let innerHTML = null;
@@ -4035,7 +3998,7 @@ function pushStartCustomElement(
           innerHTML = propValue;
           break;
         case 'style':
-          pushStyleAttribute(target, propValue);
+          open += styleAttributeToString(propValue);
           break;
         case 'suppressContentEditableWarning':
         case 'suppressHydrationWarning':
@@ -4062,13 +4025,12 @@ function pushStartCustomElement(
             } else if (typeof propValue === 'object') {
               continue;
             }
-            target.push(
-              attributeSeparator,
-              stringToChunk(attributeName),
-              attributeAssign,
-              stringToChunk(escapeTextForBrowser(propValue)),
-              attributeEnd,
-            );
+            open +=
+              ' ' +
+              attributeName +
+              '="' +
+              escapeTextForBrowser(propValue) +
+              '"';
           }
           break;
       }
@@ -4076,9 +4038,9 @@ function pushStartCustomElement(
   }
 
   // TODO: ViewTransition attributes gets observed by the Custom Element which is a bit sketchy.
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   pushInnerHTML(target, innerHTML, children);
   return children;
 }
@@ -4091,7 +4053,7 @@ function pushStartPreformattedElement(
   tag: string,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag(tag));
+  let open = startStringForTag(tag);
 
   let children = null;
   let innerHTML = null;
@@ -4109,15 +4071,15 @@ function pushStartPreformattedElement(
           innerHTML = propValue;
           break;
         default:
-          pushAttribute(target, propKey, propValue);
+          open += attributeToString(propKey, propValue);
           break;
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
 
   // text/html ignores the first character in these tags if it's a newline
   // Prefer to break application/xml over text/html (for now) by adding

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1259,10 +1259,6 @@ function processStyleName(styleName: string): string {
   return result;
 }
 
-const styleAttributeStart = stringToPrecomputedChunk(' style="');
-const styleAssign = stringToPrecomputedChunk(':');
-const styleSeparator = stringToPrecomputedChunk(';');
-
 function pushStyleAttribute(
   target: Array<Chunk | PrecomputedChunk>,
   style: Object,
@@ -1720,9 +1716,7 @@ function pushAttribute(
       // these aren't boolean attributes (they are coerced to strings).
       if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          stringToChunk(
-            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
-          ),
+          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
         );
       }
       return;
@@ -1784,9 +1778,7 @@ function pushAttribute(
         // Ignored
       } else if (typeof value !== 'function' && typeof value !== 'symbol') {
         target.push(
-          stringToChunk(
-            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
-          ),
+          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
         );
       }
       return;
@@ -1803,9 +1795,7 @@ function pushAttribute(
         (value as any) >= 1
       ) {
         target.push(
-          stringToChunk(
-            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
-          ),
+          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
         );
       }
       return;
@@ -1819,9 +1809,7 @@ function pushAttribute(
         !isNaN(value)
       ) {
         target.push(
-          stringToChunk(
-            ' ' + name + '="' + escapeTextForBrowser(value) + '"',
-          ),
+          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
         );
       }
       return;
@@ -1880,11 +1868,7 @@ function pushAttribute(
         }
         target.push(
           stringToChunk(
-            ' ' +
-              attributeName +
-              '="' +
-              escapeTextForBrowser(value) +
-              '"',
+            ' ' + attributeName + '="' + escapeTextForBrowser(value) + '"',
           ),
         );
       }
@@ -2000,12 +1984,14 @@ function pushStartAnchor(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  if (innerHTML == null && typeof children === 'string') {
-    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
-    return null;
-  }
   target.push(endOfStartTag);
   pushInnerHTML(target, innerHTML, children);
+  if (typeof children === 'string') {
+    // Special case children as a string to avoid the unnecessary comment.
+    // TODO: Remove this special case after the general optimization is in place.
+    target.push(stringToChunk(encodeHTMLTextNode(children)));
+    return null;
+  }
   return children;
 }
 
@@ -4005,13 +3991,14 @@ function pushStartGenericElement(
 
   pushViewTransitionAttributes(target, formatContext);
 
-  if (innerHTML == null && typeof children === 'string') {
-    // Fast path: close tag and emit text child in a single push.
-    target.push(stringToChunk('>' + encodeHTMLTextNode(children)));
-    return null;
-  }
   target.push(endOfStartTag);
   pushInnerHTML(target, innerHTML, children);
+  if (typeof children === 'string') {
+    // Special case children as a string to avoid the unnecessary comment.
+    // TODO: Remove this special case after the general optimization is in place.
+    target.push(stringToChunk(encodeHTMLTextNode(children)));
+    return null;
+  }
   return children;
 }
 

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1199,20 +1199,19 @@ export function pushSegmentFinale(
   }
 }
 
-function pushViewTransitionAttributes(
-  target: Array<Chunk | PrecomputedChunk>,
+function viewTransitionAttributesToString(
   formatContext: FormatContext,
-): void {
+): string {
   if (!enableViewTransition) {
-    return;
+    return '';
   }
   const viewTransition = formatContext.viewTransition;
   if (viewTransition === null) {
-    return;
+    return '';
   }
+  let attrs = '';
   if (viewTransition.name !== 'auto') {
-    pushStringAttribute(
-      target,
+    attrs += stringAttributeToString(
       'vt-name',
       viewTransition.nameIdx === 0
         ? viewTransition.name
@@ -1224,27 +1223,44 @@ function pushViewTransitionAttributes(
     // TODO: Make this deterministic.
     viewTransition.nameIdx++;
   }
-  pushStringAttribute(target, 'vt-update', viewTransition.update);
+  attrs += stringAttributeToString('vt-update', viewTransition.update);
   if (viewTransition.enter !== 'none') {
-    pushStringAttribute(target, 'vt-enter', viewTransition.enter);
+    attrs += stringAttributeToString('vt-enter', viewTransition.enter);
   }
   if (viewTransition.exit !== 'none') {
-    pushStringAttribute(target, 'vt-exit', viewTransition.exit);
+    attrs += stringAttributeToString('vt-exit', viewTransition.exit);
   }
   if (viewTransition.share !== 'none') {
-    pushStringAttribute(target, 'vt-share', viewTransition.share);
+    attrs += stringAttributeToString('vt-share', viewTransition.share);
   }
   if (
     enableViewTransitionParentEnterExit &&
     viewTransition.parentEnter !== 'none'
   ) {
-    pushStringAttribute(target, 'vt-parent-enter', viewTransition.parentEnter);
+    attrs += stringAttributeToString(
+      'vt-parent-enter',
+      viewTransition.parentEnter,
+    );
   }
   if (
     enableViewTransitionParentEnterExit &&
     viewTransition.parentExit !== 'none'
   ) {
-    pushStringAttribute(target, 'vt-parent-exit', viewTransition.parentExit);
+    attrs += stringAttributeToString(
+      'vt-parent-exit',
+      viewTransition.parentExit,
+    );
+  }
+  return attrs;
+}
+
+function pushViewTransitionAttributes(
+  target: Array<Chunk | PrecomputedChunk>,
+  formatContext: FormatContext,
+): void {
+  const attrs = viewTransitionAttributesToString(formatContext);
+  if (attrs !== '') {
+    target.push(stringToChunk(attrs));
   }
 }
 
@@ -1259,10 +1275,7 @@ function processStyleName(styleName: string): string {
   return result;
 }
 
-function pushStyleAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
-  style: Object,
-): void {
+function styleAttributeToString(style: Object): string {
   if (typeof style !== 'object') {
     throw new Error(
       'The `style` prop expects a mapping from style properties to values, ' +
@@ -1328,23 +1341,58 @@ function pushStyleAttribute(
     }
   }
   if (styleString !== '') {
-    target.push(stringToChunk(' style="' + styleString + '"'));
+    return ' style="' + styleString + '"';
+  }
+  return '';
+}
+
+function pushStyleAttribute(
+  target: Array<Chunk | PrecomputedChunk>,
+  style: Object,
+): void {
+  const attr = styleAttributeToString(style);
+  if (attr !== '') {
+    target.push(stringToChunk(attr));
   }
 }
 
 const attributeSeparator = stringToPrecomputedChunk(' ');
 const attributeAssign = stringToPrecomputedChunk('="');
 const attributeEnd = stringToPrecomputedChunk('"');
-const attributeEmptyString = stringToPrecomputedChunk('=""');
+
+function booleanAttributeToString(
+  name: string,
+  value: string | boolean | number | Function | Object, // not null or undefined
+): string {
+  if (value && typeof value !== 'function' && typeof value !== 'symbol') {
+    return ' ' + name + '=""';
+  }
+  return '';
+}
 
 function pushBooleanAttribute(
   target: Array<Chunk | PrecomputedChunk>,
   name: string,
   value: string | boolean | number | Function | Object, // not null or undefined
 ): void {
-  if (value && typeof value !== 'function' && typeof value !== 'symbol') {
-    target.push(stringToChunk(' ' + name + '=""'));
+  const attr = booleanAttributeToString(name, value);
+  if (attr !== '') {
+    target.push(stringToChunk(attr));
   }
+}
+
+function stringAttributeToString(
+  name: string,
+  value: string | boolean | number | Function | Object, // not null or undefined
+): string {
+  if (
+    typeof value !== 'function' &&
+    typeof value !== 'symbol' &&
+    typeof value !== 'boolean'
+  ) {
+    return ' ' + name + '="' + escapeTextForBrowser(value) + '"';
+  }
+  return '';
 }
 
 function pushStringAttribute(
@@ -1352,14 +1400,9 @@ function pushStringAttribute(
   name: string,
   value: string | boolean | number | Function | Object, // not null or undefined
 ): void {
-  if (
-    typeof value !== 'function' &&
-    typeof value !== 'symbol' &&
-    typeof value !== 'boolean'
-  ) {
-    target.push(
-      stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
-    );
+  const attr = stringAttributeToString(name, value);
+  if (attr !== '') {
+    target.push(stringToChunk(attr));
   }
 }
 
@@ -1543,10 +1586,7 @@ function pushFormActionAttribute(
 
 let blobCache: null | WeakMap<Blob, Thenable<string>> = null;
 
-function pushSrcObjectAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
-  blob: Blob,
-): void {
+function srcObjectAttributeToString(blob: Blob): string {
   // Throwing a Promise style suspense read of the Blob content.
   if (blobCache === null) {
     blobCache = new WeakMap();
@@ -1573,50 +1613,38 @@ function pushSrcObjectAttribute(
     throw thenable;
   }
   const url = thenable.value;
-  target.push(
-    attributeSeparator,
-    stringToChunk('src'),
-    attributeAssign,
-    stringToChunk(escapeTextForBrowser(url)),
-    attributeEnd,
-  );
+  return ' src="' + escapeTextForBrowser(url) + '"';
 }
 
-function pushAttribute(
-  target: Array<Chunk | PrecomputedChunk>,
+function attributeToString(
   name: string,
   value: string | boolean | number | Function | Object, // not null or undefined
-): void {
+): string {
   switch (name) {
     // These are very common props and therefore are in the beginning of the switch.
     // TODO: aria-label is a very common prop but allows booleans so is not like the others
     // but should ideally go in this list too.
     case 'className': {
-      pushStringAttribute(target, 'class', value);
-      break;
+      return stringAttributeToString('class', value);
     }
     case 'tabIndex': {
-      pushStringAttribute(target, 'tabindex', value);
-      break;
+      return stringAttributeToString('tabindex', value);
     }
     case 'dir':
     case 'role':
     case 'viewBox':
     case 'width':
     case 'height': {
-      pushStringAttribute(target, name, value);
-      break;
+      return stringAttributeToString(name, value);
     }
     case 'style': {
-      pushStyleAttribute(target, value);
-      return;
+      return styleAttributeToString(value);
     }
     case 'src': {
       // $FlowFixMe[invalid-compare]
       if (enableSrcObject && typeof value === 'object' && value !== null) {
         if (typeof Blob === 'function' && value instanceof Blob) {
-          pushSrcObjectAttribute(target, value);
-          return;
+          return srcObjectAttributeToString(value);
         }
       }
       // Fallthrough to general urls
@@ -1643,7 +1671,7 @@ function pushAttribute(
             );
           }
         }
-        return;
+        return '';
       }
     }
     // Fall through to the last case which shouldn't remove empty strings.
@@ -1656,18 +1684,13 @@ function pushAttribute(
         typeof value === 'symbol' ||
         typeof value === 'boolean'
       ) {
-        return;
+        return '';
       }
       if (__DEV__) {
         checkAttributeStringCoercion(value, name);
       }
       const sanitizedValue = sanitizeURL('' + value);
-      target.push(
-        stringToChunk(
-          ' ' + name + '="' + escapeTextForBrowser(sanitizedValue) + '"',
-        ),
-      );
-      return;
+      return ' ' + name + '="' + escapeTextForBrowser(sanitizedValue) + '"';
     }
     case 'defaultValue':
     case 'defaultChecked': // These shouldn't be set as attributes on generic HTML elements.
@@ -1676,12 +1699,11 @@ function pushAttribute(
     case 'suppressHydrationWarning':
     case 'ref':
       // Ignored. These are built-in to React on the client.
-      return;
+      return '';
     case 'autoFocus':
     case 'multiple':
     case 'muted': {
-      pushBooleanAttribute(target, name.toLowerCase(), value);
-      return;
+      return booleanAttributeToString(name.toLowerCase(), value);
     }
     case 'xlinkHref': {
       if (
@@ -1689,18 +1711,13 @@ function pushAttribute(
         typeof value === 'symbol' ||
         typeof value === 'boolean'
       ) {
-        return;
+        return '';
       }
       if (__DEV__) {
         checkAttributeStringCoercion(value, name);
       }
       const sanitizedValue = sanitizeURL('' + value);
-      target.push(
-        stringToChunk(
-          ' xlink:href="' + escapeTextForBrowser(sanitizedValue) + '"',
-        ),
-      );
-      return;
+      return ' xlink:href="' + escapeTextForBrowser(sanitizedValue) + '"';
     }
     case 'contentEditable':
     case 'spellCheck':
@@ -1715,11 +1732,9 @@ function pushAttribute(
       // In React, we let users pass `true` and `false` even though technically
       // these aren't boolean attributes (they are coerced to strings).
       if (typeof value !== 'function' && typeof value !== 'symbol') {
-        target.push(
-          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
-        );
+        return ' ' + name + '="' + escapeTextForBrowser(value) + '"';
       }
-      return;
+      return '';
     }
     case 'inert': {
       if (__DEV__) {
@@ -1760,28 +1775,19 @@ function pushAttribute(
     case 'seamless':
     case 'itemScope': {
       // Boolean
-      if (value && typeof value !== 'function' && typeof value !== 'symbol') {
-        target.push(
-          attributeSeparator,
-          stringToChunk(name),
-          attributeEmptyString,
-        );
-      }
-      return;
+      return booleanAttributeToString(name, value);
     }
     case 'capture':
     case 'download': {
       // Overloaded Boolean
       if (value === true) {
-        target.push(stringToChunk(' ' + name + '=""'));
+        return ' ' + name + '=""';
       } else if (value === false) {
         // Ignored
       } else if (typeof value !== 'function' && typeof value !== 'symbol') {
-        target.push(
-          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
-        );
+        return ' ' + name + '="' + escapeTextForBrowser(value) + '"';
       }
-      return;
+      return '';
     }
     case 'cols':
     case 'rows':
@@ -1794,11 +1800,9 @@ function pushAttribute(
         !isNaN(value) &&
         (value as any) >= 1
       ) {
-        target.push(
-          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
-        );
+        return ' ' + name + '="' + escapeTextForBrowser(value) + '"';
       }
-      return;
+      return '';
     }
     case 'rowSpan':
     case 'start': {
@@ -1808,39 +1812,28 @@ function pushAttribute(
         typeof value !== 'symbol' &&
         !isNaN(value)
       ) {
-        target.push(
-          stringToChunk(' ' + name + '="' + escapeTextForBrowser(value) + '"'),
-        );
+        return ' ' + name + '="' + escapeTextForBrowser(value) + '"';
       }
-      return;
+      return '';
     }
     case 'xlinkActuate':
-      pushStringAttribute(target, 'xlink:actuate', value);
-      return;
+      return stringAttributeToString('xlink:actuate', value);
     case 'xlinkArcrole':
-      pushStringAttribute(target, 'xlink:arcrole', value);
-      return;
+      return stringAttributeToString('xlink:arcrole', value);
     case 'xlinkRole':
-      pushStringAttribute(target, 'xlink:role', value);
-      return;
+      return stringAttributeToString('xlink:role', value);
     case 'xlinkShow':
-      pushStringAttribute(target, 'xlink:show', value);
-      return;
+      return stringAttributeToString('xlink:show', value);
     case 'xlinkTitle':
-      pushStringAttribute(target, 'xlink:title', value);
-      return;
+      return stringAttributeToString('xlink:title', value);
     case 'xlinkType':
-      pushStringAttribute(target, 'xlink:type', value);
-      return;
+      return stringAttributeToString('xlink:type', value);
     case 'xmlBase':
-      pushStringAttribute(target, 'xml:base', value);
-      return;
+      return stringAttributeToString('xml:base', value);
     case 'xmlLang':
-      pushStringAttribute(target, 'xml:lang', value);
-      return;
+      return stringAttributeToString('xml:lang', value);
     case 'xmlSpace':
-      pushStringAttribute(target, 'xml:space', value);
-      return;
+      return stringAttributeToString('xml:space', value);
     default:
       if (
         // shouldIgnoreAttribute
@@ -1849,7 +1842,7 @@ function pushAttribute(
         (name[0] === 'o' || name[0] === 'O') &&
         (name[1] === 'n' || name[1] === 'N')
       ) {
-        return;
+        return '';
       }
 
       const attributeName = getAttributeAlias(name);
@@ -1858,20 +1851,28 @@ function pushAttribute(
         switch (typeof value) {
           case 'function':
           case 'symbol':
-            return;
+            return '';
           case 'boolean': {
             const prefix = attributeName.toLowerCase().slice(0, 5);
             if (prefix !== 'data-' && prefix !== 'aria-') {
-              return;
+              return '';
             }
           }
         }
-        target.push(
-          stringToChunk(
-            ' ' + attributeName + '="' + escapeTextForBrowser(value) + '"',
-          ),
-        );
+        return ' ' + attributeName + '="' + escapeTextForBrowser(value) + '"';
       }
+      return '';
+  }
+}
+
+function pushAttribute(
+  target: Array<Chunk | PrecomputedChunk>,
+  name: string,
+  value: string | boolean | number | Function | Object, // not null or undefined
+): void {
+  const attr = attributeToString(name, value);
+  if (attr !== '') {
+    target.push(stringToChunk(attr));
   }
 }
 
@@ -1949,7 +1950,7 @@ function pushStartAnchor(
   props: Object,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag('a'));
+  let open = startStringForTag('a');
 
   let children = null;
   let innerHTML = null;
@@ -1966,25 +1967,27 @@ function pushStartAnchor(
         case 'dangerouslySetInnerHTML':
           innerHTML = propValue;
           break;
-        case 'href':
+        case 'href': {
           if (propValue === '') {
             // Empty `href` is special on anchors so we're short-circuiting here.
             // On other tags it should trigger a warning
-            pushStringAttribute(target, 'href', '');
+            open += stringAttributeToString('href', '');
           } else {
-            pushAttribute(target, propKey, propValue);
+            open += attributeToString(propKey, propValue);
           }
           break;
-        default:
-          pushAttribute(target, propKey, propValue);
+        }
+        default: {
+          open += attributeToString(propKey, propValue);
           break;
+        }
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   pushInnerHTML(target, innerHTML, children);
   if (typeof children === 'string') {
     // Special case children as a string to avoid the unnecessary comment.
@@ -3491,7 +3494,7 @@ function pushSelfClosing(
   tag: string,
   formatContext: FormatContext,
 ): null {
-  target.push(startChunkForTag(tag));
+  let open = startStringForTag(tag);
 
   for (const propKey in props) {
     if (hasOwnProperty.call(props, propKey)) {
@@ -3506,16 +3509,17 @@ function pushSelfClosing(
             `${tag} is a self-closing tag and must neither have \`children\` nor ` +
               'use `dangerouslySetInnerHTML`.',
           );
-        default:
-          pushAttribute(target, propKey, propValue);
+        default: {
+          open += attributeToString(propKey, propValue);
           break;
+        }
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTagSelfClosing);
+  target.push(stringToChunk(open + '/>'));
   return null;
 }
 
@@ -3965,7 +3969,10 @@ function pushStartGenericElement(
   tag: string,
   formatContext: FormatContext,
 ): ReactNodeList {
-  target.push(startChunkForTag(tag));
+  // The whole open tag is accumulated into one string and pushed as a single
+  // chunk to keep the per-chunk costs (push, byte counting, write) to one per
+  // element rather than one per attribute plus two for the tag itself.
+  let open = startStringForTag(tag);
 
   let children = null;
   let innerHTML = null;
@@ -3982,16 +3989,17 @@ function pushStartGenericElement(
         case 'dangerouslySetInnerHTML':
           innerHTML = propValue;
           break;
-        default:
-          pushAttribute(target, propKey, propValue);
+        default: {
+          open += attributeToString(propKey, propValue);
           break;
+        }
       }
     }
   }
 
-  pushViewTransitionAttributes(target, formatContext);
+  open += viewTransitionAttributesToString(formatContext);
 
-  target.push(endOfStartTag);
+  target.push(stringToChunk(open + '>'));
   pushInnerHTML(target, innerHTML, children);
   if (typeof children === 'string') {
     // Special case children as a string to avoid the unnecessary comment.
@@ -4172,6 +4180,22 @@ function startChunkForTag(tag: string): PrecomputedChunk {
     validatedTagCache.set(tag, tagStartChunk);
   }
   return tagStartChunk;
+}
+
+// Same as startChunkForTag but for paths that accumulate the whole open tag
+// into a single string before pushing it as one chunk.
+const validatedTagStringCache = new Map<string, string>();
+function startStringForTag(tag: string): string {
+  let tagStartString = validatedTagStringCache.get(tag);
+  if (tagStartString === undefined) {
+    if (!VALID_TAG_REGEX.test(tag)) {
+      throw new Error(`Invalid tag: ${tag}`);
+    }
+
+    tagStartString = '<' + tag;
+    validatedTagStringCache.set(tag, tagStartString);
+  }
+  return tagStartString;
 }
 
 export const doctypeChunk: PrecomputedChunk =

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -223,11 +223,8 @@ export function typedArrayToBinaryChunk(
 
 export function byteLengthOfChunk(chunk: Chunk | PrecomputedChunk): number {
   return typeof chunk === 'string'
-    ? chunk.length // Fast path: .length === byte length for ASCII (99%+ of HTML output).
-    : // For multi-byte chars this slightly underestimates, which is fine
-      // because byteSize is only used for heuristic decisions (outlining
-      // threshold and progressive chunk sizing).
-      chunk.byteLength;
+    ? Buffer.byteLength(chunk, 'utf8')
+    : chunk.byteLength;
 }
 
 export function byteLengthOfBinaryChunk(chunk: BinaryChunk): number {

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -223,8 +223,11 @@ export function typedArrayToBinaryChunk(
 
 export function byteLengthOfChunk(chunk: Chunk | PrecomputedChunk): number {
   return typeof chunk === 'string'
-    ? Buffer.byteLength(chunk, 'utf8')
-    : chunk.byteLength;
+    ? chunk.length // Fast path: .length === byte length for ASCII (99%+ of HTML output).
+    : // For multi-byte chars this slightly underestimates, which is fine
+      // because byteSize is only used for heuristic decisions (outlining
+      // threshold and progressive chunk sizing).
+      chunk.byteLength;
 }
 
 export function byteLengthOfBinaryChunk(chunk: BinaryChunk): number {


### PR DESCRIPTION
Does what it says on the tin. Originally discovered by @switz in https://github.com/react/react/pull/36139 and split out by @eps1lon into https://github.com/react/react/pull/36899, then I further removed parts that regressed.

Here's what Claude had to say about this:

## Perf

Benched end to end with the harness from vercel/next.js#95943: production Next.js app (16.3.0-canary.96, node streams) on Vercel Sandbox x86 VMs, identical except for the vendored React build — this PR (`f66efc12`) vs its merge-base (`b685b40d`). 16 VMs, both arms interleaved in each, whole experiment run twice independently.

Throughput, PR vs base:

| route | run 1 | run 2 | verdict |
|---|---|---|---|
| /dashboard under load | +5.7% ±2.6 (p=0.0002) | +8.5% ±1.5 (p<0.0001) | confirmed |
| /dashboard serial | +6.1% ±1.3 (p<0.0001) | +6.2% ±0.7 (p<0.0001) | confirmed |
| /blog serial | +2.1% ±0.8 (p=0.0001) | +2.0% ±0.8 (p=0.0001) | confirmed |
| /docs serial | +0.7% ±0.6 (p=0.029) | +1.5% ±0.5 (p<0.0001) | confirmed, small |
| /docs under load | +3.3% ±2.7 (p=0.021) | +2.7% ±1.7 (p=0.004) | likely, small |
| /blog under load | +1.5% ±1.8 (p=0.11) | +2.1% ±2.2 (p=0.06) | no detected difference |

Output is unchanged (HTML byte-identical between arms on /blog and /docs, 0.0% deltas on /dashboard). Gains track how much of the response is HTML vs Flight data: /dashboard is 28% HTML, /blog 18%, /docs 14%.

### Where the time went

CPU profiles from all 16 VMs: same workload, 3.8% less total CPU on the PR arm. An attribute used to be ~4 chunks (` style="`, name, `:`, value, `"`); now it's part of one string per tag. Every chunk paid three per-chunk costs, and the entire saving decomposes into them (summed over 16 VMs):

| per-chunk cost | functions | base | PR |
|---|---|---|---|
| encoding into the output buffer | `writeChunk` + `TextEncoder.encodeInto` | 105.3s | 53.6s |
| the flush loop over each segment's chunk array | `flushSubtree` + `flushSegment` | 12.6s | 5.5s |
| byte accounting for progressive rendering (per-chunk `byteLengthOfChunk`) | `finishedSegment` + `Buffer.byteLength` + inlined into `performWork` | 19.3s | 9.2s |
| building attributes (now string concat instead of chunk pushes) | `pushAttribute` + `pushStringAttribute` + `pushStartGenericElement` | 28.9s | 24.0s |

Everything else — `renderElement`, `renderNode`, Flight, task machinery — is flat within ±2%. GC drops slightly (~4s, all 16 VMs). One profiling note: `performWork` shows a big drop despite being untouched by this PR; that's the byte accounting loop V8 inlines into it, confirmed by line-level ticks and by the sum being invariant to inlining flags.

### Microbench

Both React CI builds run directly (unminified, real function names) with `renderToPipeableStream` on an attribute-heavy tree: −25% median render time, byte-identical output, same profile shape as e2e, and no deopt differences (`--trace-deopt`: warmup-only in both arms).