### PR TITLE
[Flight] Pack deferred children into continuation rows

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1479,6 +1479,37 @@ function createLazyChunkWrapper<T>(
   return lazyType;
 }
 
+type PackedChunkItemReference<T> = {
+  _chunk: SomeChunk<Array<T>>,
+  _index: number,
+};
+
+function readPackedChunkItem<T>(reference: PackedChunkItemReference<T>): T {
+  const items = readChunk(reference._chunk);
+  return items[reference._index];
+}
+
+function createLazyPackedItemWrapper<T>(
+  chunk: SomeChunk<Array<T>>,
+  index: number,
+): LazyComponent<T, PackedChunkItemReference<T>> {
+  // The parent row initializes immediately and each item suspends at its
+  // slot until the packed row arrives.
+  const lazyType: LazyComponent<T, PackedChunkItemReference<T>> = {
+    $$typeof: REACT_LAZY_TYPE,
+    _payload: {_chunk: chunk, _index: index},
+    _init: readPackedChunkItem,
+  };
+  if (__DEV__) {
+    // Forward the live array of the whole packed row. Per-item attribution
+    // would require per-item debug info rows, which packing avoids.
+    lazyType._debugInfo = chunk._debugInfo;
+    // Initialize a store for key validation by the JSX runtime.
+    lazyType._store = {validated: 0};
+  }
+  return lazyType;
+}
+
 function getChunk(response: Response, id: number): SomeChunk<any> {
   const chunks = response._chunks;
   let chunk = chunks.get(id);
@@ -2415,7 +2446,8 @@ function parseModelString(
       }
       case 'L': {
         // Lazy node
-        const id = parseInt(value.slice(2), 16);
+        const ref = value.slice(2);
+        const id = parseInt(ref, 16);
         const chunk = getChunk(response, id);
         if (enableProfilerTimer && enableComponentPerformanceTrack) {
           if (
@@ -2424,6 +2456,12 @@ function parseModelString(
           ) {
             initializingChunk._children.push(chunk);
           }
+        }
+        const separatorIdx = ref.indexOf(':');
+        if (separatorIdx > -1) {
+          // A reference to one item inside a packed row of deferred siblings.
+          const index = parseInt(ref.slice(separatorIdx + 1), 10);
+          return createLazyPackedItemWrapper(chunk, index);
         }
         // We create a React.lazy wrapper around any lazy values.
         // When passed into React, we'll know how to suspend on this.

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1051,6 +1051,85 @@ describe('ReactFlightDOMEdge', () => {
     expect(result.a).toBe(result.b);
   });
 
+  it('should dedupe objects shared across packed siblings props', async () => {
+    // Each packed item anchors parent-path references for its subtree at its
+    // own reference, like a row root does.
+    const categories = [
+      {name: 'Engineering', description: 'Deep dives from the teams.'},
+      {name: 'Guides', description: 'Step-by-step guides and how-tos.'},
+      {name: 'Culture', description: 'Life at the company.'},
+    ];
+    const seen = [];
+    const Card = clientExports(function Card({category, index}) {
+      seen.push(category);
+      return (
+        <article>
+          {category.name} card {index}
+        </article>
+      );
+    });
+    const clientModuleMetadata = webpackMap[Card.$$id];
+
+    const children = [];
+    for (let i = 0; i < 60; i++) {
+      const text =
+        'filler text that accumulates serialized size toward the limit ' + i;
+      children.push(<i key={'f' + i}>{text}</i>);
+    }
+    for (let i = 0; i < 30; i++) {
+      children.push(
+        <Card key={'c' + i} category={categories[i % 3]} index={i} />,
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <section>{children}</section>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    if (!__DEV__) {
+      // The shared object is serialized once. (DEV may serialize props again
+      // into debug info rows.)
+      expect(serializedContent.match(/Deep dives from the teams/g).length).toBe(
+        1,
+      );
+    }
+
+    const response = ReactServerDOMClient.createFromReadableStream(stream2, {
+      serverConsumerManifest: {
+        moduleMap: {
+          [clientModuleMetadata.id]: {
+            '*': clientModuleMetadata,
+          },
+        },
+        moduleLoading: webpackModuleLoading,
+      },
+    });
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<ClientRoot />),
+    );
+    const html = await readResult(ssrStream);
+    expect(html).toContain('Engineering<!-- --> card <!-- -->0');
+    expect(html).toContain('Culture<!-- --> card <!-- -->29');
+
+    const engineering = seen.filter(
+      category => category.name === 'Engineering',
+    );
+    expect(engineering.length).toBe(10);
+    for (let i = 1; i < engineering.length; i++) {
+      expect(engineering[i]).toBe(engineering[0]);
+    }
+  });
+
   it('regression: should not leak serialized size', async () => {
     const MAX_ROW_SIZE = 3200;
     // This test case is a bit convoluted and may no longer trigger the original bug.

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -803,6 +803,254 @@ describe('ReactFlightDOMEdge', () => {
     expect(html).toBe(html2);
   });
 
+  it('should pack deferred siblings into shared rows', async () => {
+    const paragraphs = [];
+    for (let i = 0; i < 200; i++) {
+      const text =
+        'This is paragraph number ' +
+        i +
+        ' with enough copy to accumulate serialized size along the way.';
+      paragraphs.push(
+        <p key={i} className="text">
+          {text}
+        </p>,
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(paragraphs),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Deferred siblings are delivered by shared packed rows, referenced by
+    // index, instead of one row each.
+    expect(serializedContent).toMatch(/\$L[0-9a-f]+:\d/);
+    if (!__DEV__) {
+      expect(serializedContent.split('\n').length).toBeLessThan(30);
+      // ~150 deferred paragraphs at up to PACKED_SIBLINGS_LIMIT per row.
+      const packedRows = serializedContent.match(/\n[0-9a-f]+:\[\[/g);
+      expect(packedRows.length).toBeGreaterThanOrEqual(3);
+      expect(packedRows.length).toBeLessThanOrEqual(6);
+    }
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+
+    // Use the SSR render to resolve any lazy elements
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    const html = await readResult(ssrStream);
+
+    const ssrStream2 = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(paragraphs),
+    );
+    const html2 = await readResult(ssrStream2);
+
+    expect(html).toBe(html2);
+  });
+
+  it('should keep children flat with correct keys across packed rows', async () => {
+    const Inspector = clientExports(function Inspector({children}) {
+      const flat = Array.isArray(children);
+      const allNodes =
+        flat &&
+        children.every(
+          child =>
+            child != null &&
+            (typeof child === 'object' || typeof child === 'string'),
+        );
+      return (
+        <div
+          data-flat={String(flat)}
+          data-all={String(allNodes)}
+          data-count={String(flat ? children.length : -1)}>
+          {children}
+        </div>
+      );
+    });
+    const clientModuleMetadata = webpackMap[Inspector.$$id];
+
+    const items = [];
+    for (let i = 0; i < 150; i++) {
+      const text =
+        'Item body with some padding text to build up serialized size ' + i;
+      items.push(<span key={'k' + i}>{text}</span>);
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <Inspector>{items}</Inspector>,
+        webpackMap,
+      ),
+    );
+    const response = ReactServerDOMClient.createFromReadableStream(stream, {
+      serverConsumerManifest: {
+        moduleMap: {
+          [clientModuleMetadata.id]: {
+            '*': clientModuleMetadata,
+          },
+        },
+        moduleLoading: webpackModuleLoading,
+      },
+    });
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<ClientRoot />),
+    );
+    const html = await readResult(ssrStream);
+    expect(html).toContain('data-flat="true"');
+    expect(html).toContain('data-all="true"');
+    expect(html).toContain('data-count="150"');
+    expect(html).toContain(
+      'Item body with some padding text to build up serialized size 149</span>',
+    );
+  });
+
+  it('should recover when a packed sibling suspends', async () => {
+    let resolveData;
+    const dataPromise = new Promise(resolve => (resolveData = resolve));
+    async function AsyncItem() {
+      const text = await dataPromise;
+      return <b>{text}</b>;
+    }
+    const children = [];
+    for (let i = 0; i < 100; i++) {
+      const text =
+        'sync item with plenty of text to push the row over the limit ' + i;
+      children.push(<i key={i}>{text}</i>);
+    }
+    // An async item deep in the deferred tail.
+    children.push(<AsyncItem key="async" />);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <section>{children}</section>,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    await serverAct(() => resolveData('finally here'));
+
+    const serializedContent = await readResult(stream1);
+    // The packed row flushed before the suspended sibling resolved: its slot
+    // degraded to a reference and the sync siblings were not held back.
+    expect(serializedContent.indexOf('over the limit 99')).toBeLessThan(
+      serializedContent.indexOf('finally here'),
+    );
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    const html = await readResult(ssrStream);
+    expect(html).toContain(
+      'sync item with plenty of text to push the row over the limit 99</i>',
+    );
+    expect(html).toContain('<b>finally here</b>');
+  });
+
+  it('should error every packed sibling when the render is aborted', async () => {
+    const never = new Promise(() => {});
+    async function Hanging() {
+      await never;
+      return null;
+    }
+    const children = [];
+    for (let i = 0; i < 100; i++) {
+      const text =
+        'item text that adds serialized weight for deferral purposes ' + i;
+      children.push(<i key={i}>{text}</i>);
+    }
+    children.push(<Hanging key="hang" />);
+
+    const controller = new AbortController();
+    const errors = [];
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <section>{children}</section>,
+        null,
+        {
+          signal: controller.signal,
+          onError(error) {
+            errors.push(error.message);
+            return 'digest';
+          },
+        },
+      ),
+    );
+    const response = ReactServerDOMClient.createFromReadableStream(stream, {
+      serverConsumerManifest: {
+        moduleMap: null,
+        moduleLoading: null,
+      },
+    });
+    await serverAct(() => controller.abort(new Error('goodbye')));
+
+    let error = null;
+    try {
+      const ssrStream = await serverAct(() =>
+        ReactDOMServer.renderToReadableStream(response),
+      );
+      await readResult(ssrStream);
+    } catch (x) {
+      error = x;
+    }
+    expect(error).not.toBe(null);
+    expect(error.digest).toBe('digest');
+    expect(errors).toContain('goodbye');
+    assertConsoleErrorDev(['[Server] Error: goodbye\n    in <stack>']);
+  });
+
+  it('should dedupe objects shared with packed siblings', async () => {
+    const shared = {shared: 'value'};
+    const items = [];
+    for (let i = 0; i < 100; i++) {
+      const text =
+        'padding text to accumulate row size for deferral to happen soon ' + i;
+      items.push(
+        <span key={i} data-index={i}>
+          {text}
+        </span>,
+      );
+    }
+    const model = {
+      tree: <section>{items}</section>,
+      a: shared,
+      b: shared,
+    };
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(model),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream, {
+      serverConsumerManifest: {
+        moduleMap: null,
+        moduleLoading: null,
+      },
+    });
+    expect(result.a).toBe(result.b);
+  });
+
   it('regression: should not leak serialized size', async () => {
     const MAX_ROW_SIZE = 3200;
     // This test case is a bit convoluted and may no longer trigger the original bug.

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -553,6 +553,8 @@ type Task = {
   implicitSlot: boolean, // true if the root server component of this sequence had a null key
   formatContext: FormatContext, // an approximate parent context from host components
   thenableState: ThenableState | null,
+  packedItems: null | Array<ReactClientValue>, // a packed row's deferred siblings; the same array as the model
+
   timed: boolean, // Profiling-only. Whether we need to track the completion time of this task.
   time: number, // Profiling-only. The last time stamp emitted for this task.
   environmentName: string, // DEV-only. Used to track if the environment for this task changed.
@@ -2153,12 +2155,44 @@ let canEmitDebugInfo: boolean = false;
 let serializedSize = 0;
 const MAX_ROW_SIZE = 3200;
 
+// How many deferred siblings can share one packed row. We can't use a size
+// limit like MAX_ROW_SIZE because we emit the references into the row
+// before any of the items have rendered, but at typical deferred element
+// sizes this keeps packed rows near MAX_ROW_SIZE. It also bounds how much
+// the client has to buffer, since no item resolves until the whole row is
+// received.
+const PACKED_SIBLINGS_LIMIT = 64;
+
+// The task currently accumulating deferred siblings, if any. This is only
+// valid while the task we're deferring out of is still rendering.
+let currentPackedTask: null | Task = null;
+
 function deferTask(request: Request, task: Task): ReactJSONValue {
   // Like outlineTask but instead the item is scheduled to be serialized
-  // after its parent in the stream.
+  // after its parent in the stream. Deferred siblings that share the same
+  // serialization context are packed into a shared row and referenced by
+  // index to avoid emitting one row per sibling.
+  const packedTask = currentPackedTask;
+  if (
+    packedTask !== null &&
+    packedTask.keyPath === task.keyPath &&
+    packedTask.implicitSlot === task.implicitSlot &&
+    packedTask.formatContext === task.formatContext
+  ) {
+    const items = packedTask.packedItems;
+    if (items !== null && items.length < PACKED_SIBLINGS_LIMIT) {
+      const index = items.push(task.model) - 1;
+      registerPackedItem(request, task, packedTask.id, index);
+      return serializeLazyPackedItemID(packedTask.id, index);
+    }
+    // This packed row is full. Start a new one.
+  }
+  const packedItems: Array<ReactClientValue> = [
+    task.model, // the currently rendering element
+  ];
   const newTask = createTask(
     request,
-    task.model, // the currently rendering element
+    packedItems,
     task.keyPath, // unlike outlineModel this one carries along context
     task.implicitSlot,
     task.formatContext,
@@ -2171,9 +2205,36 @@ function deferTask(request: Request, task: Task): ReactJSONValue {
     __DEV__ ? task.debugStack : null,
     __DEV__ ? task.debugTask : null,
   );
+  newTask.packedItems = packedItems;
+  currentPackedTask = newTask;
 
+  registerPackedItem(request, task, newTask.id, 0);
   pingTask(request, newTask);
-  return serializeLazyID(newTask.id);
+  return serializeLazyPackedItemID(newTask.id, 0);
+}
+
+function registerPackedItem(
+  request: Request,
+  task: Task,
+  packedId: number,
+  index: number,
+): void {
+  // We may have just registered this element for dedupe as a path to its
+  // slot in the parent row, but that slot now holds only a lazy reference
+  // to the packed item. The rendered content itself lives at
+  // "$<row>:<index>" inside the packed row, so we point the registration
+  // there and later occurrences resolve it without going through the lazy.
+  // If we're in some kind of context we can't reuse the result of this
+  // render, so we don't register it.
+  if (task.keyPath === null && !task.implicitSlot) {
+    const model = task.model;
+    if (typeof model === 'object' && model !== null) {
+      request.writtenObjects.set(
+        model,
+        serializeByValueID(packedId) + ':' + index,
+      );
+    }
+  }
 }
 
 function outlineTask(request: Request, task: Task): ReactJSONValue {
@@ -2780,6 +2841,7 @@ function createTask(
     formatContext: formatContext,
     ping: () => pingTask(request, task),
     thenableState: null,
+    packedItems: null,
   } as Omit<
     Task,
     | 'timed'
@@ -2934,6 +2996,12 @@ function serializeByValueID(id: number): string {
 
 function serializeLazyID(id: number): string {
   return '$L' + id.toString(16);
+}
+
+function serializeLazyPackedItemID(id: number, index: number): string {
+  // The index is decimal, unlike row ids, because it's also used as a
+  // property path segment which the client applies verbatim as an array key.
+  return '$L' + id.toString(16) + ':' + index;
 }
 
 function serializePromiseID(id: number): string {
@@ -5951,6 +6019,10 @@ function retryTask(request: Request, task: Task): void {
 
   // We stash the outer parent size so we can restore it when we exit.
   const parentSerializedSize = serializedSize;
+  // Deferred siblings only pack into rows created while the same task is
+  // rendering, so each task gets a fresh packing scope.
+  const prevPackedTask = currentPackedTask;
+  currentPackedTask = null;
   // We don't reset the serialized size counter from reentry because that indicates that we
   // are outlining a model and we actually want to include that size into the parent since
   // it will still block the parent row. It only restores to zero at the top of the stack.
@@ -5963,6 +6035,57 @@ function retryTask(request: Request, task: Task): void {
     if (__DEV__) {
       // Track that we can emit debug info for the current task.
       canEmitDebugInfo = true;
+    }
+
+    const items = task.packedItems;
+    if (items !== null) {
+      // A packed row of deferred siblings. We can't render the items array
+      // as one model because an array picks up fragment key semantics, and
+      // the references into the row are by index so it has to serialize as
+      // exactly this array.
+      const resolved: Array<ReactJSONValue> = [];
+      for (let i = 0; i < items.length; i++) {
+        // Each item gets a fresh size budget, like it would have gotten in
+        // its own row, because a shared budget would run out and cascade
+        // the rest of the items into packed row after packed row. Oversized
+        // items still defer their own children, which bounds each item's
+        // contribution to the row.
+        serializedSize = 0;
+        // The item's dedupe registration points into this row, so we treat
+        // it as the model root or it would dedupe against itself.
+        modelRoot = items[i];
+        // If an item suspends or errors, resolveModel leaves a reference
+        // in its slot, like it would in its own row.
+        resolved[i] = resolveModel(request, task, items, '' + i, items[i]);
+      }
+      modelRoot = null;
+
+      if (__DEV__) {
+        canEmitDebugInfo = false;
+        const currentEnv = (0, request.environmentName)();
+        if (currentEnv !== task.environmentName) {
+          request.pendingChunks++;
+          emitDebugChunk(request, task.id, {env: currentEnv});
+        }
+      }
+      if (
+        enableProfilerTimer &&
+        (enableComponentPerformanceTrack || enableAsyncDebugInfo)
+      ) {
+        if (task.timed) {
+          markOperationEndTime(request, task, performance.now());
+        }
+      }
+
+      task.keyPath = null;
+      task.implicitSlot = false;
+      // $FlowFixMe[incompatible-type] stringify can return null for undefined but we never do
+      const json: string = stringify(resolved);
+      emitModelChunk(request, task.id, json);
+      task.status = COMPLETED;
+      request.abortableTasks.delete(task);
+      callOnAllReadyIfReady(request);
+      return;
     }
 
     // We call the destructive form that mutates this task. That way if something
@@ -6071,6 +6194,7 @@ function retryTask(request: Request, task: Task): void {
       canEmitDebugInfo = prevCanEmitDebugInfo;
     }
     serializedSize = parentSerializedSize;
+    currentPackedTask = prevPackedTask;
   }
 }
 
@@ -6084,10 +6208,13 @@ function tryStreamTask(request: Request, task: Task): void {
     canEmitDebugInfo = false;
   }
   const parentSerializedSize = serializedSize;
+  const prevPackedTask = currentPackedTask;
+  currentPackedTask = null;
   try {
     emitChunk(request, task, task.model);
   } finally {
     serializedSize = parentSerializedSize;
+    currentPackedTask = prevPackedTask;
     if (__DEV__) {
       canEmitDebugInfo = prevCanEmitDebugInfo;
     }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3698,6 +3698,10 @@ function renderModelDestructive(
               // This is the ID we're currently emitting so we need to write it
               // once but if we discover it again, we refer to it by id.
               modelRoot = null;
+              // We're rendering the content this reference resolves to, so
+              // the result can be referred to by the same reference and
+              // descendants can chain off it for dedupe.
+              elementReference = existingReference;
             } else {
               // We've already emitted this as an outlined object, so we can refer to that by its
               // existing ID. TODO: We should use a lazy reference since, unlike plain objects,


### PR DESCRIPTION
Fixes https://github.com/react/react/issues/35125. Inspired by https://github.com/react/react/pull/36053.

If a row exceeds `MAX_ROW_SIZE`, we currently emit all of the remaining JSX elements as lazy rows.

For example, suppose we have a list of paragraphs. They overflow into lazy rows like this:

```
0:["$","main",null,{"children":[<p0>,<p1>, /* ...after MAX_ROW_SIZE... */ "$L1","$L2","$L3","$L4", …]}]
1:<p2>
2:<p3>
3:<p4>
4:<p5>
...
```

This can severely bloat the RSC payload and we pay per-row cost at every layer:

<img width="1611" height="1077" alt="514275426-4fe0d9ad-dc12-4fa7-b1e7-087fbebedd64" src="https://github.com/user-attachments/assets/147261cc-15a9-4d7c-99cd-1300446d9f8e" />

After this change, we emit them grouped like this instead:

```
0:["$","main",null,{"children":[<p0>,<p1>,"$L1:0","$L1:1","$L1:2","$L1:3", …]}]
1:[<p2>,<p3>,<p4>,<p5>, …]
```

Here, `$L1:0` means "first item of the array", and so on. A row gets max 64 items, then we do a new row.

Unlike in https://github.com/react/react/pull/36053, we don't change the deserialized format, so it is not observable by client components. This is a transport-only change. 

Note that we need to be careful to not break object deduplication between these. There's a test for that.

## Perf

I initially had a better result but this turned out due to missing deduplication (which has some cost of its own, apparently). But even after fixing that, it comes out as an improvement using https://github.com/vercel/next.js/pull/95807 bench in Next:

<img width="1033" height="416" alt="Screenshot 2026-07-18 at 01 22 52" src="https://github.com/user-attachments/assets/8e2003b4-7c29-4440-aa2e-1e7f6e54f885" />

Also variance under load seems lower.

