### PR TITLE
[react-devtools] Keep single-string console specifiers literal when no argument is supplied

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -163,6 +163,20 @@ describe('utils', () => {
       );
     });
 
+    it('keeps specifiers literal when no argument is supplied', () => {
+      expect(formatConsoleArgumentsToSingleString('%s %s', 'value')).toEqual(
+        'value %s',
+      );
+      expect(formatConsoleArgumentsToSingleString('%d %d', 1)).toEqual('1 %d');
+      expect(formatConsoleArgumentsToSingleString('%i %i', 1)).toEqual('1 %i');
+      expect(formatConsoleArgumentsToSingleString('%f %f', 1.5)).toEqual(
+        '1.5 %f',
+      );
+      expect(formatConsoleArgumentsToSingleString('%s %d', 'value')).toEqual(
+        'value %d',
+      );
+    });
+
     it('should gracefully handle Symbol types', () => {
       expect(
         formatConsoleArgumentsToSingleString(Symbol('a'), 'b', Symbol('c')),

--- a/packages/react-devtools-shared/src/backend/utils/index.js
+++ b/packages/react-devtools-shared/src/backend/utils/index.js
@@ -197,6 +197,13 @@ export function formatConsoleArgumentsToSingleString(
 
       // $FlowFixMe[incompatible-type]
       formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+        // No argument left for this specifier. Keep it as a literal, like the
+        // browser console and formatConsoleArguments do, rather than emitting
+        // 'undefined' / 'NaN' from formatting an empty shift().
+        if (!escaped && args.length === 0) {
+          return match;
+        }
+
         let arg = args.shift();
         switch (flag) {
           case 's':


### PR DESCRIPTION
## Summary

Fixes #37126.

`formatConsoleArgumentsToSingleString` still consumed a missing argument for unmatched `%s` / `%d` / `%i` / `%f` placeholders via `args.shift()`, so results like `value undefined` and `1 NaN` were produced. That diverged from browser console / Node `util.format` behavior, and from the sibling `formatConsoleArguments` helper which already keeps unmatched specifiers literal (#36930).

This change skips the substitution when no argument remains, so unmatched placeholders stay as literals (e.g. `value %s`, `1 %d`). That keeps DevTools message keys aligned with the console output for warnings and errors logged during render, commit, and passive effects.

## Test plan

- [x] Added regression coverage in `utils-test.js` mirroring the existing `formatConsoleArguments` missing-argument cases
- [x] Verified the updated formatting cases locally (`value %s`, `1 %d`, `1 %i`, `1.5 %f`, plus existing substitution cases still pass)

