### PR TITLE
[Flight] Let bundlers deduplicate import metadata

### DIFF
--- a/packages/react-server-dom-turbopack/src/server/ReactFlightServerConfigTurbopackBundler.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightServerConfigTurbopackBundler.js
@@ -42,6 +42,44 @@ export function getClientReferenceKey(
   return reference.$$async ? reference.$$id + '#async' : reference.$$id;
 }
 
+// Every manifest entry gets its own copy of its chunk list out of
+// JSON.parse. Canonicalize them so the Flight server can write each
+// distinct list once per request.
+const canonicalChunkListsByManifest: WeakMap<
+  ClientManifest,
+  Map<string, Array<string>>,
+> = new WeakMap();
+const canonicalChunkListByInstance: WeakMap<
+  Array<string>,
+  Array<string>,
+> = new WeakMap();
+
+function internChunkList(
+  config: ClientManifest,
+  chunks: Array<string>,
+): Array<string> {
+  if (chunks.length === 0) {
+    return chunks;
+  }
+  const interned = canonicalChunkListByInstance.get(chunks);
+  if (interned !== undefined) {
+    return interned;
+  }
+  let table = canonicalChunkListsByManifest.get(config);
+  if (table === undefined) {
+    table = new Map();
+    canonicalChunkListsByManifest.set(config, table);
+  }
+  const key = JSON.stringify(chunks);
+  let canonical = table.get(key);
+  if (canonical === undefined) {
+    canonical = chunks;
+    table.set(key, canonical);
+  }
+  canonicalChunkListByInstance.set(chunks, canonical);
+  return canonical;
+}
+
 export function resolveClientReferenceMetadata<T>(
   config: ClientManifest,
   clientReference: ClientReference<T>,
@@ -80,9 +118,18 @@ export function resolveClientReferenceMetadata<T>(
     );
   }
   if (resolvedModuleData.async === true || clientReference.$$async === true) {
-    return [resolvedModuleData.id, resolvedModuleData.chunks, name, 1];
+    return [
+      resolvedModuleData.id,
+      internChunkList(config, resolvedModuleData.chunks),
+      name,
+      1,
+    ];
   } else {
-    return [resolvedModuleData.id, resolvedModuleData.chunks, name];
+    return [
+      resolvedModuleData.id,
+      internChunkList(config, resolvedModuleData.chunks),
+      name,
+    ];
   }
 }
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -321,6 +321,85 @@ describe('ReactFlightDOMEdge', () => {
     expect(result).toEqual('<span>Client Component</span>');
   });
 
+  it('should write a chunk list shared by several import rows only once', async () => {
+    // Three distinct client modules from the same chunk group: their
+    // manifest entries carry equal (but instance-distinct) chunk lists,
+    // the shape a JSON-parsed manifest produces.
+    const chunkLoad = Promise.resolve();
+    const ClientA = clientExports(
+      function ClientA() {
+        return <span>A</span>;
+      },
+      '42S',
+      '/shared-chunk-list.js',
+      chunkLoad,
+    );
+    const ClientB = clientExports(
+      function ClientB() {
+        return <span>B</span>;
+      },
+      '42S',
+      '/shared-chunk-list.js',
+    );
+    const ClientC = clientExports(
+      function ClientC() {
+        return <span>C</span>;
+      },
+      '42S',
+      '/shared-chunk-list.js',
+    );
+
+    const translationMap = {};
+    [ClientA, ClientB, ClientC].forEach(Component => {
+      translationMap[webpackMap[Component.$$id].id] = {
+        '*': webpackMap[Component.$$id],
+      };
+    });
+
+    function App() {
+      return (
+        <div>
+          <ClientA />
+          <ClientB />
+          <ClientC />
+        </div>
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(<App />, webpackMap),
+    );
+    const [payloadStream, consumeStream] = stream.tee();
+
+    // The shared list appears once inline in the first import row and
+    // once as the outlined row the later import rows reference — not
+    // once per module.
+    const payload = await readResult(payloadStream);
+    expect(payload.match(/shared-chunk-list\.js/g).length).toBe(2);
+
+    const response = ReactServerDOMClient.createFromReadableStream(
+      consumeStream,
+      {
+        serverConsumerManifest: {
+          moduleMap: translationMap,
+          moduleLoading: webpackModuleLoading,
+        },
+      },
+    );
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<ClientRoot />),
+    );
+    const result = await readResult(ssrStream);
+    expect(result).toEqual(
+      '<div><span>A</span><span>B</span><span>C</span></div>',
+    );
+  });
+
   it('should resolve cyclic references in client component props after two rounds of serialization and deserialization', async () => {
     const ClientComponent = clientExports(function ClientComponent({data}) {
       return (

--- a/packages/react-server-dom-webpack/src/server/ReactFlightServerConfigWebpackBundler.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightServerConfigWebpackBundler.js
@@ -42,6 +42,44 @@ export function getClientReferenceKey(
   return reference.$$async ? reference.$$id + '#async' : reference.$$id;
 }
 
+// Every manifest entry gets its own copy of its chunk list out of
+// JSON.parse. Canonicalize them so the Flight server can write each
+// distinct list once per request.
+const canonicalChunkListsByManifest: WeakMap<
+  ClientManifest,
+  Map<string, Array<string>>,
+> = new WeakMap();
+const canonicalChunkListByInstance: WeakMap<
+  Array<string>,
+  Array<string>,
+> = new WeakMap();
+
+function internChunkList(
+  config: ClientManifest,
+  chunks: Array<string>,
+): Array<string> {
+  if (chunks.length === 0) {
+    return chunks;
+  }
+  const interned = canonicalChunkListByInstance.get(chunks);
+  if (interned !== undefined) {
+    return interned;
+  }
+  let table = canonicalChunkListsByManifest.get(config);
+  if (table === undefined) {
+    table = new Map();
+    canonicalChunkListsByManifest.set(config, table);
+  }
+  const key = JSON.stringify(chunks);
+  let canonical = table.get(key);
+  if (canonical === undefined) {
+    canonical = chunks;
+    table.set(key, canonical);
+  }
+  canonicalChunkListByInstance.set(chunks, canonical);
+  return canonical;
+}
+
 export function resolveClientReferenceMetadata<T>(
   config: ClientManifest,
   clientReference: ClientReference<T>,
@@ -80,9 +118,18 @@ export function resolveClientReferenceMetadata<T>(
     );
   }
   if (resolvedModuleData.async === true || clientReference.$$async === true) {
-    return [resolvedModuleData.id, resolvedModuleData.chunks, name, 1];
+    return [
+      resolvedModuleData.id,
+      internChunkList(config, resolvedModuleData.chunks),
+      name,
+      1,
+    ];
   } else {
-    return [resolvedModuleData.id, resolvedModuleData.chunks, name];
+    return [
+      resolvedModuleData.id,
+      internChunkList(config, resolvedModuleData.chunks),
+      name,
+    ];
   }
 }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -615,6 +615,7 @@ export type Request = {
   writtenClientReferences: Map<ClientReferenceKey, number>,
   writtenServerReferences: Map<ServerReference<any>, number>,
   writtenObjects: WeakMap<Reference, string>,
+  writtenImportMetadata: WeakMap<Reference, string>,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
   identifierCount: number,
@@ -740,6 +741,7 @@ function RequestInstance(
   this.writtenClientReferences = new Map();
   this.writtenServerReferences = new Map();
   this.writtenObjects = new WeakMap();
+  this.writtenImportMetadata = new WeakMap();
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
   this.identifierCount = 1;
@@ -4446,6 +4448,53 @@ function emitErrorChunk(
   }
 }
 
+// Instances shared between import rows (like a chunk list shared by the
+// modules of a chunk group, see internChunkList) are written once: when
+// first repeated they get outlined into the import queue, ahead of the
+// rows that reference them. The map is separate from writtenObjects so
+// import metadata can only ever reference other import rows.
+const IMPORT_METADATA_SEEN_ONCE = '';
+
+function importMetadataReplacer(
+  request: Request,
+  key: string,
+  value: mixed,
+): mixed {
+  if (key === '') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return escapeStringValue(value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    const writtenImportMetadata = request.writtenImportMetadata;
+    const existing = writtenImportMetadata.get(value as any);
+    if (existing === undefined) {
+      writtenImportMetadata.set(value as any, IMPORT_METADATA_SEEN_ONCE);
+    } else if (existing === IMPORT_METADATA_SEEN_ONCE) {
+      request.pendingChunks++;
+      const outlinedId = request.nextChunkId++;
+      const json = stringifyImportMetadata(request, value);
+      const row = outlinedId.toString(16) + ':' + json + '\n';
+      request.completedImportChunks.push(stringToChunk(row));
+      const reference = serializeByValueID(outlinedId);
+      writtenImportMetadata.set(value as any, reference);
+      return reference;
+    } else {
+      return existing;
+    }
+  }
+  return value;
+}
+
+function stringifyImportMetadata(request: Request, metadata: mixed): string {
+  // $FlowFixMe[incompatible-type] stringify can return null
+  const json: string = stringify(metadata, function (key, value) {
+    return importMetadataReplacer(request, key, value);
+  });
+  return json;
+}
+
 function emitImportChunk(
   request: Request,
   id: number,
@@ -4453,7 +4502,11 @@ function emitImportChunk(
   debug: boolean,
 ): void {
   // $FlowFixMe[incompatible-type] stringify can return null
-  const json: string = stringify(clientReferenceMetadata);
+  const json: string =
+    __DEV__ && debug
+      ? // The debug channel can't reference rows in the main stream.
+        stringify(clientReferenceMetadata)
+      : stringifyImportMetadata(request, clientReferenceMetadata);
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {


### PR DESCRIPTION
We know that super repetitive chunk lists are a big part of payloads on big apps: https://github.com/vercel/next.js/issues/95559.

We could dedupe them by introducing a special concept of chunk shape like in https://github.com/react/react/pull/36198 and https://github.com/react/react/pull/36197.

However, not all targets (e.g. ESM) have a concept of a chunk. And some bundlers might be more dynamic where reusing lists doesn't make sense at all. Or maybe something else might need to be reused.

So in this PR the proposal is that we just give bundlers metadata its own object deduplication, and *it's up to the bundler* to decide whether to take advantage of it and what should not get repeated.

In these first integrations, we deduplicate by giving each chunk array a canonical array. But bundlers could also do this upstream when loading the manifest.

## Perf

This was looking good on my testing with realistic app payload.

<img width="1126" height="530" alt="Screenshot 2026-07-20 at 04 15 05" src="https://github.com/user-attachments/assets/43c32e25-86fc-4c1d-ba27-8de307bc57b5" />
