### PR TITLE
[Flight] Guard __webpack_get_script_filename__ for non-webpack runtimes

### DIFF
--- a/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js
@@ -48,7 +48,10 @@ export function addChunkDebugInfo(
   }
   let ioInfo = chunkIOInfoCache.get(chunkId);
   if (ioInfo === undefined) {
-    const scriptFilename = __webpack_get_script_filename__(chunkId);
+    const scriptFilename =
+      typeof __webpack_get_script_filename__ === 'function'
+        ? __webpack_get_script_filename__(chunkId)
+        : __webpack_require__.u(chunkId);
     let href;
     try {
       // $FlowFixMe[incompatible-type]


### PR DESCRIPTION
## Summary

`addChunkDebugInfo` calls `__webpack_get_script_filename__(chunkId)` directly when collecting IO debug info for a resolved client module. That global was added in 19.2.0. Bundlers that only emulate part of the webpack runtime, such as Expo/Metro, don't provide it, so resolving a client reference throws `ReferenceError: __webpack_get_script_filename__ is not defined` and breaks server functions under Suspense. 19.1.8 worked here because it only relied on globals Metro already polyfills (`__webpack_require__`, `__webpack_chunk_load__`, `__webpack_require__.u`).

This guards the call and falls back to `__webpack_require__.u(chunkId)` when the newer global is missing, so the debug info still resolves on webpack and no longer crashes elsewhere.

Fixes #37038

## How did you test this change?

On webpack the behavior is unchanged, since `__webpack_get_script_filename__` is defined and still used. For the Metro case I confirmed that calling the missing global throws the exact `ReferenceError` from the issue, and that the `typeof ... === 'function' ? ... : __webpack_require__.u(chunkId)` fallback returns the chunk filename without throwing. The reporter's repro (https://github.com/Matb85/expo-rsc-192-reproduction) hits this path when a `"use server"` function resolves inside a `Suspense` boundary.
