### PR TITLE
[react-devtools] Keep console specifiers literal in single-string formatter

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -180,6 +180,13 @@ describe('utils', () => {
         formatConsoleArgumentsToSingleString('%o', Object.create(null)),
       ).toEqual('%o [object Object]');
     });
+
+    it('should keep specifiers literal when no argument is supplied', () => {
+      expect(formatConsoleArgumentsToSingleString('%s %s', 'value')).toEqual(
+        'value %s',
+      );
+      expect(formatConsoleArgumentsToSingleString('%d %d', 1)).toEqual('1 %d');
+    });
   });
 
   describe('formatWithStyles', () => {

--- a/packages/react-devtools-shared/src/backend/utils/index.js
+++ b/packages/react-devtools-shared/src/backend/utils/index.js
@@ -197,6 +197,10 @@ export function formatConsoleArgumentsToSingleString(
 
       // $FlowFixMe[incompatible-type]
       formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+        if (args.length === 0) {
+          // No argument left for this specifier, so keep it literal like the console does.
+          return match;
+        }
         let arg = args.shift();
         switch (flag) {
           case 's':


### PR DESCRIPTION
## Summary

`formatConsoleArgumentsToSingleString` in `packages/react-devtools-shared/src/backend/utils/index.js` builds the message key for warnings and errors logged during render, commit, and passive effects. When a format string has more `%s`/`%d`/`%i`/`%f` specifiers than arguments, it shifts off an empty array, so `formatConsoleArgumentsToSingleString('%s %s', 'value')` returns `value undefined` and `('%d %d', 1)` returns `1 NaN`. Browsers and Node's `util.format` leave an unmatched specifier as-is (`value %s`, `1 %d`), so DevTools can track a different message than the one the console actually printed. This keeps the specifier literal when no argument is left to consume, the same way the sibling `formatConsoleArguments` was fixed in #36930.

Fixes #37126

## How did you test this change?

Added a regression test to the `formatConsoleArgumentsToSingleString` describe block. It fails on `main` (`value undefined`, `1 NaN`) and passes with the fix.

```
yarn test --build --project devtools packages/react-devtools-shared/src/__tests__/utils-test.js
# 56 passed
```

The full `react-devtools-shared` suite also passes (452 passed).
