### PR TITLE
[Flight] Allow old non-live async debug info to be GC'd

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -91,6 +91,7 @@ import {
   getChildFormatContext,
   initAsyncDebugInfo,
   markAsyncSequenceRootTask,
+  markAsyncSequenceRequest,
   getCurrentAsyncSequence,
   getAsyncSequenceFromPromise,
   parseStackTrace,
@@ -801,6 +802,11 @@ function RequestInstance(
         performance.timeOrigin,
     );
     this.abortTime = -0.0;
+    if (__DEV__ && enableAsyncDebugInfo) {
+      // Let the async sequence tracking know this request may consume async
+      // debug info from here on.
+      markAsyncSequenceRequest(this as any);
+    }
   } else {
     timeOrigin = 0;
   }
@@ -896,6 +902,15 @@ export function resolveRequest(): null | Request {
     if (store) return store;
   }
   return null;
+}
+
+// A closed main stream doesn't mean the request is done: a separate debug
+// channel can stay open and keep receiving debug info.
+export function canRequestStillEmitDebugInfo(request: Request): boolean {
+  return (
+    request.debugDestination !== null ||
+    (request.status !== CLOSING && request.status !== CLOSED)
+  );
 }
 
 function isTypedArray(value: any): boolean {

--- a/packages/react-server/src/ReactFlightServerConfigDebugNode.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNode.js
@@ -26,7 +26,13 @@ import {
   UNRESOLVED_AWAIT_NODE,
 } from './ReactFlightAsyncSequence';
 import {resolveOwner} from './flight/ReactFlightCurrentOwner';
-import {resolveRequest, isAwaitInUserspace} from './ReactFlightServer';
+import type {Request} from './ReactFlightServer';
+
+import {
+  resolveRequest,
+  isAwaitInUserspace,
+  canRequestStillEmitDebugInfo,
+} from './ReactFlightServer';
 import {createHook, executionAsyncId} from 'async_hooks';
 import {promiseHooks} from 'v8';
 import {enableAsyncDebugInfo} from 'shared/ReactFeatureFlags';
@@ -71,6 +77,85 @@ const executingPromises: Array<Promise<any>> =
 
 // Keep the last resolved await as a workaround for async functions missing data.
 let lastRanAwait: null | AwaitNode = null;
+
+// The requests that might still consume async debug info, held weakly so one
+// that never formally closes still expires with GC.
+const liveRequests: Set<WeakRef<Request>> =
+  __DEV__ && enableAsyncDebugInfo ? new Set() : (null as any);
+
+export function markAsyncSequenceRequest(request: Request): void {
+  if (__DEV__ && enableAsyncDebugInfo) {
+    liveRequests.add(new WeakRef(request));
+  }
+}
+
+function getOldestLiveRequestTimeOrigin(): number {
+  let oldest = Infinity;
+  liveRequests.forEach(requestRef => {
+    const request = requestRef.deref();
+    if (request === undefined || !canRequestStillEmitDebugInfo(request)) {
+      liveRequests.delete(requestRef);
+    } else if (request.timeOrigin < oldest) {
+      oldest = request.timeOrigin;
+    }
+  });
+  return oldest;
+}
+
+// visitAsyncNodeImpl stops at any node that resolved at or before the
+// consuming request's time origin, so a node that resolved before every
+// possible consumer's origin contributes nothing wherever it appears and can
+// drop its own links, releasing the history behind it. Two consumers keep links
+// alive: a live request, which pins its own history from its time origin (those
+// nodes are re-enqueued, so they don't count against this budget), and a
+// request that doesn't exist yet, which may backdate itself with
+// options.startTime. Only the latter is unbounded, so it's bounded by count
+// rather than by time, which would be multiplied by the tracking rate. Measured
+// gaps between capturing a start time and creating the request stay near a
+// hundred operations even under load.
+const MAX_RETAINED_OPERATIONS = 10000;
+
+const agingOperations: Array<AsyncSequence> =
+  __DEV__ && enableAsyncDebugInfo ? [] : (null as any);
+let agingHead = 0;
+let operationsSinceSweep = 0;
+
+function trackAgingOperation(node: AsyncSequence): void {
+  agingOperations.push(node);
+  if (++operationsSinceSweep >= 128) {
+    sweepAgingOperations();
+  }
+}
+
+function sweepAgingOperations(): void {
+  operationsSinceSweep = 0;
+  const cutoff = getOldestLiveRequestTimeOrigin();
+  // A node that can't be cleared goes back on the tail, so the queue doesn't
+  // shorten and the range has to be taken up front. Capped so a backlog drains
+  // over later sweeps instead of pausing this one.
+  let remaining = agingOperations.length - agingHead - MAX_RETAINED_OPERATIONS;
+  if (remaining > 1000) {
+    remaining = 1000;
+  }
+  while (remaining-- > 0) {
+    const node = agingOperations[agingHead];
+    agingOperations[agingHead] = null as any;
+    agingHead++;
+    // Unsettled nodes (end < 0) are never cleared. The walk stops at `<=` the
+    // origin, so requiring strictly before the cutoff is conservative.
+    if (node.end >= 0 && node.end < cutoff) {
+      (node as any).awaited = null;
+      (node as any).previous = null;
+    } else if (node.awaited !== null || node.previous !== null) {
+      // Pinned by a live request or not settled yet; reconsider later.
+      agingOperations.push(node);
+    }
+  }
+  if (agingHead > 1024 && agingHead * 2 >= agingOperations.length) {
+    agingOperations.splice(0, agingHead);
+    agingHead = 0;
+  }
+}
 
 function resolvePromiseOrAwaitNode(
   unresolvedNode: UnresolvedAwaitNode | UnresolvedPromiseNode,
@@ -245,6 +330,7 @@ function promiseSettled(node: AsyncSequence, selfResolved: boolean): void {
           awaited: resolvedNode.awaited,
           previous: resolvedNode.previous,
         };
+        trackAgingOperation(clonedNode);
         // We started awaiting on the callback when the original .then() resolved.
         resolvedNode.start = resolvedNode.end;
         // It resolved now. We could use the end time of "awaited" maybe.
@@ -301,6 +387,7 @@ export function initAsyncDebugInfo(): void {
             node = createPromiseNode(promise, getCurrentOperation());
           }
           pendingPromises.set(promise, node);
+          trackAgingOperation(node);
         },
         before(promise: Promise<any>): void {
           executingPromises.push(promise);
@@ -394,6 +481,7 @@ export function initAsyncDebugInfo(): void {
               awaited: null,
               previous: null,
             } as IONode;
+            trackAgingOperation(node);
           } else if (
             trigger.tag === AWAIT_NODE ||
             trigger.tag === UNRESOLVED_AWAIT_NODE
@@ -411,6 +499,7 @@ export function initAsyncDebugInfo(): void {
               awaited: null,
               previous: trigger,
             } as IONode;
+            trackAgingOperation(node);
           } else {
             // Otherwise, this is just a continuation of the same I/O sequence.
             node = trigger;
@@ -452,6 +541,7 @@ export function initAsyncDebugInfo(): void {
                 awaited: ioNode.awaited,
                 previous: ioNode.previous,
               };
+              trackAgingOperation(clonedNode);
               pendingOperations.set(asyncId, clonedNode);
             }
           } else {
@@ -473,6 +563,8 @@ export function markAsyncSequenceRootTask(): void {
     } else {
       pendingOperations.delete(executionAsyncId());
     }
+    // Renders are also a good time to release expired history.
+    sweepAgingOperations();
   }
 }
 

--- a/packages/react-server/src/ReactFlightServerConfigDebugNode.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNode.js
@@ -44,6 +44,26 @@ enableAsyncDebugInfo
 const pendingOperations: Map<number, AsyncSequence> =
   __DEV__ && enableAsyncDebugInfo ? new Map() : (null as any);
 
+// We intentionally don't use the async_hooks destroy hook to prune the map.
+// Destroy hooks are counted globally in Node.js and as soon as one exists,
+// every Promise in the process gets its own GC-tracked destroy registration,
+// which is the per-Promise overhead the V8 promise hooks otherwise avoid.
+// Instead we observe the collection of the resource object itself. Resources
+// are passed to init so this tracks the actual handle, not just an id.
+const pendingOperationsRegistry: FinalizationRegistry<number> =
+  __DEV__ && enableAsyncDebugInfo
+    ? new FinalizationRegistry(asyncId => {
+        pendingOperations.delete(asyncId);
+      })
+    : (null as any);
+
+// Pooled resources (e.g. HTTPPARSER) are inited with a new id on each reuse
+// but only collected when the pool releases them. Tracking the last id per
+// resource lets a reuse evict the previous use's entry, so a pooled resource
+// holds at most one entry at a time.
+const lastResourceId: WeakMap<any, number> =
+  __DEV__ && enableAsyncDebugInfo ? new WeakMap() : (null as any);
+
 // The stack of Promises whose continuations are currently executing.
 // The equivalent of executionAsyncId() for the V8 promise hooks.
 const executingPromises: Array<Promise<any>> =
@@ -396,6 +416,14 @@ export function initAsyncDebugInfo(): void {
             node = trigger;
           }
         }
+        const previousId = lastResourceId.get(resource);
+        if (previousId !== undefined) {
+          // This resource was reused from a pool. Its previous use is done.
+          pendingOperations.delete(previousId);
+          pendingOperationsRegistry.unregister(resource);
+        }
+        lastResourceId.set(resource, asyncId);
+        pendingOperationsRegistry.register(resource, asyncId, resource);
         pendingOperations.set(asyncId, node);
       },
       before(asyncId: number): void {
@@ -430,12 +458,6 @@ export function initAsyncDebugInfo(): void {
             beforeExecution(node);
           }
         }
-      },
-
-      destroy(asyncId: number): void {
-        // If we needed the meta data from this operation we should have already
-        // extracted it or it should be part of a chain of triggers.
-        pendingOperations.delete(asyncId);
       },
     }).enable();
   }

--- a/packages/react-server/src/ReactFlightServerConfigDebugNoop.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNoop.js
@@ -12,6 +12,7 @@ import type {AsyncSequence} from './ReactFlightAsyncSequence';
 // Exported for runtimes that don't support Promise instrumentation for async debugging.
 export function initAsyncDebugInfo(): void {}
 export function markAsyncSequenceRootTask(): void {}
+export function markAsyncSequenceRequest(request: any): void {}
 export function getCurrentAsyncSequence(): null | AsyncSequence {
   return null;
 }

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoExpiration-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoExpiration-test.js
@@ -11,6 +11,8 @@
 import {patchSetImmediate} from '../../../../scripts/jest/patchSetImmediate';
 
 let React;
+let ReactServer;
+let cache;
 let ReactServerDOMServer;
 let ReactServerDOMClient;
 let Stream;
@@ -42,8 +44,9 @@ describe('ReactFlightAsyncDebugInfoExpiration', () => {
     jest.mock('react-server-dom-webpack/server', () =>
       jest.requireActual('react-server-dom-webpack/server.node'),
     );
-    require('react');
+    ReactServer = require('react');
     ReactServerDOMServer = require('react-server-dom-webpack/server');
+    cache = ReactServer.cache;
 
     jest.resetModules();
     jest.useRealTimers();
@@ -158,6 +161,134 @@ describe('ReactFlightAsyncDebugInfoExpiration', () => {
       )
     ) {
       expect(getDebugInfo(result).filter(entry => entry.awaited)).toEqual([]);
+    }
+  });
+
+  it('keeps history alive while a debug channel is still open', async () => {
+    // A bidirectional debug channel lets the client ask for more debug info
+    // after the response is done. The main stream closes but this request can
+    // still walk the graph, so its history has to stay put.
+    const debugChannel = new Stream.Duplex({
+      ...streamOptions,
+      read() {},
+      write(chunk, encoding, callback) {
+        callback();
+      },
+    });
+    async function Init() {
+      await delay(1);
+      return 'ok';
+    }
+    const initStream = ReactServerDOMServer.renderToPipeableStream(
+      <Init />,
+      {},
+      {filterStackFrame, debugChannel},
+    );
+    const initReadable = new Stream.PassThrough(streamOptions);
+    const initResult = ReactServerDOMClient.createFromNodeStream(initReadable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    initStream.pipe(initReadable);
+    expect(await initResult).toBe('ok');
+    await finishLoadingStream(initReadable);
+
+    async function fetchCachedData() {
+      await delay(5);
+      return 'hello';
+    }
+    const cachedStartTime =
+      // $FlowFixMe[prop-missing]
+      performance.timeOrigin + performance.now();
+    const cachedData = fetchCachedData();
+    await cachedData;
+
+    churnPastRetention();
+
+    async function Component() {
+      return 'data:' + (await cachedData);
+    }
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      <Component />,
+      {},
+      {
+        filterStackFrame,
+        startTime: cachedStartTime,
+      },
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect(await result).toBe('data:hello');
+    await finishLoadingStream(readable);
+
+    if (
+      __DEV__ &&
+      gate(
+        flags =>
+          flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+      )
+    ) {
+      // The fetch resolved after the first request started, so that request
+      // pinned it through the sweeps and it's still here.
+      const awaitedNames = getDebugInfo(result)
+        .filter(entry => entry.awaited)
+        .map(entry => entry.awaited.name);
+      expect(awaitedNames).toContain('setTimeout');
+    }
+  });
+
+  it('keeps debug info intact when history expires during the render', async () => {
+    const getData = cache(async function getData(text) {
+      await delay(1);
+      return text.toUpperCase();
+    });
+
+    // History expires while this render is still running. Anything the
+    // render itself can still emit must survive the sweeps.
+    async function Child() {
+      const greeting = await getData('hi');
+      return greeting + ', Seb';
+    }
+
+    async function Component() {
+      await getData('hi');
+      churnPastRetention();
+      return <Child />;
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      <Component />,
+      {},
+      {
+        filterStackFrame,
+      },
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect(await result).toBe('HI, Seb');
+    await finishLoadingStream(readable);
+
+    if (
+      __DEV__ &&
+      gate(
+        flags =>
+          flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+      )
+    ) {
+      // The cached entry resolved after this request started, so its awaited
+      // I/O info must survive the sweeps.
+      const awaitedNames = getDebugInfo(result)
+        .filter(entry => entry.awaited)
+        .map(entry => entry.awaited.name);
+      expect(awaitedNames).toContain('delay');
     }
   });
 });

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoExpiration-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfoExpiration-test.js
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment node
+ */
+'use strict';
+
+// The async debug info tracking retains the history behind every tracked
+// operation only for as long as some request could still emit it. History
+// expires after enough newer operations have been tracked, so these tests
+// churn through awaits to age it.
+
+import {patchSetImmediate} from '../../../../scripts/jest/patchSetImmediate';
+
+let React;
+let ReactServerDOMServer;
+let ReactServerDOMClient;
+let Stream;
+let getDebugInfo;
+
+const streamOptions = {
+  objectMode: true,
+};
+
+function filterStackFrame(filename, functionName) {
+  return (
+    !filename.startsWith('node:') &&
+    !filename.includes('node_modules') &&
+    // Filter out our own internal source code since it'll typically be in node_modules
+    (!filename.includes('/packages/') || filename.includes('/__tests__/')) &&
+    !filename.includes('/build/') &&
+    !functionName.includes('internal_')
+  );
+}
+
+describe('ReactFlightAsyncDebugInfoExpiration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useRealTimers();
+    patchSetImmediate();
+    global.console = require('console');
+
+    jest.mock('react', () => require('react/react.react-server'));
+    jest.mock('react-server-dom-webpack/server', () =>
+      jest.requireActual('react-server-dom-webpack/server.node'),
+    );
+    require('react');
+    ReactServerDOMServer = require('react-server-dom-webpack/server');
+
+    jest.resetModules();
+    jest.useRealTimers();
+    patchSetImmediate();
+
+    __unmockReact();
+    jest.unmock('react-server-dom-webpack/server');
+    jest.mock('react-server-dom-webpack/client', () =>
+      jest.requireActual('react-server-dom-webpack/client.node'),
+    );
+
+    React = require('react');
+    ReactServerDOMClient = require('react-server-dom-webpack/client');
+    Stream = require('stream');
+
+    getDebugInfo = require('internal-test-utils').getDebugInfo.bind(null, {
+      ignoreProps: true,
+      useFixedTime: true,
+    });
+  });
+
+  function delay(timeout) {
+    return new Promise(resolve => {
+      setTimeout(resolve, timeout);
+    });
+  }
+
+  function finishLoadingStream(readable) {
+    return new Promise(resolve => {
+      if (readable.readableEnded) {
+        resolve();
+      } else {
+        readable.on('end', () => resolve());
+      }
+    });
+  }
+
+  // Enough tracked operations to age everything created before them past the
+  // retention budget. Every Promise is tracked at creation and the expiration
+  // sweeps run every 128 tracked operations, so nothing needs to be awaited.
+  function churnPastRetention() {
+    for (let i = 0; i < 20; i++) {
+      for (let j = 0; j < 1500; j++) {
+        Promise.resolve(j);
+      }
+    }
+  }
+
+  it('expires history that resolved long before a backdated request', async () => {
+    // A request initializes the tracking; after the stream closes, nothing
+    // pins history anymore.
+    async function Init() {
+      await delay(1);
+      return 'ok';
+    }
+    const initStream = ReactServerDOMServer.renderToPipeableStream(
+      <Init />,
+      {},
+      {filterStackFrame},
+    );
+    const initReadable = new Stream.PassThrough(streamOptions);
+    const initResult = ReactServerDOMClient.createFromNodeStream(initReadable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    initStream.pipe(initReadable);
+    expect(await initResult).toBe('ok');
+    await finishLoadingStream(initReadable);
+
+    // Data fetched outside any request and kept alive, like a module-level
+    // cache. A request backdated to before the fetch may still consume its
+    // history for as long as the retention window allows.
+    async function fetchCachedData() {
+      await delay(5);
+      return 'hello';
+    }
+    const cachedStartTime =
+      // $FlowFixMe[prop-missing]
+      performance.timeOrigin + performance.now();
+    const cachedData = fetchCachedData();
+    await cachedData;
+
+    churnPastRetention();
+
+    // This request claims it started before the fetch, but arrived long
+    // after it, so the fetch's history must be gone.
+    async function Component() {
+      return 'data:' + (await cachedData);
+    }
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      <Component />,
+      {},
+      {
+        filterStackFrame,
+        startTime: cachedStartTime,
+      },
+    );
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+    expect(await result).toBe('data:hello');
+    await finishLoadingStream(readable);
+
+    if (
+      __DEV__ &&
+      gate(
+        flags =>
+          flags.enableComponentPerformanceTrack && flags.enableAsyncDebugInfo,
+      )
+    ) {
+      expect(getDebugInfo(result).filter(entry => entry.awaited)).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #37133.

Alternative to #36995 (which couldn't work due to #37037).

Fixes vercel/next.js#85666.

---

In DEV each `await` adds a node to the async debug info graph that points back at the node it awaited and at the node that ran before it in the same async context. These are strong references and they only point backwards, so a promise that hasn't settled keeps every node created before it alive. In a dev server some promises never settle — a Next.js HMR subscription is an infinite `for await...of`, one per compiled chunk. We could try to whack-a-mole it with fixes like vercel/next.js#91704 but ideally we would solve this once and for all.

A walk already stops at any node that resolved at or before the walking request's `timeOrigin`, since data that was ready before the render started isn't reported. So once a node is older than every request that could still walk it, clearing its two links can't change what anyone emits. Since #37133 those links are the only thing keeping the history behind it alive.

The cutoff is the oldest `timeOrigin` of any live request. A request stays live while it can still emit debug info, not just while its main stream is open, so an open debug channel keeps it in the set. Anything a live request can reach goes back on the queue instead of being cleared.

Each node clears its own links rather than links that point at old nodes. `awaited` is also read directly, not only followed: the aborting path reports a promise that spanned the abort time, and it needs the link to be there.

Clearing isn't immediate. A request can be created later with `options.startTime` set to before the node resolved, and it is supposed to see that history, so a node is only cleared once 10k more operations have been tracked. Counting operations rather than time is deliberate: a time window gets multiplied by the tracking rate, and on an idle server it retains everything. Sweeping is capped at 1000 nodes and runs once per 128 operations, so a backlog drains over later sweeps instead of pausing a render.

A request that backdates further than 10k operations now gets history starting at the cutoff instead of all of it. History reached through an expired node in a `previous` chain goes too. At least in Next.js scenarios I've tested, creating the request after capturing its `startTime` is synchronous and takes around a hundred operations, so this shouldn't affect anything in practice. I suspect there are cases where this is supported so maybe it could be configurable? It just feels like the tradeoff is wrong right now. Or maybe there is another solution I don't see that lets us have both.

The first commit is unrelated. The map of non-Promise resources (timers, sockets, file handles) was pruned by the `async_hooks` destroy hook. Node counts destroy hooks globally, so while any of them exists every promise in the process gets its own GC tracked destroy registration, which is the per-promise cost that #37133 removed. A `FinalizationRegistry` on the resource object prunes the map instead.

## Test Plan

I asked Claude to measure this on v0 repo by simulating edits:

<img width="1628" height="1058" alt="Screenshot 2026-07-28 at 22 15 52" src="https://github.com/user-attachments/assets/ef0aa425-6081-407e-8d0e-a5847dc14c11" />

v0's dev server tracks about 43k awaits per page load. The benchmark replays that with 40 page loads, each one a Flight render plus 43k background awaits with an idle gap in between, sampling the heap after a forced GC at the end of each load. Before this the heap goes from 13 MB to 187 MB over the 40 loads and stays at 187 MB after the workload stops. After, it stays between 9 and 10 MB.

I couldn't figure out how to test the memory thing itself reliably so instead I have tests verifying what we're "breaking" intentionally (and that we don't do that for things visible to live requests):

- `expires history that resolved long before a backdated request` fetches data outside any request, tracks enough newer operations to age it out, then renders a request whose `startTime` predates the fetch. On the parent commit the fetch's full history is still emitted.

- `keeps history alive while a debug channel is still open` does the same aging with a request whose main stream has closed but whose debug channel hasn't, and asserts the history survives. Treating that request as done breaks it.

- `keeps debug info intact when history expires during the render` runs several sweeps in the middle of a render and asserts that a later component still gets the awaited I/O info for a value that resolved after the request started. Replacing the `liveRequests` cutoff with an unconditional sweep breaks it.
