### PR TITLE
[compiler] Fix react-compiler-healthcheck reporting every component as compiled

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
@@ -55,16 +55,14 @@ const COMPILER_OPTIONS: PluginOptions = {
 
 function isActionableDiagnostic(detail: CompilerErrorDetailOptions) {
   switch (detail.severity) {
-    case ErrorSeverity.InvalidReact:
-    case ErrorSeverity.InvalidJS:
+    case ErrorSeverity.Error:
       return true;
-    case ErrorSeverity.InvalidConfig:
-    case ErrorSeverity.Invariant:
-    case ErrorSeverity.CannotPreserveMemoization:
-    case ErrorSeverity.Todo:
+    case ErrorSeverity.Warning:
+    case ErrorSeverity.Hint:
+    case ErrorSeverity.Off:
       return false;
     default:
-      throw new Error(`Unhandled error severity \`${detail.severity}\``);
+      return false;
   }
 }
 


### PR DESCRIPTION
## Summary

`react-compiler-healthcheck` reports "N out of N components" on every codebase, because it can never record a bailout. `isActionableDiagnostic` switches on `ErrorSeverity` members (`InvalidReact`, `InvalidJS`, `InvalidConfig`, `Invariant`, `CannotPreserveMemoization`, `Todo`) that were removed from the enum, which now only has `Error`, `Warning`, `Hint`, and `Off`. So a real `detail.severity` matches no case, hits `default`, and throws `Unhandled error severity`. That throw fires inside `logger.logEvent`, and `compile()` runs everything in `try { … } catch {}`, so the error is swallowed. The failing component never lands in `ActionableFailures`/`OtherFailures`, `totalComponents` collapses down to the success count, and the summary can only ever print 100%. The throw also aborts the file early, so any successes after the first bailout in that file are lost too.

This maps the switch onto the current enum (`Error` is actionable, `Warning`/`Hint`/`Off` are not) and makes `default` non-fatal, so an unknown severity gets counted instead of throwing.

Fixes #37138

## How did you test this change?

Built the package and ran it over two files, one clean component and one that mutates props (an `Error`-severity bailout):

- Before: `Successfully compiled 1 out of 1 components.` The bailing component was dropped silently.
- After: `Successfully compiled 1 out of 2 components.`

Temporarily logging inside `compile`'s `catch` confirmed the swallowed error was `Unhandled error severity \`Error\``. `prettier --check` on the changed file passes.
