### PR TITLE
[Flight] Fix small debug info bugs found by the fuzzer

### DIFF
--- a/packages/internal-test-utils/debugInfo.js
+++ b/packages/internal-test-utils/debugInfo.js
@@ -59,12 +59,7 @@ function normalizeIOInfo(config: DebugInfoConfig, ioInfo) {
   const promise = ioInfo.value;
   if (promise) {
     // init
-    // TODO: Subscribing without a rejection handler shouldn't turn a
-    // rejected value into an unhandled rejection.
-    promise.then(
-      function () {},
-      function () {},
-    );
+    promise.then();
     if (promise.status === 'fulfilled') {
       if (ioInfo.name === 'rsc stream') {
         copy.byteSize = 0;

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -982,10 +982,11 @@ function initializeDebugChunk(
     const debugInfo = chunk._debugInfo;
     const prevIsInitializingDebugInfo = isInitializingDebugInfo;
     isInitializingDebugInfo = true;
+    let idx = -1;
     try {
       if (debugChunk.status === RESOLVED_MODEL) {
         // Find the index of this debug info by walking the linked list.
-        let idx = debugInfo.length;
+        idx = debugInfo.length;
         let c = debugChunk._debugChunk;
         while (c !== null) {
           if (c.status !== INITIALIZED) {
@@ -1045,7 +1046,14 @@ function initializeDebugChunk(
         }
       }
     } catch (error) {
-      triggerErrorOnChunk(response, chunk, error);
+      // The chunk is the data chunk whose debug info failed to initialize.
+      // Its data is unaffected, so drop the entry rather than rejecting the
+      // chunk with an error that isn't the data's. The reserved slot gets a
+      // minimal component info, like errors are represented in debug info.
+      if (idx !== -1) {
+        const erroredComponent: ReactComponentInfo = {name: ''};
+        debugInfo[idx] = erroredComponent;
+      }
     } finally {
       isInitializingDebugInfo = prevIsInitializingDebugInfo;
     }
@@ -4076,7 +4084,8 @@ function initializeFakeStack(
     debugInfo.debugStack = createFakeJSXCallStackInDEV(response, stack, env);
   }
   const owner = debugInfo.owner;
-  if (owner != null) {
+  // The owner may have been degraded to a placeholder string by the server.
+  if (owner != null && typeof owner === 'object') {
     // Initialize any owners not yet initialized.
     initializeFakeStack(response, owner);
     if (owner.debugLocation === undefined && debugInfo.debugStack != null) {
@@ -4323,7 +4332,13 @@ function resolveConsoleEntry(
   }
 }
 
-function initializeIOInfo(response: Response, ioInfo: ReactIOInfo): void {
+function initializeIOInfo(response: Response, value: mixed): void {
+  if (typeof value !== 'object' || value === null) {
+    // The server degraded this model to a placeholder string when it failed
+    // to serialize it. There is no entry to initialize.
+    return;
+  }
+  const ioInfo: ReactIOInfo = value as any;
   if (ioInfo.stack !== undefined) {
     initializeFakeTask(response, ioInfo);
     initializeFakeStack(response, ioInfo);

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -253,6 +253,9 @@ function ReactPromise(status: any, value: any, reason: any) {
     this._debugInfo = [];
   }
 }
+
+function noop() {}
+
 // We subclass Promise.prototype so that we get other methods like .catch
 ReactPromise.prototype = Object.create(Promise.prototype) as any;
 // TODO: This doesn't return a new Promise chain unlike the real .then
@@ -291,7 +294,14 @@ ReactPromise.prototype.then = function <T>(
         rej(reason);
       };
     });
-    wrapperPromise.then(resolveCallback, rejectCallback);
+    // Subscriptions must all defer through the wrapper so they fire in
+    // registration order, even those that passed no rejection callback.
+    // Those could never handle the wrapper's rejection since .then()
+    // doesn't return a chained Promise, so swallow it, like in prod.
+    wrapperPromise.then(
+      resolveCallback,
+      typeof rejectCallback === 'function' ? rejectCallback : noop,
+    );
   }
   // The status might have changed after initialization.
   switch (chunk.status) {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1188,8 +1188,9 @@ function pushServerComponentStack(
   if (debugInfo != null) {
     const stack: ReactDebugInfo = debugInfo;
     for (let i = 0; i < stack.length; i++) {
+      // The array can have holes for debug info that is still streaming in.
       const componentInfo: ReactComponentInfo = stack[i] as any;
-      if (typeof componentInfo.name !== 'string') {
+      if (componentInfo == null || typeof componentInfo.name !== 'string') {
         continue;
       }
       if (componentInfo.debugStack === undefined) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -5379,6 +5379,60 @@ function renderDebugModel(
   return 'unknown type ' + typeof value;
 }
 
+function makeDebugModelSafeForStringify(model: ReactJSONValue): ReactJSONValue {
+  // JSON.stringify probes each object property's toJSON before the replacer
+  // can substitute it, so a value whose property access throws unwinds the
+  // whole stringify. Our own ClientReference proxies exempt the probe, but
+  // userland reference proxies of the same shape don't. Run the same probes
+  // first and replace just the values that fail. Nested objects pass through
+  // the replacer again, so one level at a time covers the whole tree.
+  if (typeof model !== 'object' || model === null) {
+    return model;
+  }
+  const object: {[string]: mixed} = model as any;
+  try {
+    for (const key in object) {
+      if (!hasOwnProperty.call(object, key)) {
+        continue;
+      }
+      const value = object[key];
+      if (
+        (typeof value === 'object' && value !== null) ||
+        typeof value === 'function'
+      ) {
+        // The same probe JSON.stringify runs.
+        // eslint-disable-next-line ft-flow/no-unused-expressions
+        (value as any).toJSON;
+      }
+    }
+    // The common case allocates nothing and returns the model as is.
+    return model;
+  } catch (x) {
+    const safeCopy: {[string]: mixed} = isArray(model) ? ([] as any) : {};
+    const keys = Object.keys(object);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      let value;
+      try {
+        value = object[key];
+        if (
+          (typeof value === 'object' && value !== null) ||
+          typeof value === 'function'
+        ) {
+          // eslint-disable-next-line ft-flow/no-unused-expressions
+          (value as any).toJSON;
+        }
+      } catch (x2) {
+        value =
+          'Unknown Value: React could not send it from the server.\n' +
+          x2.message;
+      }
+      safeCopy[key] = value;
+    }
+    return safeCopy as any;
+  }
+}
+
 function serializeDebugModel(
   request: Request,
   objectLimit: number,
@@ -5397,12 +5451,14 @@ function serializeDebugModel(
       // By-pass toJSON and use the original value.
       // $FlowFixMe[incompatible-use]
       const originalValue = this[parentPropertyName];
-      return renderDebugModel(
-        request,
-        counter,
-        this,
-        parentPropertyName,
-        originalValue,
+      return makeDebugModelSafeForStringify(
+        renderDebugModel(
+          request,
+          counter,
+          this,
+          parentPropertyName,
+          originalValue,
+        ),
       );
     } catch (x) {
       return (
@@ -5457,12 +5513,14 @@ function emitOutlinedDebugModelChunk(
       // By-pass toJSON and use the original value.
       // $FlowFixMe[incompatible-use]
       const originalValue = this[parentPropertyName];
-      return renderDebugModel(
-        request,
-        counter,
-        this,
-        parentPropertyName,
-        originalValue,
+      return makeDebugModelSafeForStringify(
+        renderDebugModel(
+          request,
+          counter,
+          this,
+          parentPropertyName,
+          originalValue,
+        ),
       );
     } catch (x) {
       return (

--- a/packages/react-server/src/ReactFlightServerConfigDebugNode.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNode.js
@@ -54,6 +54,16 @@ function resolvePromiseOrAwaitNode(
 
 const emptyStack: ReactStackTrace = [];
 
+// Stacks captured inside a hook callback start with our own frame, then the
+// dispatch frames of the hook infrastructure, which are not a fixed depth
+// (Node adds a frame when something else in the process also registered
+// v8.promiseHooks). So we skip our frame by count and the dispatch frames
+// by module. Only the dispatch modules: frames from other node internals
+// are what classifies an await as not being in user space.
+function parseHookStackTrace(error: Error): null | ReactStackTrace {
+  return parseStackTracePrivate(error, 1, true);
+}
+
 // Initialize the tracing of async operations.
 // We do this globally since the async work can potentially eagerly
 // start before the first request and once requests start they can interleave.
@@ -104,7 +114,7 @@ export function initAsyncDebugInfo(): void {
               if (request === null) {
                 // We don't collect stacks for awaits that weren't in the scope of a specific render.
               } else {
-                stack = parseStackTracePrivate(new Error(), 5);
+                stack = parseHookStackTrace(new Error());
                 if (stack !== null && !isAwaitInUserspace(request, stack)) {
                   // If this await was not done directly in user space, then clear the stack. We won't use it
                   // anyway. This lets future awaits on this await know that we still need to get their stacks
@@ -129,8 +139,7 @@ export function initAsyncDebugInfo(): void {
             node = {
               tag: UNRESOLVED_PROMISE_NODE,
               owner: owner,
-              stack:
-                owner === null ? null : parseStackTracePrivate(new Error(), 5),
+              stack: owner === null ? null : parseHookStackTrace(new Error()),
               start: performance.now(),
               end: -1.1, // Set when we resolve.
               promise: new WeakRef(resource as Promise<any>),
@@ -170,8 +179,7 @@ export function initAsyncDebugInfo(): void {
             node = {
               tag: IO_NODE,
               owner: owner,
-              stack:
-                owner === null ? parseStackTracePrivate(new Error(), 3) : null,
+              stack: owner === null ? parseHookStackTrace(new Error()) : null,
               start: performance.now(),
               end: -1.1, // Only set when pinged.
               promise: null,
@@ -187,8 +195,7 @@ export function initAsyncDebugInfo(): void {
             node = {
               tag: IO_NODE,
               owner: owner,
-              stack:
-                owner === null ? parseStackTracePrivate(new Error(), 3) : null,
+              stack: owner === null ? parseHookStackTrace(new Error()) : null,
               start: performance.now(),
               end: -1.1, // Only set when pinged.
               promise: null,

--- a/packages/react-server/src/ReactFlightStackConfigV8.js
+++ b/packages/react-server/src/ReactFlightStackConfigV8.js
@@ -9,7 +9,15 @@
 
 import type {ReactStackTrace} from 'shared/ReactTypes';
 
+// The dispatch frames of Node's hook infrastructure. The same module names
+// in every currently supported Node.js version. async_hooks dispatches
+// through node:internal/promise_hooks when something else in the process
+// also registered v8.promiseHooks.
+const asyncHooksModule = 'node:internal/async_hooks';
+const promiseHooksModule = 'node:internal/promise_hooks';
+
 let framesToSkip: number = 0;
+let skipHookDispatchFrames: boolean = false;
 let collectedStackTrace: null | ReactStackTrace = null;
 
 const identifierRegExp = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
@@ -54,9 +62,24 @@ function collectStackTracePrivate(
   structuredStackTrace: CallSite[],
 ): string {
   const result: ReactStackTrace = [];
+  let firstFrame = framesToSkip;
+  if (skipHookDispatchFrames) {
+    // Skip leading frames from the hook dispatch without collecting them.
+    while (firstFrame < structuredStackTrace.length) {
+      const scriptName =
+        structuredStackTrace[firstFrame].getScriptNameOrSourceURL();
+      if (
+        scriptName !== asyncHooksModule &&
+        scriptName !== promiseHooksModule
+      ) {
+        break;
+      }
+      firstFrame++;
+    }
+  }
   // Collect structured stack traces from the callsites.
   // We mirror how V8 serializes stack frames and how we later parse them.
-  for (let i = framesToSkip; i < structuredStackTrace.length; i++) {
+  for (let i = firstFrame; i < structuredStackTrace.length; i++) {
     const callSite = structuredStackTrace[i];
     let name = callSite.getFunctionName() || '<anonymous>';
     if (name.includes('react_stack_bottom_frame')) {
@@ -156,9 +179,11 @@ const stackTraceCache: WeakMap<Error, ReactStackTrace> = __DEV__
 export function parseStackTracePrivate(
   error: Error,
   skipFrames: number,
+  skipHookDispatch?: boolean,
 ): null | ReactStackTrace {
   collectedStackTrace = null;
   framesToSkip = skipFrames;
+  skipHookDispatchFrames = skipHookDispatch === true;
   const previousPrepare = Error.prepareStackTrace;
   Error.prepareStackTrace = collectStackTracePrivate;
   try {
@@ -187,6 +212,7 @@ export function parseStackTrace(
   // and we need to ensure that we don't get the source mapped version.
   collectedStackTrace = null;
   framesToSkip = skipFrames;
+  skipHookDispatchFrames = false;
   const previousPrepare = Error.prepareStackTrace;
   Error.prepareStackTrace = collectStackTrace;
   let stack;

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -4211,4 +4211,61 @@ describe('ReactFlightAsyncDebugInfo', () => {
       expect(ioNames).toContain('readFile');
     }
   });
+
+  it('does not turn a caught rejection in debug info into an unhandled rejection', async () => {
+    // A rejection that the server component caught still gets its value
+    // serialized into the debug info as a rejected promise. Subscribing to
+    // that value without a rejection handler, which is what getDebugInfo
+    // does, must not turn the already-handled error into an unhandled
+    // rejection. There is no explicit assertion for the leak: jest fails
+    // any test that leaks one.
+    function rejectAfterIO() {
+      return new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error('boom')), 1);
+      });
+    }
+
+    async function Component() {
+      try {
+        await rejectAfterIO();
+      } catch (x) {
+        // The rejection is handled. The render succeeds.
+      }
+      return 'ok';
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      ReactServer.createElement(Component),
+      {},
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect(await result).toBe('ok');
+    await finishLoadingStream(readable);
+
+    if (
+      __DEV__ &&
+      gate(
+        flags =>
+          flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+      )
+    ) {
+      const rejectedValues = getDebugInfo(result)
+        .filter(entry => entry.awaited && entry.awaited.value)
+        .map(entry => entry.awaited.value)
+        .filter(value => value.reason !== undefined);
+      expect(rejectedValues.length).toBe(1);
+      expect(rejectedValues[0].reason.message).toBe('boom');
+    }
+
+    // Node reports a rejection as unhandled once the microtask queue of the
+    // current macrotask has drained without a handler getting attached. One
+    // timer hop moves past that point, so a leak fails this test instead of
+    // whichever test happens to run next.
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
 });

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -4268,4 +4268,151 @@ describe('ReactFlightAsyncDebugInfo', () => {
     // whichever test happens to run next.
     await new Promise(resolve => setTimeout(resolve, 0));
   });
+
+  // A thenable that throws for any property access outside the thenable
+  // protocol. Our own ClientReference proxies exempt the serialization
+  // probes, but userland reference proxies of the same shape don't.
+  function proxyThenable(value) {
+    return new Proxy(
+      {
+        then(resolve) {
+          resolve(value);
+        },
+      },
+      {
+        get(target, key) {
+          if (
+            key === 'then' ||
+            key === 'status' ||
+            key === 'value' ||
+            key === 'reason' ||
+            key === 'constructor' ||
+            typeof key === 'symbol'
+          ) {
+            return target[key];
+          }
+          throw new Error('touched forbidden key ' + String(key));
+        },
+        set(target, key, newValue) {
+          target[key] = newValue;
+          return true;
+        },
+      },
+    );
+  }
+
+  it('tolerates a proxy thenable prop on a component that awaits I/O', async () => {
+    // The prop makes JSON.stringify of the component's debug info throw.
+    // That must never affect the component's actual data.
+    // I/O created outside any component so the degraded component info is
+    // only referenced by the Child task's awaited debug rows.
+    const io1 = delay(1);
+    const io2 = delay(10);
+
+    async function Child({data}) {
+      // Awaited debug rows flush earlier than the task's own model row.
+      await io1;
+      await io2;
+      return 'child:' + (await data);
+    }
+
+    async function App() {
+      await io1;
+      return [
+        'app',
+        [
+          ReactServer.createElement(Child, {
+            key: '0',
+            data: proxyThenable('a'),
+          }),
+        ],
+      ];
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      ReactServer.createElement(App, null),
+      {},
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect((await result)[0]).toBe('app');
+    await finishLoadingStream(readable);
+  });
+
+  it('tolerates a prop with a throwing toJSON getter on a component that awaits I/O', async () => {
+    // JSON.stringify probes toJSON on every raw object before the replacer
+    // runs, so the probe throws while the component's debug info is
+    // serialized. That must never affect the component's actual data.
+    const throwingToJSON = {
+      get toJSON() {
+        throw new Error('touched forbidden key toJSON');
+      },
+    };
+
+    const io1 = delay(1);
+    const io2 = delay(10);
+
+    async function Child({data}) {
+      await io1;
+      await io2;
+      return 'child';
+    }
+
+    async function App() {
+      await io1;
+      return [
+        'app',
+        [ReactServer.createElement(Child, {key: '0', data: throwingToJSON})],
+      ];
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      ReactServer.createElement(App, null),
+      {},
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect((await result)[0]).toBe('app');
+    await finishLoadingStream(readable);
+  });
+
+  it('tolerates a userland thenable prop that resolves twice', async () => {
+    // Every consumer that attaches raw .then() callbacks in this path
+    // already guards against multiple settles.
+    const evilThenable = {
+      then(resolve) {
+        resolve('a');
+        resolve('b');
+      },
+    };
+
+    async function Child({data}) {
+      return 'child:' + (await data);
+    }
+
+    function App() {
+      return ReactServer.createElement(Child, {data: evilThenable});
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      ReactServer.createElement(App, null),
+      {},
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect(await result).toBe('child:a');
+    await finishLoadingStream(readable);
+  });
 });

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -4160,4 +4160,55 @@ describe('ReactFlightAsyncDebugInfo', () => {
       `);
     }
   });
+
+  it('names I/O started from an fs callback before the request', async () => {
+    // I/O started outside of a render has no owner, so its name comes from
+    // the top frame of the stack captured when it starts. The callback form
+    // of the fs API dispatches through a different depth than fs/promises,
+    // and that frame used to be attributed one frame too deep, naming the io
+    // after whatever userspace frame sat there instead of the fs call.
+    const {readFile} = require('fs');
+    const filename = path.join(__dirname, 'test-file.txt');
+    function readFileWithCallback() {
+      return new Promise((resolve, reject) => {
+        readFile(filename, (error, buffer) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(buffer.toString('utf8').slice(0, 26));
+          }
+        });
+      });
+    }
+    const filePromise = readFileWithCallback();
+    async function Component() {
+      return await filePromise;
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      ReactServer.createElement(Component),
+      {},
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect(await result).toBe('Lorem ipsum dolor sit amet');
+    await finishLoadingStream(readable);
+
+    if (
+      __DEV__ &&
+      gate(
+        flags =>
+          flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+      )
+    ) {
+      const ioNames = getDebugInfo(result)
+        .filter(entry => entry.awaited)
+        .map(entry => entry.awaited.name);
+      expect(ioNames).toContain('readFile');
+    }
+  });
 });

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
@@ -180,6 +180,29 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       }
       return result;
     }
+    // Leaves delivered through a userland thenable: their io entries
+    // describe whatever context settled the thenable, not the leaf.
+    const foreignLeaves = new Set();
+    // Leaves settled in another leaf's io callback: the driver settles a
+    // batch back to back in the context of the batch's last io.
+    const foreignSettles = new Set();
+    function trackForeignValue(promise) {
+      promise.then(
+        function (value) {
+          if (typeof value === 'string' && /^v[0-9]+$/.test(value)) {
+            foreignLeaves.add(value);
+          } else if (
+            value !== null &&
+            typeof value === 'object' &&
+            typeof value.id === 'string'
+          ) {
+            foreignLeaves.add(value.id);
+          }
+        },
+        function (error) {},
+      );
+      return promise;
+    }
     function withComponent(componentName, source) {
       const parentChain = currentChain;
       currentChain = [componentName];
@@ -226,6 +249,31 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       });
     }
 
+    // Throws for any property access outside the thenable protocol, like
+    // userland reference proxies without the serialization exemptions our
+    // own ClientReference proxies carry.
+    function proxyThenable(thenable) {
+      return new Proxy(thenable, {
+        get(target, key) {
+          if (
+            key === 'then' ||
+            key === 'status' ||
+            key === 'value' ||
+            key === 'reason' ||
+            key === 'constructor' ||
+            typeof key === 'symbol'
+          ) {
+            return target[key];
+          }
+          throw new Error('touched forbidden key ' + String(key));
+        },
+        set(target, key, value) {
+          target[key] = value;
+          return true;
+        },
+      });
+    }
+
     // A promise backed by one unit of real I/O whose resolution is parked
     // with the driver. The io kind is decided when the seed is built, never
     // when the leaf is created.
@@ -249,6 +297,7 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
           : id;
       const promise = new Promise((resolve, reject) => {
         pending.push({
+          id: id,
           io: useTimer ? waitForTimer : readFromFile,
           settle() {
             meta.settleIndex = settleCount++;
@@ -428,16 +477,16 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         // driver like other leaves; resolves to more data.
         const inner = genSource(depth + 1);
         return named('queryThenable', function queryThenable() {
-          return {
+          return proxyThenable({
             then(resolve) {
               pending.push({
                 io: async function noIO() {},
                 settle() {
-                  resolve(retain(Promise.resolve(inner())));
+                  resolve(retain(trackForeignValue(Promise.resolve(inner()))));
                 },
               });
             },
-          };
+          });
         });
       }
       // A Promise subclass, like a polyfill or instrumented promise.
@@ -466,6 +515,10 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       bumpSettleBatch,
       propLeaves,
       trackPropLeaves,
+      foreignLeaves,
+      foreignSettles,
+      trackForeignValue,
+      proxyThenable,
     };
   }
 
@@ -482,14 +535,24 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       const Component = {
         [name]: function () {
           const value = ReactServer.use(
-            program.retain(
-              Promise.resolve(program.withComponent(name, source)),
-            ),
+            program.retain(program.withComponent(name, source)),
           );
           return name + ':' + String(value);
         },
       }[name];
       return Component;
+    }
+
+    function identity(x) {
+      return x;
+    }
+    function wrapPropInProxy(promise) {
+      const tracked = program.trackForeignValue(promise);
+      return program.proxyThenable({
+        then(resolve, reject) {
+          return tracked.then(resolve, reject);
+        },
+      });
     }
 
     function makeComponent(depth, options) {
@@ -550,13 +613,9 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
             ? 'text'
             : 'array';
 
-      // A promise started by the parent and awaited by the first child.
-      // TODO: Pass the source's raw result once debug info serialization
-      // survives props that throw on unexpected property access (like our
-      // own ClientReference proxies do). JSON.stringify's toJSON probe
-      // throws while the component's debug info is serialized, the server
-      // degrades the debug info to a string, and the client then corrupts
-      // the component's data chunk while failing to initialize it.
+      // A promise started by the parent and awaited by the first child,
+      // sometimes hidden behind a throwing proxy.
+      const proxyProp = rand.intBetween(0, 1) === 0;
       const propSource =
         children.length > 0 &&
         // use() components ignore their props, so a promise prop passed to
@@ -606,9 +665,14 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
               data:
                 i === 0 && propSource
                   ? program.retain(
-                      Promise.resolve(
+                      (proxyProp ? wrapPropInProxy : identity)(
                         program.trackPropLeaves(() =>
-                          program.withComponent(name, sources[0]),
+                          program.withComponent(
+                            name,
+                            proxyProp
+                              ? program.named('proxyProp', sources[0])
+                              : sources[0],
+                          ),
                         ),
                       ),
                     )
@@ -669,6 +733,9 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
           await batch[i].io();
         }
         for (let i = 0; i < batch.length; i++) {
+          if (i !== batch.length - 1 && batch[i].id != null) {
+            program.foreignSettles.add(batch[i].id);
+          }
           batch[i].settle();
           onSettle();
         }
@@ -730,6 +797,8 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       componentRoots,
       componentCreators,
       leafMeta,
+      foreignLeaves,
+      foreignSettles,
       rootIndex,
       violations,
       leafSightings,
@@ -737,6 +806,15 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     } = ctx;
     let lastTime = -Infinity;
     debugInfo.forEach(entry => {
+      if (
+        entry.awaited &&
+        entry.awaited.name === 'rsc stream' &&
+        typeof entry.awaited.end === 'number'
+      ) {
+        // Merged debug info from another chunk follows. Segments are
+        // individually ordered but their spans can overlap.
+        lastTime = -Infinity;
+      }
       if (typeof entry.time === 'number') {
         if (entry.time < lastTime) {
           violations.push(
@@ -835,6 +913,11 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
             violations.push('io resolved to unknown leaf ' + leafId);
           } else {
             leafSightings.set(leafId, (leafSightings.get(leafId) || 0) + 1);
+            if (foreignLeaves.has(leafId) || foreignSettles.has(leafId)) {
+              // This entry's io belongs to whatever settled the value, so
+              // the leaf-identity checks don't apply.
+              return;
+            }
             const frames = io.stack ? io.stack.map(frame => frame[0]) : [];
             // Pool io is named after the fs or timer API call, chained io
             // after the leaf constructor.
@@ -1114,6 +1197,8 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         componentRoots,
         componentCreators,
         leafMeta: program.leafMeta,
+        foreignLeaves: program.foreignLeaves,
+        foreignSettles: program.foreignSettles,
         rootIndex: i,
         violations,
         leafSightings: new Map(),
@@ -1217,7 +1302,11 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
           meta.chain.indexOf('loadAll') !== -1 ||
           meta.chain.indexOf('readPages') !== -1 ||
           meta.chain.indexOf('queryThenable') !== -1 ||
-          program.propLeaves.has(leafId)
+          // A value delivered through a userland thenable: React cannot see
+          // through it, so the io behind it never reaches the consumer.
+          meta.chain.indexOf('proxyProp') !== -1 ||
+          program.propLeaves.has(leafId) ||
+          program.foreignLeaves.has(leafId)
         ) {
           return;
         }

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
@@ -802,6 +802,11 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       }
       const io = entry.awaited;
       if (io) {
+        if (io.value != null && typeof io.value.then === 'function') {
+          // A fulfillment-only subscription, like a DevTools-style inspector
+          // would use, must be safe even for caught rejections.
+          io.value.then(function inspectValue() {});
+        }
         if (
           typeof io.start === 'number' &&
           typeof io.end === 'number' &&

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
@@ -168,18 +168,27 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
     function bumpSettleBatch() {
       settleBatch++;
     }
-    // Leaves whose promise is handed to a child as a prop: the child's await
-    // dedupes into the parent's, so they don't surface individually.
-    // TODO: assert exactly where they do surface instead.
+    // Leaves whose promise is handed to a child as a prop. The child awaits
+    // the prop, so a single-leaf prop must be attributed in the child's
+    // render; leaves behind composite sources only surface through whatever
+    // io ends up unblocking the composite.
     const propLeaves = new Set();
-    function trackPropLeaves(fn) {
+    const propConsumers = new Map();
+    function trackPropLeaves(fn, consumerName, singleLeaf) {
       const before = nextValue;
       const result = fn();
       for (let i = before; i < nextValue; i++) {
         propLeaves.add('v' + i);
+        if (singleLeaf) {
+          propConsumers.set('v' + i, consumerName);
+        }
       }
       return result;
     }
+    // Combinator awaits attribute only the io that unblocked them. When
+    // every part is a plain single-leaf fetch, the settle order decides
+    // which part that is, so the oracle can demand it exactly.
+    const combinatorAwaits = [];
     // Leaves delivered through a userland thenable: their io entries
     // describe whatever context settled the thenable, not the leaf.
     const foreignLeaves = new Set();
@@ -351,14 +360,21 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         // A component fetching its own data.
         const useTimer = rand.intBetween(0, 1) === 0;
         if (rand.intBetween(0, 1) === 0) {
-          return named('fetchData', function fetchData() {
+          const fetchData = named('fetchData', function fetchData() {
             return leaf({useTimer: useTimer});
           });
+          fetchData.singleLeaf = true;
+          return fetchData;
         }
-        return named('fetchAndTransform', async function fetchAndTransform() {
-          const data = await leaf({useTimer: useTimer});
-          return String(data).toUpperCase();
-        });
+        const fetchAndTransform = named(
+          'fetchAndTransform',
+          async function fetchAndTransform() {
+            const data = await leaf({useTimer: useTimer});
+            return String(data).toUpperCase();
+          },
+        );
+        fetchAndTransform.singleLeaf = true;
+        return fetchAndTransform;
       }
       if (roll <= 40) {
         const key = rand.intBetween(0, 3);
@@ -395,7 +411,27 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
           parts.push(genSource(depth + 1));
         }
         return named('loadAll', function loadAll() {
-          return Promise.all(parts.map(part => part()));
+          const record = {
+            kind: 'all',
+            completionOrder: [],
+            chain: currentChain === null ? null : currentChain.slice(),
+            flat: parts.every(part => part.singleLeaf === true),
+            parts: [],
+          };
+          combinatorAwaits.push(record);
+          return Promise.all(
+            parts.map(function startPart(part, partIndex) {
+              const from = nextValue;
+              const result = part();
+              record.parts.push({from: from, to: nextValue});
+              return Promise.resolve(result).then(
+                function recordPartCompletion(partValue) {
+                  record.completionOrder.push(partIndex);
+                  return partValue;
+                },
+              );
+            }),
+          );
         });
       }
       if (roll <= 81) {
@@ -403,10 +439,16 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         // data, which forks the await chain.
         const inner = genSource(depth + 1);
         const next = rand.intBetween(0, 1) === 0 ? genSource(depth + 1) : null;
+        // When the callback starts new work, the original value's io forks
+        // off the await chain and only the new work unblocks the consumer.
+        const innerSource =
+          next === null ? inner : named('forkedDerived', inner);
         return named('loadDerived', function loadDerived() {
-          return Promise.resolve(inner()).then(function transformResult(x) {
-            return next !== null ? next() : 'transformed:' + x;
-          });
+          return Promise.resolve(innerSource()).then(
+            function transformResult(x) {
+              return next !== null ? next() : 'transformed:' + x;
+            },
+          );
         });
       }
       if (roll <= 85) {
@@ -424,7 +466,27 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         const first = genSource(depth + 1);
         const second = genSource(depth + 1);
         return named('loadFastest', function loadFastest() {
-          return Promise.race([first(), second()]);
+          const record = {
+            kind: 'race',
+            completionOrder: [],
+            chain: currentChain === null ? null : currentChain.slice(),
+            flat: first.singleLeaf === true && second.singleLeaf === true,
+            parts: [],
+          };
+          combinatorAwaits.push(record);
+          return Promise.race(
+            [first, second].map(function startPart(part, partIndex) {
+              const from = nextValue;
+              const result = part();
+              record.parts.push({from: from, to: nextValue});
+              return Promise.resolve(result).then(
+                function recordPartCompletion(partValue) {
+                  record.completionOrder.push(partIndex);
+                  return partValue;
+                },
+              );
+            }),
+          );
         });
       }
       if (roll <= 92) {
@@ -468,9 +530,11 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       }
       if (roll <= 98) {
         const useTimer = rand.intBetween(0, 1) === 0;
-        return named('fetchObject', function fetchObject() {
+        const fetchObject = named('fetchObject', function fetchObject() {
           return leaf({object: true, useTimer: useTimer});
         });
+        fetchObject.singleLeaf = true;
+        return fetchObject;
       }
       if (roll <= 99) {
         // A userland thenable, like an ORM query object. Parked with the
@@ -519,6 +583,8 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       foreignSettles,
       trackForeignValue,
       proxyThenable,
+      propConsumers,
+      combinatorAwaits,
     };
   }
 
@@ -666,13 +732,16 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
                 i === 0 && propSource
                   ? program.retain(
                       (proxyProp ? wrapPropInProxy : identity)(
-                        program.trackPropLeaves(() =>
-                          program.withComponent(
-                            name,
-                            proxyProp
-                              ? program.named('proxyProp', sources[0])
-                              : sources[0],
-                          ),
+                        program.trackPropLeaves(
+                          () =>
+                            program.withComponent(
+                              name,
+                              proxyProp
+                                ? program.named('proxyProp', sources[0])
+                                : sources[0],
+                            ),
+                          Child.name,
+                          !proxyProp && sources[0].singleLeaf === true,
                         ),
                       ),
                     )
@@ -799,9 +868,13 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       leafMeta,
       foreignLeaves,
       foreignSettles,
+      propLeaves,
+      propConsumers,
+      useComponents,
       rootIndex,
       violations,
       leafSightings,
+      unidentifiedAwaits,
       orderSamples,
     } = ctx;
     let lastTime = -Infinity;
@@ -906,6 +979,116 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         if (typeof io.byteSize === 'number' && io.byteSize < 0) {
           violations.push('negative byteSize');
         }
+        // Identity checks shared by resolved and rejected leaves: the io kind
+        // and its stack must describe the code recorded as creating the leaf.
+        const checkLeafIo = (leafId, meta) => {
+          // V8 prefixes names with the receiver when a function is invoked
+          // as a method (program.leaf becomes Object.leaf); compare by the
+          // bare name.
+          const bareName = name =>
+            name.indexOf('.') === -1
+              ? name
+              : name.slice(name.lastIndexOf('.') + 1);
+          const frames = io.stack
+            ? io.stack.map(frame => bareName(frame[0]))
+            : [];
+          const ioName = bareName(io.name);
+          // Pool io is named after the fs or timer API call, chained io
+          // after the leaf constructor.
+          if (meta.chain === null) {
+            if (!meta.useTimer && !/readFile/.test(io.name)) {
+              violations.push(leafId + ' pool fs io named ' + io.name);
+            }
+            if (meta.useTimer && !/setTimeout/.test(io.name)) {
+              violations.push(leafId + ' pool timer io named ' + io.name);
+            }
+          } else if (ioName !== 'leaf') {
+            violations.push(leafId + ' chained io named ' + io.name);
+          }
+          // Stacks start at the promise executor or the leaf
+          // constructor, never inside hook dispatch internals.
+          if (
+            frames.length > 0 &&
+            frames[0] !== 'readFixture' &&
+            frames[0] !== 'sleep' &&
+            frames[0] !== 'leaf'
+          ) {
+            violations.push(leafId + ' io stack starts at ' + frames[0]);
+          }
+          if (meta.useTimer && frames.indexOf('readFixture') !== -1) {
+            violations.push(
+              leafId + ' used a timer but its io stack reads a file',
+            );
+          }
+          if (!meta.useTimer && frames.indexOf('sleep') !== -1) {
+            violations.push(
+              leafId + ' read a file but its io stack is a timer',
+            );
+          }
+          if (meta.chain !== null) {
+            const initiator = meta.chain[meta.chain.length - 1];
+            // A leaf initiated by one render's component must never be
+            // attributed inside the other render.
+            if (
+              componentRoots.has(initiator) &&
+              componentRoots.get(initiator) !== rootIndex
+            ) {
+              violations.push(
+                leafId +
+                  ' was initiated by the other render (' +
+                  initiator +
+                  ')',
+              );
+            }
+            // The awaited entry belongs to the task of the component that
+            // performed the await: the child for a promise passed down as a
+            // prop, otherwise the component recorded invoking the source.
+            // Shared sources (cache(), the pool, use()) are awaited by
+            // whichever component got there, so they carry no expectation.
+            let expectedOwner = null;
+            if (propConsumers.has(leafId)) {
+              expectedOwner = propConsumers.get(leafId);
+            } else if (
+              !propLeaves.has(leafId) &&
+              meta.chain.indexOf('fetchCached') === -1 &&
+              !useComponents.has(initiator) &&
+              componentRoots.get(initiator) === rootIndex
+            ) {
+              expectedOwner = initiator;
+            }
+            if (expectedOwner !== null && entry.owner != null) {
+            }
+            if (
+              expectedOwner !== null &&
+              entry.owner != null &&
+              entry.owner.name !== expectedOwner
+            ) {
+              violations.push(
+                leafId +
+                  ' awaited entry owned by ' +
+                  entry.owner.name +
+                  ' but awaited by ' +
+                  expectedOwner,
+              );
+            }
+          }
+        };
+        // Without a debug channel a value that is still pending when its
+        // await is serialized stays a halted stub forever, so the entry is
+        // attributed but can't be joined to a leaf. Count it against its
+        // owner so the completeness checks below can tell "attributed with
+        // an unreadable value" apart from "never attributed".
+        if (
+          io.value != null &&
+          io.value.status !== 'fulfilled' &&
+          io.value.status !== 'rejected' &&
+          entry.owner != null
+        ) {
+          unidentifiedAwaits.set(
+            entry.owner.name,
+            (unidentifiedAwaits.get(entry.owner.name) || 0) + 1,
+          );
+        }
         const leafId = leafIdOfValue(io.value);
         if (leafId !== null) {
           const meta = leafMeta.get(leafId);
@@ -918,55 +1101,10 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
               // the leaf-identity checks don't apply.
               return;
             }
-            const frames = io.stack ? io.stack.map(frame => frame[0]) : [];
-            // Pool io is named after the fs or timer API call, chained io
-            // after the leaf constructor.
-            if (meta.chain === null) {
-              if (!meta.useTimer && !/readFile/.test(io.name)) {
-                violations.push(leafId + ' pool fs io named ' + io.name);
-              }
-              if (meta.useTimer && !/setTimeout/.test(io.name)) {
-                violations.push(leafId + ' pool timer io named ' + io.name);
-              }
-            } else if (io.name !== 'leaf') {
-              violations.push(leafId + ' chained io named ' + io.name);
+            if (meta.rejects) {
+              violations.push(leafId + ' was created to reject but resolved');
             }
-            // Stacks start at the promise executor or the leaf
-            // constructor, never inside hook dispatch internals.
-            if (
-              frames.length > 0 &&
-              frames[0] !== 'readFixture' &&
-              frames[0] !== 'sleep' &&
-              frames[0] !== 'leaf'
-            ) {
-              violations.push(leafId + ' io stack starts at ' + frames[0]);
-            }
-            if (meta.useTimer && frames.indexOf('readFixture') !== -1) {
-              violations.push(
-                leafId + ' used a timer but its io stack reads a file',
-              );
-            }
-            if (!meta.useTimer && frames.indexOf('sleep') !== -1) {
-              violations.push(
-                leafId + ' read a file but its io stack is a timer',
-              );
-            }
-            // A leaf initiated by one render's component must never be
-            // attributed inside the other render.
-            if (meta.chain !== null) {
-              const initiator = meta.chain[meta.chain.length - 1];
-              if (
-                componentRoots.has(initiator) &&
-                componentRoots.get(initiator) !== rootIndex
-              ) {
-                violations.push(
-                  leafId +
-                    ' was initiated by the other render (' +
-                    initiator +
-                    ')',
-                );
-              }
-            }
+            checkLeafIo(leafId, meta);
             // The recorded value must be exactly what the leaf resolved to.
             const value = io.value.value;
             if (meta.object) {
@@ -985,6 +1123,29 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
                 end: io.end,
               });
             }
+          }
+        } else if (
+          io.value != null &&
+          io.value.status === 'rejected' &&
+          io.value.reason != null &&
+          typeof io.value.reason.message === 'string' &&
+          /^rejected v[0-9]+$/.test(io.value.reason.message)
+        ) {
+          // The rejection path must attribute its io as precisely as the
+          // happy path does.
+          const rejectedId = io.value.reason.message.slice('rejected '.length);
+          const meta = leafMeta.get(rejectedId);
+          if (meta === undefined) {
+            violations.push('io rejected with unknown leaf ' + rejectedId);
+          } else if (!meta.rejects) {
+            violations.push(
+              rejectedId + ' was created to resolve but rejected',
+            );
+          } else if (
+            !foreignLeaves.has(rejectedId) &&
+            !foreignSettles.has(rejectedId)
+          ) {
+            checkLeafIo(rejectedId, meta);
           }
         } else if (
           io.value != null &&
@@ -1199,9 +1360,13 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         leafMeta: program.leafMeta,
         foreignLeaves: program.foreignLeaves,
         foreignSettles: program.foreignSettles,
+        propLeaves: program.propLeaves,
+        propConsumers: program.propConsumers,
+        useComponents,
         rootIndex: i,
         violations,
         leafSightings: new Map(),
+        unidentifiedAwaits: new Map(),
         orderSamples: [],
         collected: false,
       };
@@ -1282,24 +1447,70 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
       }
     });
 
+    // For a combinator over plain single-leaf parts the settle order decides
+    // which part unblocked it: the last part to settle for all(), the first
+    // for race(). That leaf must be attributed like any direct await; the
+    // other parts stay exempt.
+    const combinatorUnblockers = new Set();
+    program.combinatorAwaits.forEach(record => {
+      if (
+        !record.flat ||
+        record.completionOrder.length !== record.parts.length
+      ) {
+        return;
+      }
+      // The part whose promise completed last (for all) or first (for race)
+      // is the one whose io unblocked the combinator. Completion order is
+      // recorded live because a part may take extra microtask hops after its
+      // leaf settles, so leaf settle order is not completion order.
+      const winnerIndex =
+        record.kind === 'all'
+          ? record.completionOrder[record.completionOrder.length - 1]
+          : record.completionOrder[0];
+      const part = record.parts[winnerIndex];
+      if (part.from + 1 !== part.to) {
+        return;
+      }
+      const winner = 'v' + part.from;
+      const winnerMeta = program.leafMeta.get(winner);
+      if (winnerMeta !== undefined && winnerMeta.settleIndex !== -1) {
+        combinatorUnblockers.add(winner);
+      }
+    });
+
     // Completeness: every leaf a component actually fetched and settled must
     // be attributed somewhere in that component's render. Exemptions, each
     // for a reason: aborted renders (the abort races the io), rejected roots
     // (nothing was collected), throwing subtrees (they never finish),
-    // combinator and parallel awaits (only the io that unblocked them is
-    // attributed -- TODO: the driver knows the settle order, so the
-    // unblocker is predictable; assert it exactly), use() components (the
-    // used promise carries the transformed value, so there is nothing to
-    // join on), and pre-request pool data (no initiating component).
+    // combinator parts that did not unblock their combinator and parallel
+    // awaits (only the io that unblocked them is attributed), use()
+    // components (the used promise carries the transformed value, so there
+    // is nothing to join on), and pre-request pool data (no initiating
+    // component).
     if (abortAfter === -1) {
       program.leafMeta.forEach((meta, leafId) => {
+        const combinators =
+          meta.chain === null
+            ? 0
+            : meta.chain.filter(
+                sourceName =>
+                  sourceName === 'loadAll' || sourceName === 'loadFastest',
+              ).length;
         if (
           meta.chain === null ||
           meta.rejects ||
           meta.big ||
           meta.settleIndex === -1 ||
-          meta.chain.indexOf('loadFastest') !== -1 ||
-          meta.chain.indexOf('loadAll') !== -1 ||
+          (combinators > 0 &&
+            !(combinators === 1 && combinatorUnblockers.has(leafId))) ||
+          meta.chain.indexOf('forkedDerived') !== -1 ||
+          // Like combinators, a derived chain nested inside another
+          // composite attributes whichever io the enclosing await chain
+          // surfaces, not necessarily its own.
+          (meta.chain.indexOf('loadDerived') !== -1 &&
+            !componentRoots.has(
+              meta.chain[meta.chain.indexOf('loadDerived') + 1],
+            )) ||
           meta.chain.indexOf('readPages') !== -1 ||
           meta.chain.indexOf('queryThenable') !== -1 ||
           // A value delivered through a userland thenable: React cannot see
@@ -1321,11 +1532,46 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
         }
         const ctx = contexts[componentRoots.get(initiator)];
         if (ctx && ctx.collected === true && !ctx.leafSightings.has(leafId)) {
+          const wildcards = ctx.unidentifiedAwaits.get(initiator) || 0;
+          if (wildcards > 0) {
+            ctx.unidentifiedAwaits.set(initiator, wildcards - 1);
+            return;
+          }
           violations.push(
             leafId +
               ' (' +
               meta.chain.join('<') +
               ') settled but never appeared in the debug info',
+          );
+        }
+      });
+
+      // A single-leaf promise handed down as a prop is awaited by the child,
+      // so it must be attributed inside the child's render.
+      program.propConsumers.forEach((consumer, leafId) => {
+        const meta = program.leafMeta.get(leafId);
+        if (
+          meta === undefined ||
+          meta.settleIndex === -1 ||
+          program.foreignLeaves.has(leafId)
+        ) {
+          return;
+        }
+        if (!componentRoots.has(consumer) || exempt.has(consumer)) {
+          return;
+        }
+        const ctx = contexts[componentRoots.get(consumer)];
+        if (ctx && ctx.collected === true && !ctx.leafSightings.has(leafId)) {
+          const wildcards = ctx.unidentifiedAwaits.get(consumer) || 0;
+          if (wildcards > 0) {
+            ctx.unidentifiedAwaits.set(consumer, wildcards - 1);
+            return;
+          }
+          violations.push(
+            leafId +
+              ' was passed as a prop to ' +
+              consumer +
+              ' but never appeared in its render',
           );
         }
       });

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoFuzz-test.js
@@ -831,6 +831,28 @@ describe('ReactFlightAsyncDebugInfoFuzz', () => {
           } else {
             leafSightings.set(leafId, (leafSightings.get(leafId) || 0) + 1);
             const frames = io.stack ? io.stack.map(frame => frame[0]) : [];
+            // Pool io is named after the fs or timer API call, chained io
+            // after the leaf constructor.
+            if (meta.chain === null) {
+              if (!meta.useTimer && !/readFile/.test(io.name)) {
+                violations.push(leafId + ' pool fs io named ' + io.name);
+              }
+              if (meta.useTimer && !/setTimeout/.test(io.name)) {
+                violations.push(leafId + ' pool timer io named ' + io.name);
+              }
+            } else if (io.name !== 'leaf') {
+              violations.push(leafId + ' chained io named ' + io.name);
+            }
+            // Stacks start at the promise executor or the leaf
+            // constructor, never inside hook dispatch internals.
+            if (
+              frames.length > 0 &&
+              frames[0] !== 'readFixture' &&
+              frames[0] !== 'sleep' &&
+              frames[0] !== 'leaf'
+            ) {
+              violations.push(leafId + ' io stack starts at ' + frames[0]);
+            }
             if (meta.useTimer && frames.indexOf('readFixture') !== -1) {
               violations.push(
                 leafId + ' used a timer but its io stack reads a file',


### PR DESCRIPTION
Stacked on #37129.

I'm not sure these are important and show up in practice vs which are purely test artifacts. This is the stuff found by the fuzzer so I figured we might want to fix these. See individual commits.

#### Strip hook dispatch stack frames by module instead of position

The await stack parse skipped a fixed count of `async_hooks` dispatch frames. This is a bit fragile (it is already wrong for plain `fs` callbacks). The proposal is to skip our own frame by count and the dispatch frames by module instead. The fuzzer now checks IO frame names; without the fix that fails on 5 of 20 seeds.

#### Don't turn fulfillment-only chunk subscriptions into unhandled rejections

In DEV, calling `chunk.then(onFulfill)` with no rejection callback still wires up a real native Promise inside the wrapper. If the chunk errors, that Promise rejects, and nothing can catch it: the caller didn't pass a rejection callback, and our `.then()` returns undefined so there's nothing to attach one to. Node then kills the process for an unhandled rejection. In practice only our test utils subscribe like this today, so this mostly makes tests around rejections not blow up. The fix is to only forward the rejection when the caller passed a rejection callback, which is what prod does.

#### Don't let debug info failures corrupt the data they describe

The server degrades a debug model to a placeholder string when it fails to serialize, and a prop that throws on property access triggers that today. The client then threw while initializing entries that reference the degraded model — writing a fake stack location onto an owner that's now a string — and the throw rejected the entry's pending data chunk. When the chunk's real row arrived, `resolveModelChunk` assumed that this means it's a stream chunk (because the chunk was no longer pending) and crashed the whole stream with `controller.enqueueModel is not a function`.

Now the failed entry is dropped instead (its slot gets a minimal component info). The next commit fixes the trigger, so this is not strictly necessary for the tests to pass, but it prevents similar crashes if there are more bugs like it.

#### Keep the shape of debug models that fail to serialize

`JSON.stringify` probes `toJSON` on every raw object before the replacer can substitute it, so a value whose property access throws replaced the whole model with a placeholder string, breaking every reference into it.

Probe each object the replacer returns first. If it throws, copy with a placeholder per broken value. The fuzzer now delivers promise props behind throwing proxies; without the fix that fails on 3 of 20 seeds.