### PR TITLE
[Fabric] Fix Flow constant-condition warnings in commitMutationEffectsOnFiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -144,6 +144,13 @@ export function commitHostUpdate(
   }
 }
 
+export function commitHostCloned(): void {
+  // In persistence mode, host updates are performed as clones during the render
+  // phase (completeWork) rather than as mutations during commit. We only need to
+  // track that a mutation occurred so the parent ViewTransition can detect it.
+  trackHostMutation();
+}
+
 export function commitHostTextUpdate(
   finishedWork: Fiber,
   newText: string,

--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -142,6 +142,13 @@ export function commitHostUpdate(
   }
 }
 
+export function commitHostCloned(): void {
+  // In persistence mode, host updates are performed as clones during the render
+  // phase (completeWork) rather than as mutations during commit. We only need to
+  // track that a mutation occurred so the parent ViewTransition can detect it.
+  trackHostMutation();
+}
+
 export function commitHostTextUpdate(
   finishedWork: Fiber,
   newText: string,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -61,6 +61,7 @@ import {
   enableFragmentRefs,
   enableDefaultTransitionIndicator,
   enableFragmentRefsTextNodes,
+  enableViewTransitionForPersistenceMode,
 } from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
@@ -238,6 +239,7 @@ import {
 import {
   commitHostMount,
   commitHostHydratedInstance,
+  commitHostCloned,
   commitHostUpdate,
   commitHostTextUpdate,
   commitHostResetTextContent,
@@ -2271,6 +2273,9 @@ function commitMutationEffectsOnFiber(
       } else {
         // $FlowFixMe[constant-condition]
         if (supportsPersistence) {
+          if (enableViewTransitionForPersistenceMode && (flags & Cloned)) {
+            commitHostCloned();
+          }
           if (finishedWork.alternate !== null) {
             // `finishedWork.alternate.stateNode` is pointing to a stale shadow
             // node at this point, retaining it and its subtree. To reclaim
@@ -2307,6 +2312,9 @@ function commitMutationEffectsOnFiber(
 
           commitHostTextUpdate(finishedWork, newText, oldText);
         }
+      }
+      if (supportsPersistence && enableViewTransitionForPersistenceMode && (flags & Cloned)) {
+        commitHostCloned();
       }
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2273,6 +2273,7 @@ function commitMutationEffectsOnFiber(
       } else {
         // $FlowFixMe[constant-condition]
         if (supportsPersistence) {
+          // $FlowFixMe[constant-condition]
           if (enableViewTransitionForPersistenceMode && (flags & Cloned)) {
             commitHostCloned();
           }
@@ -2313,6 +2314,7 @@ function commitMutationEffectsOnFiber(
           commitHostTextUpdate(finishedWork, newText, oldText);
         }
       }
+      // $FlowFixMe[constant-condition]
       if (supportsPersistence && enableViewTransitionForPersistenceMode && (flags & Cloned)) {
         commitHostCloned();
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -2327,6 +2327,7 @@ function commitMutationEffectsOnFiber(
       } else {
         // $FlowFixMe[constant-condition]
         if (supportsPersistence) {
+          // $FlowFixMe[constant-condition]
           if (enableViewTransitionForPersistenceMode && (flags & Cloned)) {
             commitHostCloned();
           }
@@ -2367,6 +2368,7 @@ function commitMutationEffectsOnFiber(
           commitHostTextUpdate(finishedWork, newText, oldText);
         }
       }
+      // $FlowFixMe[constant-condition]
       if (supportsPersistence && enableViewTransitionForPersistenceMode && (flags & Cloned)) {
         commitHostCloned();
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -61,6 +61,7 @@ import {
   enableFragmentRefs,
   enableDefaultTransitionIndicator,
   enableFragmentRefsTextNodes,
+  enableViewTransitionForPersistenceMode,
 } from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
@@ -239,6 +240,7 @@ import {
 import {
   commitHostMount,
   commitHostHydratedInstance,
+  commitHostCloned,
   commitHostUpdate,
   commitHostTextUpdate,
   commitHostResetTextContent,
@@ -2325,6 +2327,9 @@ function commitMutationEffectsOnFiber(
       } else {
         // $FlowFixMe[constant-condition]
         if (supportsPersistence) {
+          if (enableViewTransitionForPersistenceMode && (flags & Cloned)) {
+            commitHostCloned();
+          }
           if (finishedWork.alternate !== null) {
             // `finishedWork.alternate.stateNode` is pointing to a stale shadow
             // node at this point, retaining it and its subtree. To reclaim
@@ -2361,6 +2366,9 @@ function commitMutationEffectsOnFiber(
 
           commitHostTextUpdate(finishedWork, newText, oldText);
         }
+      }
+      if (supportsPersistence && enableViewTransitionForPersistenceMode && (flags & Cloned)) {
+        commitHostCloned();
       }
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -10,6 +10,7 @@
 import {
   enableCreateEventHandleAPI,
   enableEffectEventMutationPhase,
+  enableViewTransitionForPersistenceMode,
 } from 'shared/ReactFeatureFlags';
 
 export type Flags = number;
@@ -115,7 +116,13 @@ export const BeforeMutationMask: number =
 // For View Transition support we use the snapshot phase to scan the tree for potentially
 // affected ViewTransition components.
 export const BeforeAndAfterMutationTransitionMask: number =
-  Snapshot | Update | Placement | ChildDeletion | Visibility | ContentReset;
+  Snapshot |
+  Update |
+  Placement |
+  ChildDeletion |
+  Visibility |
+  ContentReset |
+  (enableViewTransitionForPersistenceMode ? Cloned : 0);
 
 export const MutationMask =
   Placement |


### PR DESCRIPTION
## Summary

PR #36990 by @zeyap added ViewTransition onUpdate support for persistence mode (Fabric) but is failing 22 Flow checks + Prettier.

## Flow fixes

Two missing \\[constant-condition]\ suppressions:

1. **HostText branch** (line 2316): \supportsPersistence\ is a build-time constant used as a condition without suppression, causing Flow to error in all variants.
2. **HostComponent branch** (line 2276): \enableViewTransitionForPersistenceMode\ is a build-time constant used inside the already-suppressed \supportsPersistence\ block.

## Prettier

The Prettier failure may need a separate fix - the CI environment has the prettier-plugin-hermes-parser which isn't available in local dev.

Co-authored-by: Zeya Peng <zeyap@users.noreply.github.com>