### PR TITLE
[Fragment Refs] Fix DOM/Fiber containment validation

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1673,6 +1673,42 @@ describe('FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs
+    it('returns implementation specific when DOM containment disagrees with the Fiber tree', async () => {
+      const fragmentRef = React.createRef();
+      const childRef = React.createRef();
+      const unrelatedParentRef = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+
+      function Test() {
+        return (
+          <div>
+            <div>
+              <React.Fragment ref={fragmentRef}>
+                <div ref={childRef} />
+              </React.Fragment>
+            </div>
+            <div ref={unrelatedParentRef} />
+          </div>
+        );
+      }
+
+      await act(() => root.render(<Test />));
+      unrelatedParentRef.current.appendChild(childRef.current);
+
+      expectPosition(
+        fragmentRef.current.compareDocumentPosition(unrelatedParentRef.current),
+        {
+          preceding: false,
+          following: false,
+          contains: false,
+          containedBy: false,
+          disconnected: false,
+          implementationSpecific: true,
+        },
+      );
+    });
+
+    // @gate enableFragmentRefs
     it('handles fragment instances with one child', async () => {
       const fragmentRef = React.createRef();
       const beforeRef = React.createRef();

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1675,28 +1675,37 @@ describe('FragmentRefs', () => {
     // @gate enableFragmentRefs
     it('returns implementation specific when DOM containment disagrees with the Fiber tree', async () => {
       const fragmentRef = React.createRef();
-      const childRef = React.createRef();
-      const unrelatedParentRef = React.createRef();
+      const portalContainerRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
 
       function Test() {
+        const [portalContainer, setPortalContainer] = React.useState(null);
+
+        React.useLayoutEffect(() => {
+          setPortalContainer(portalContainerRef.current);
+        }, []);
+
         return (
-          <div>
-            <div>
-              <React.Fragment ref={fragmentRef}>
-                <div ref={childRef} />
-              </React.Fragment>
-            </div>
-            <div ref={unrelatedParentRef} />
-          </div>
+          <>
+            <div ref={portalContainerRef} />
+            {portalContainer === null
+              ? null
+              : createPortal(
+                  <div>
+                    <React.Fragment ref={fragmentRef}>
+                      <div />
+                    </React.Fragment>
+                  </div>,
+                  portalContainer,
+                )}
+          </>
         );
       }
 
       await act(() => root.render(<Test />));
-      unrelatedParentRef.current.appendChild(childRef.current);
 
       expectPosition(
-        fragmentRef.current.compareDocumentPosition(unrelatedParentRef.current),
+        fragmentRef.current.compareDocumentPosition(portalContainerRef.current),
         {
           preceding: false,
           following: false,

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -596,21 +596,7 @@ export function isFragmentContainedByFiber(
   fragmentFiber: Fiber,
   otherFiber: Fiber,
 ): boolean {
-  let current: Fiber | null = fragmentFiber;
-  const fiberHostParent: Fiber | null =
-    getFragmentParentInstanceOrContainerFiber(fragmentFiber);
-  while (current !== null) {
-    if (
-      (current.tag === HostComponent ||
-        current.tag === HostRoot ||
-        current.tag === HostSingleton) &&
-      (current === fiberHostParent || current.alternate === fiberHostParent)
-    ) {
-      return true;
-    }
-    current = current.return;
-  }
-  return false;
+  return doesFiberContain(otherFiber, fragmentFiber);
 }
 
 export function isFiberPreceding(fiber: Fiber, otherFiber: Fiber): boolean {


### PR DESCRIPTION
## Summary

`isFragmentContainedByFiber` ignored the Fiber it was meant to compare and instead checked whether a mounted Fragment reached its own host parent. This made `FragmentInstance.compareDocumentPosition()` accept DOM containment even when the DOM had been imperatively moved outside the corresponding Fiber subtree.

Use the existing alternate-aware `doesFiberContain` helper to validate the actual ancestor, and cover the DOM/Fiber disagreement with a regression test.

## How did you test this change?

- Confirmed the regression test fails before the fix: the result contained `PRECEDING | CONTAINS` instead of `IMPLEMENTATION_SPECIFIC`.
- `yarn test --silent --no-watchman ReactDOMFragmentRefs-test --runInBand`
- `yarn test --prod --silent --no-watchman ReactDOMFragmentRefs-test --runInBand`
- `yarn test-www --silent --no-watchman ReactDOMFragmentRefs-test --runInBand`
- `yarn test-www --variant=false --silent --no-watchman ReactDOMFragmentRefs-test --runInBand`
- `yarn flow dom-node`
- `yarn prettier`
- `yarn linc`
