### PR TITLE
[compiler] Mark unported assertion logs as unimplemented

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/pipeline.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/pipeline.rs
@@ -161,14 +161,14 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertConsistentIdentifiers",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
     // TODO: port assertTerminalSuccessorsExist
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertTerminalSuccessorsExist",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -212,7 +212,7 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertConsistentIdentifiers",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -694,7 +694,7 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertValidBlockNesting",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -718,7 +718,7 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertValidBlockNesting",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 
@@ -756,14 +756,14 @@ pub fn compile_fn(
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertTerminalSuccessorsExist",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
     // TODO: port assertTerminalPredsExist
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new(
             "AssertTerminalPredsExist",
-            "ok".to_string(),
+            "unimplemented".to_string(),
         ));
     }
 


### PR DESCRIPTION
## Summary

Changes assertion pass debug log entries from \ok\ to \unimplemented\ so debug output reflects the real state of the Rust port pipeline.

## Test status

⚠️ The CI \ash scripts/test-rust-port.sh\ test may fail because test snapshots need to be regenerated. A maintainer should run \cargo test\ (or the snapshot update workflow in \compiler/scripts/test-rust-port.ts\) to update snapshots.

## Credits

Original work by @fallintoplace in #36960.