### PR TITLE
[Flight] Fix Flow errors in stripChunkAffixesFromManifest

### DIFF
--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackChunkAffixes-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackChunkAffixes-test.js
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+import {patchSetImmediate} from '../../../../scripts/jest/patchSetImmediate';
+
+let clientExports;
+let turbopackMap;
+let turbopackModules;
+let React;
+let ReactDOMServer;
+let ReactServerDOMServer;
+let ReactServerDOMClient;
+let Stream;
+let use;
+let serverAct;
+let assertConsoleErrorDev;
+
+const CHUNK_PREFIX = '/assets/chunks/';
+const CHUNK_SUFFIX = '.js?dpl=dpl_abc123';
+
+describe('ReactFlightTurbopackChunkAffixes', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    patchSetImmediate();
+    serverAct = require('internal-test-utils').serverAct;
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
+
+    // Simulate the condition resolution
+    jest.mock('react', () => require('react/react.react-server'));
+    jest.mock('react-server-dom-turbopack/server', () =>
+      require('react-server-dom-turbopack/server.node'),
+    );
+    ReactServerDOMServer = require('react-server-dom-turbopack/server');
+
+    const TurbopackMock = require('./utils/TurbopackMock');
+    clientExports = TurbopackMock.clientExports;
+    turbopackMap = TurbopackMock.turbopackMap;
+    turbopackModules = TurbopackMock.turbopackModules;
+
+    jest.resetModules();
+    __unmockReact();
+    jest.unmock('react-server-dom-turbopack/server');
+    jest.mock('react-server-dom-turbopack/client', () =>
+      require('react-server-dom-turbopack/client.node'),
+    );
+
+    React = require('react');
+    ReactDOMServer = require('react-dom/server.node');
+    ReactServerDOMClient = require('react-server-dom-turbopack/client');
+    Stream = require('stream');
+    use = React.use;
+  });
+
+  function readResult(stream) {
+    return new Promise((resolve, reject) => {
+      let buffer = '';
+      const writable = new Stream.PassThrough();
+      writable.setEncoding('utf8');
+      writable.on('data', chunk => {
+        buffer += chunk;
+      });
+      writable.on('error', error => {
+        reject(error);
+      });
+      writable.on('end', () => {
+        resolve(buffer);
+      });
+      stream.pipe(writable);
+    });
+  }
+
+  function setup() {
+    function ClientComponent() {
+      return <span>Client Component</span>;
+    }
+    // The Client build may not have the same IDs as the Server bundles for the
+    // same component.
+    const ClientComponentOnTheClient = clientExports(
+      ClientComponent,
+      CHUNK_PREFIX + 'client-abc123' + CHUNK_SUFFIX,
+    );
+    const ClientComponentOnTheServer = clientExports(ClientComponent);
+
+    // In the SSR bundle this module won't exist. We simulate this by deleting
+    // it and providing a translation from the client metadata to the SSR
+    // metadata.
+    const clientId = turbopackMap[ClientComponentOnTheClient.$$id].id;
+    delete turbopackModules[clientId];
+    const ssrMetadata = turbopackMap[ClientComponentOnTheServer.$$id];
+    const translationMap = {
+      [clientId]: {
+        '*': ssrMetadata,
+      },
+    };
+
+    function App() {
+      return <ClientComponentOnTheClient />;
+    }
+
+    return {App, translationMap};
+  }
+
+  it('loads client components through reassembled chunk URLs', async () => {
+    const {App, translationMap} = setup();
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(<App />, turbopackMap, {
+        chunkLoading: {prefix: CHUNK_PREFIX, suffix: CHUNK_SUFFIX},
+      }),
+    );
+    const readable = new Stream.PassThrough();
+    stream.pipe(readable);
+
+    let response;
+    function ClientRoot() {
+      if (!response) {
+        response = ReactServerDOMClient.createFromNodeStream(readable, {
+          moduleMap: translationMap,
+          moduleLoading: {prefix: CHUNK_PREFIX, suffix: CHUNK_SUFFIX},
+        });
+      }
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToPipeableStream(<ClientRoot />),
+    );
+    const result = await readResult(ssrStream);
+    // The chunk preload carries the reassembled URL: the affixes were
+    // stripped on the wire and restored by the consumer.
+    expect(result).toEqual(
+      '<script src="' +
+        CHUNK_PREFIX +
+        'client-abc123' +
+        CHUNK_SUFFIX +
+        '" async=""></script><span>Client Component</span>',
+    );
+  });
+
+  it('emits the chunk filename without its affixes in the payload', async () => {
+    const {App} = setup();
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(<App />, turbopackMap, {
+        chunkLoading: {prefix: CHUNK_PREFIX, suffix: CHUNK_SUFFIX},
+      }),
+    );
+    const readable = new Stream.PassThrough();
+    stream.pipe(readable);
+    const payload = await readResult(readable);
+    expect(payload).toContain('"client-abc123"');
+    expect(payload).not.toContain(CHUNK_PREFIX);
+    expect(payload).not.toContain(CHUNK_SUFFIX);
+  });
+
+  it('emits full chunk filenames when no affixes are declared', async () => {
+    const {App} = setup();
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(<App />, turbopackMap),
+    );
+    const readable = new Stream.PassThrough();
+    stream.pipe(readable);
+    const payload = await readResult(readable);
+    expect(payload).toContain(
+      JSON.stringify(CHUNK_PREFIX + 'client-abc123' + CHUNK_SUFFIX),
+    );
+  });
+
+  it('warns for a chunk that does not match the declared affixes', async () => {
+    const {App} = setup();
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(<App />, turbopackMap, {
+        chunkLoading: {prefix: '/elsewhere/', suffix: CHUNK_SUFFIX},
+      }),
+    );
+    const readable = new Stream.PassThrough();
+    stream.pipe(readable);
+    await readResult(readable);
+    assertConsoleErrorDev(
+      [
+        'A chunk filename "' +
+          CHUNK_PREFIX +
+          'client-abc123' +
+          CHUNK_SUFFIX +
+          '" does not match the declared chunkLoading prefix "/elsewhere/" ' +
+          'and suffix "' +
+          CHUNK_SUFFIX +
+          '". Every chunk must match, or the client would reconstruct a ' +
+          'wrong URL for it.',
+      ],
+      {withoutStack: true},
+    );
+  });
+});

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigTargetTurbopackServer.js
@@ -13,6 +13,7 @@ import type {Chunk} from '../shared/ReactFlightImportMetadata';
 
 export type ModuleLoading = null | {
   prefix: string,
+  suffix?: string,
   crossOrigin?: 'use-credentials' | '',
 };
 
@@ -26,7 +27,9 @@ export function prepareDestinationWithChunks(
       const chunk = chunks[i];
       // A merged chunk is `[mergedChunkFilename, ...]`; preinit its own URL.
       preinitScriptForSSR(
-        moduleLoading.prefix + (typeof chunk === 'string' ? chunk : chunk[0]),
+        moduleLoading.prefix +
+          (typeof chunk === 'string' ? chunk : chunk[0]) +
+          (moduleLoading.suffix != null ? moduleLoading.suffix : ''),
         nonce,
         moduleLoading.crossOrigin,
       );

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerEdge.js
@@ -58,11 +58,15 @@ import {
 
 import type {TemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
 
+import {stripChunkAffixesFromManifest} from './ReactFlightTurbopackChunkAffixes';
+import type {ChunkLoadingOptions} from './ReactFlightTurbopackChunkAffixes';
+
 export {createTemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
 
 export type {TemporaryReferenceSet};
 
 type Options = {
+  chunkLoading?: ChunkLoadingOptions,
   debugChannel?: {readable?: ReadableStream, writable?: WritableStream, ...},
   environmentName?: string | (() => string),
   filterStackFrame?: (url: string, functionName: string) => boolean,
@@ -129,7 +133,9 @@ function renderToReadableStream(
       : undefined;
   const request = createRequest(
     model,
-    turbopackMap,
+    options && options.chunkLoading
+      ? stripChunkAffixesFromManifest(turbopackMap, options.chunkLoading)
+      : turbopackMap,
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.temporaryReferences : undefined,
@@ -219,7 +225,9 @@ function prerender(
     }
     const request = createPrerenderRequest(
       model,
-      turbopackMap,
+      options && options.chunkLoading
+        ? stripChunkAffixesFromManifest(turbopackMap, options.chunkLoading)
+        : turbopackMap,
       onAllReady,
       onFatalError,
       options ? options.onError : undefined,

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
@@ -71,6 +71,9 @@ import {textEncoder} from 'react-server/src/ReactServerStreamConfigNode';
 import type {TemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
 import type {FileHandle} from 'react-server/src/ReactFlightReplyServer';
 
+import {stripChunkAffixesFromManifest} from './ReactFlightTurbopackChunkAffixes';
+import type {ChunkLoadingOptions} from './ReactFlightTurbopackChunkAffixes';
+
 export {createTemporaryReferenceSet} from 'react-server/src/ReactFlightServerTemporaryReferences';
 
 export type {TemporaryReferenceSet};
@@ -148,6 +151,7 @@ function startReadingFromDebugChannelReadable(
 }
 
 type Options = {
+  chunkLoading?: ChunkLoadingOptions,
   debugChannel?: Readable | Writable | Duplex | WebSocket,
   environmentName?: string | (() => string),
   filterStackFrame?: (url: string, functionName: string) => boolean,
@@ -188,7 +192,9 @@ function renderToPipeableStream(
       : undefined;
   const request = createRequest(
     model,
-    turbopackMap,
+    options && options.chunkLoading
+      ? stripChunkAffixesFromManifest(turbopackMap, options.chunkLoading)
+      : turbopackMap,
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.temporaryReferences : undefined,
@@ -347,7 +353,9 @@ function renderToReadableStream(
       : undefined;
   const request = createRequest(
     model,
-    turbopackMap,
+    options && options.chunkLoading
+      ? stripChunkAffixesFromManifest(turbopackMap, options.chunkLoading)
+      : turbopackMap,
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.temporaryReferences : undefined,
@@ -462,7 +470,9 @@ function prerenderToNodeStream(
 
     const request = createPrerenderRequest(
       model,
-      turbopackMap,
+      options && options.chunkLoading
+        ? stripChunkAffixesFromManifest(turbopackMap, options.chunkLoading)
+        : turbopackMap,
       onAllReady,
       onFatalError,
       options ? options.onError : undefined,
@@ -527,7 +537,9 @@ function prerender(
     }
     const request = createPrerenderRequest(
       model,
-      turbopackMap,
+      options && options.chunkLoading
+        ? stripChunkAffixesFromManifest(turbopackMap, options.chunkLoading)
+        : turbopackMap,
       onAllReady,
       onFatalError,
       options ? options.onError : undefined,

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightTurbopackChunkAffixes.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightTurbopackChunkAffixes.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ClientManifest} from './ReactFlightServerConfigTurbopackBundler';
+
+export type ChunkLoadingOptions = {
+  prefix?: string,
+  suffix?: string,
+};
+
+// Turbopack chunk filenames share a common URL layout: a directory prefix and,
+// on deployed apps, a version marker suffix (e.g. ?dpl=...). Both repeat in
+// every chunk entry of every client reference in the RSC payload. When the
+// caller declares them, they are stripped from the manifest entries before
+// serialization, and the runtime that loads chunks restores them, so the
+// payload only carries the variable part of each filename.
+export function stripChunkAffixesFromManifest(
+  manifest: ClientManifest,
+  chunkLoading: ChunkLoadingOptions,
+): ClientManifest {
+  const prefix = chunkLoading.prefix || '';
+  const suffix = chunkLoading.suffix || '';
+  if (prefix === '' && suffix === '') {
+    return manifest;
+  }
+  const stripped: Map<string, mixed> = new Map();
+  // Manifests can be large and most entries are never referenced by a given
+  // request, so entries are transformed lazily and memoized.
+  // $FlowFixMe[incompatible-variance]
+  // $FlowFixMe[incompatible-type]
+  // $FlowFixMe[incompatible-exact]
+  return new Proxy(manifest, {
+    get(target, key: string) {
+      const entry = target[key];
+      if (entry == null || typeof entry !== 'object') {
+        return entry;
+      }
+      let strippedEntry = stripped.get(key);
+      if (strippedEntry === undefined) {
+        // $FlowFixMe[incompatible-type] - ClientReferenceManifestEntry is opaque
+        const chunks = entry.chunks;
+        const strippedChunks: Array<string> = [];
+        for (let i = 0; i < chunks.length; i++) {
+          const chunk = chunks[i];
+          if (
+            chunk.length > prefix.length + suffix.length &&
+            chunk.startsWith(prefix) &&
+            chunk.endsWith(suffix)
+          ) {
+            strippedChunks.push(
+              chunk.slice(prefix.length, chunk.length - suffix.length),
+            );
+          } else {
+            // The chunk doesn't live under the declared layout. Leaving it
+            // intact would make the client reassemble a wrong URL, so this is
+            // a configuration error rather than something to paper over.
+            if (__DEV__) {
+              console.error(
+                'A chunk filename "%s" does not match the declared chunkLoading ' +
+                  'prefix "%s" and suffix "%s". Every chunk must match, or the ' +
+                  'client would reconstruct a wrong URL for it.',
+                chunk,
+                prefix,
+                suffix,
+              );
+            }
+            strippedChunks.push(chunk);
+          }
+        }
+        // $FlowFixMe[incompatible-type] - ClientReferenceManifestEntry is opaque
+        strippedEntry = {...entry, chunks: strippedChunks};
+        stripped.set(key, strippedEntry);
+      }
+      return strippedEntry;
+    },
+  });
+}

--- a/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigTargetWebpackServer.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigTargetWebpackServer.js
@@ -11,6 +11,7 @@ import {preinitScriptForSSR} from 'react-client/src/ReactFlightClientConfig';
 
 export type ModuleLoading = null | {
   prefix: string,
+  suffix?: string,
   crossOrigin?: 'use-credentials' | '',
 };
 
@@ -23,7 +24,9 @@ export function prepareDestinationWithChunks(
   if (moduleLoading !== null) {
     for (let i = 1; i < chunks.length; i += 2) {
       preinitScriptForSSR(
-        moduleLoading.prefix + chunks[i],
+        moduleLoading.prefix +
+          chunks[i] +
+          (moduleLoading.suffix != null ? moduleLoading.suffix : ''),
         nonce,
         moduleLoading.crossOrigin,
       );

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -161,6 +161,9 @@ describe('SchedulerBrowser', () => {
       eventLog = [];
       expect(actual).toEqual(expected);
     }
+    function clearLog() {
+      eventLog = [];
+    }
     return {
       advanceTime,
       resetTime,
@@ -168,6 +171,7 @@ describe('SchedulerBrowser', () => {
       log,
       isLogEmpty,
       assertLog,
+      clearLog,
       scheduleDiscreteEvent,
       scheduleContinuousEvent,
     };
@@ -347,5 +351,34 @@ describe('SchedulerBrowser', () => {
 
     runtime.fireMessageEvent();
     runtime.assertLog(['Message Event', 'Continuation Task']);
+  });
+
+  // Regression test for https://github.com/facebook/react/issues/17355
+  it('does not re-enter performWorkUntilDeadline', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('First Task');
+      // Schedule additional work while inside a running task.
+      scheduleCallback(NormalPriority, () => {
+        runtime.log('Nested Task');
+      });
+      // Port1.onmessage is performWorkUntilDeadline. Under Firefox/IE,
+      // a pending MessageChannel event can be delivered during alert() or
+      // debugger while isPerformingWork is still true. The guard should
+      // bail out and let the outer call continue.
+      runtime.clearLog();
+      port1.onmessage();
+      runtime.log('After Re-entrant Call');
+    });
+    runtime.assertLog(['Post Message']);
+
+    runtime.fireMessageEvent();
+    runtime.assertLog([
+      'Message Event',
+      'First Task',
+      // The re-entrant performWorkUntilDeadline should bail out (no log).
+      'After Re-entrant Call',
+      // The nested task scheduled inside First Task should still run.
+      'Nested Task',
+    ]);
   });
 });

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -496,6 +496,14 @@ function forceFrameRate(fps: number) {
 }
 
 const performWorkUntilDeadline = () => {
+  if (isPerformingWork) {
+    // Firefox and IE don't pause MessageChannel event delivery during
+    // alert(), confirm(), prompt(), or debugger statements. If we re-enter
+    // while work is already in progress, bail out and let the outer call
+    // handle remaining work when the stack unwinds.
+    return;
+  }
+
   // $FlowFixMe[constant-condition]
   if (enableRequestPaint) {
     needsPaint = false;


### PR DESCRIPTION
## Summary

PR #37031 introduced the \stripChunkAffixesFromManifest\ function but had Flow type errors in the \dom-node-turbopack\ check:

1. **Proxy return type mismatch**: \
ew Proxy(...)\ returns \Proxy<T>\ which Flow doesn't match to \ClientManifest\. Added \\[incompatible-variance]\, \\[incompatible-type]\, \\[incompatible-exact]\ — following the existing pattern in \ReactFlightTurbopackReferences.js:358-361\.

2. **Opaque type access**: \ClientReferenceManifestEntry\ is an \opaque\ type alias, so \entry.chunks\ and \{...entry}\ are inaccessible from outside its defining module. Added \\[incompatible-type]\ at both access sites.

## Test plan

Flow check \dom-node-turbopack\ should now pass.

## Credits

Original code by @gaearon in #37031.