### PR TITLE
Preserve imperative singleton attributes on acquire

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -4837,11 +4837,8 @@ export function acquireSingletonInstance(
     }
   }
 
-  const attributes = instance.attributes;
-  while (attributes.length) {
-    instance.removeAttributeNode(attributes[0]);
-  }
-
+  // Preserve attributes that aren't represented by this Fiber's props. They
+  // may have been added imperatively before React acquired the singleton.
   setInitialProperties(instance, type, props);
   precacheFiberNode(internalInstanceHandle, instance);
   updateFiberProps(instance, props);

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -405,7 +405,6 @@ describe('ReactDOM HostSingleton', () => {
     expect(body.innerHTML).toBe('<span>managed child</span>');
   });
 
-  // @gate TODO
   it('preserves imperative attributes when acquiring a singleton', async () => {
     const body = document.body;
     body.setAttribute('data-external', 'true');
@@ -421,6 +420,32 @@ describe('ReactDOM HostSingleton', () => {
 
     expect(document.body).toBe(body);
     expect(body.getAttribute('data-external')).toBe('true');
+  });
+
+  it('preserves imperative attributes when reacquiring a singleton', async () => {
+    const root = ReactDOMClient.createRoot(document);
+    const html = document.documentElement;
+
+    root.render(
+      <html key="first">
+        <head />
+        <body />
+      </html>,
+    );
+    await waitForAll([]);
+
+    html.setAttribute('data-external', 'true');
+
+    root.render(
+      <html key="second">
+        <head />
+        <body />
+      </html>,
+    );
+    await waitForAll([]);
+
+    expect(document.documentElement).toBe(html);
+    expect(html.getAttribute('data-external')).toBe('true');
   });
 
   // @gate TODO
@@ -609,16 +634,17 @@ describe('ReactDOM HostSingleton', () => {
       document.head,
       document.body,
     ]);
-    // Similar to Hydration we don't reset attributes on the instance itself even on a fresh render.
+    // Similar to hydration, a fresh render preserves existing attributes and
+    // resource nodes on singleton instances.
     expect(getVisibleChildren(document)).toEqual(
-      <html data-client-foo="foo">
-        <head>
+      <html data-foo="foo" data-client-foo="foo">
+        <head data-bar="bar">
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
           <title>a client title</title>
         </head>
-        <body data-client-baz="baz">
+        <body data-baz="baz" data-client-baz="baz">
           <style>
             {`
                 body: {
@@ -629,6 +655,12 @@ describe('ReactDOM HostSingleton', () => {
         </body>
       </html>,
     );
+
+    // The remainder of this test focuses on persistent children and resources.
+    // Attribute preservation is covered independently above.
+    document.documentElement.removeAttribute('data-foo');
+    document.head.removeAttribute('data-bar');
+    document.body.removeAttribute('data-baz');
 
     // Render new children and assert they append in the correct locations
     root.render(


### PR DESCRIPTION
## Summary

Fixes #37145.

Host Singleton acquisition currently removes every attribute from the existing DOM node before applying the new Fiber's props. This also removes attributes that React does not own, such as a `data-theme` value set by a pre-hydration script, when a keyed `<html>` remounts.

This change preserves existing attributes during acquisition and continues to apply React-owned props through `setInitialProperties`. It also enables the existing cold-acquisition test, adds coverage for keyed reacquisition, and updates the persistent document test to assert the preserved attributes explicitly.

## How did you test this change?

- `yarn test ReactDOMSingletonComponents` (22 passed, 1 skipped)
- `yarn test --prod ReactDOMSingletonComponents` (22 passed, 1 skipped)
- `yarn test ReactRenderDocument` (8 passed)
- `yarn prettier`
- `yarn linc`
- `yarn flow dom-browser`
