### PR TITLE
[Flight] Outline and dedupe repeated strings

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2173,6 +2173,10 @@ function transferReferencedDebugInfo(
   }
 }
 
+// Most references have no path, so they can all share the same empty array.
+// It's never mutated because only paths with entries get spliced in place.
+const EMPTY_REFERENCE_PATH: Array<string> = [];
+
 function getOutlinedModel<T>(
   response: Response,
   reference: string,
@@ -2180,8 +2184,10 @@ function getOutlinedModel<T>(
   key: string,
   map: (response: Response, model: any, parentObject: Object, key: string) => T,
 ): T {
-  const path = reference.split(':');
-  const id = parseInt(path[0], 16);
+  // parseInt stops at the ':' so we only need to split when there's a path.
+  const id = parseInt(reference, 16);
+  const path =
+    reference.indexOf(':') === -1 ? EMPTY_REFERENCE_PATH : reference.split(':');
   const chunk = getChunk(response, id);
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
     if (initializingChunk !== null && isArray(initializingChunk._children)) {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -3252,10 +3252,22 @@ function resolveModule(
 ): void {
   const chunks = response._chunks;
   const chunk = chunks.get(id);
-  const clientReferenceMetadata: ClientReferenceMetadata = parseModel(
-    response,
-    model,
-  );
+  const prevHandler = initializingHandler;
+  initializingHandler = null;
+  let clientReferenceMetadata: ClientReferenceMetadata;
+  try {
+    clientReferenceMetadata = parseModel(response, model);
+    if (initializingHandler !== null) {
+      // We resolve the client reference below and have nothing to wait on,
+      // so the metadata can't reference a row that hasn't arrived.
+      throw new Error(
+        'A client reference was blocked on a row that has not been received yet. ' +
+          'This is a bug in React.',
+      );
+    }
+  } finally {
+    initializingHandler = prevHandler;
+  }
   const clientReference = resolveClientReference<$FlowFixMe>(
     response._bundlerConfig,
     clientReferenceMetadata,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -2559,6 +2559,60 @@ describe('ReactFlightDOMEdge', () => {
     );
   });
 
+  async function renderThroughDebugChannel(chunkFilename) {
+    const Client = clientComponent('Client', chunkFilename);
+    // The client reference shows up in the owner's props on the debug channel.
+    function Server({component}) {
+      return ReactServer.createElement(component, null);
+    }
+
+    let debugReadableStreamController;
+    const debugReadableStream = new ReadableStream({
+      start(controller) {
+        debugReadableStreamController = controller;
+      },
+    });
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        ReactServer.createElement(Server, {component: Client}),
+        webpackMap,
+        {
+          debugChannel: {
+            writable: new WritableStream({
+              write(chunk) {
+                debugReadableStreamController.enqueue(chunk);
+              },
+              close() {
+                debugReadableStreamController.close();
+              },
+            }),
+          },
+        },
+      ),
+    );
+
+    const response = ReactServerDOMClient.createFromReadableStream(stream, {
+      serverConsumerManifest: {moduleMap: null, moduleLoading: null},
+      debugChannel: {readable: debugReadableStream},
+    });
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(<ClientRoot />),
+    );
+    return readResult(ssrStream);
+  }
+
+  it('can resolve a client reference while debug info is still blocked', async () => {
+    const result = await renderThroughDebugChannel('path/to/chunk.js');
+
+    expect(result).toBe('<span>Client</span>');
+  });
+
   it('should properly resolve with deduped objects', async () => {
     const obj = {foo: 'hi'};
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1118,77 +1118,123 @@ describe('ReactFlightDOMEdge', () => {
     );
   }
 
-  it('should dedupe strings inside client reference metadata', async () => {
-    // Bundlers repeat the same chunk in the metadata of every client reference
-    // that needs it.
-    const chunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
-    const ClientA = clientComponent('A', chunk);
-    const ClientB = clientComponent('B', chunk);
-    const ClientC = clientComponent('C', chunk);
-
+  async function renderClients(chunkFilenames) {
+    const Clients = chunkFilenames.map(chunkFilename =>
+      clientComponent('Client', chunkFilename),
+    );
     const stream = await serverAct(() =>
       ReactServerDOMServer.renderToReadableStream(
         <div>
-          <ClientA />
-          <ClientB />
-          <ClientC />
+          {Clients.map((Client, i) => (
+            <Client key={i} />
+          ))}
         </div>,
         webpackMap,
       ),
     );
     const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    const outlinedRow = ':' + JSON.stringify(chunk) + '\n';
-    expect(serializedContent).toContain(outlinedRow);
-    // The client resolves a client reference while parsing its row, so the
-    // outlined row has to be flushed before every row referencing it.
-    expect(serializedContent.indexOf(outlinedRow)).toBeLessThan(
-      serializedContent.lastIndexOf(':I['),
-    );
-    // An export name is too short to be worth outlining.
-    expect(serializedContent).not.toContain(':"*"\n');
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
+    const payload = await readResult(stream1);
+    const model = await ReactServerDOMClient.createFromReadableStream(stream2, {
+      serverConsumerManifest: {
+        moduleMap: null,
+        moduleLoading: null,
       },
-    );
+    });
     const ssrStream = await serverAct(() =>
-      ReactDOMServer.renderToReadableStream(result),
+      ReactDOMServer.renderToReadableStream(model),
     );
     expect(await readResult(ssrStream)).toBe(
-      '<div><span>A</span><span>B</span><span>C</span></div>',
+      '<div>' + '<span>Client</span>'.repeat(Clients.length) + '</div>',
     );
+    return payload;
+  }
+
+  it('should dedupe strings inside client reference metadata', async () => {
+    // Bundlers repeat the same chunk in the metadata of every client reference
+    // that needs it.
+    const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const shared = await renderClients(new Array(10).fill(chunk));
+    // The same length, so sharing is the only difference between the two.
+    const distinct = await renderClients(
+      Array.from(
+        {length: 10},
+        (_, i) => 'unique/hashed-chunk-' + ('' + i).padStart(16, '0') + '.js',
+      ),
+    );
+
+    // However many references there are, the chunk goes on the wire twice:
+    // inline for the first one, then as a row that the rest point at.
+    expect(shared.split(chunk).length - 1).toBe(2);
+    expect(distinct.length - shared.length).toBeGreaterThan(6 * chunk.length);
+
+    // The client resolves a client reference while parsing its row, so the
+    // outlined copy has to arrive before every row that points at it. Only one
+    // import row comes first, the one that spells the chunk out. The chunk id
+    // is too short to be outlined, so it counts the rows.
+    const beforeOutlinedCopy = shared.slice(0, shared.lastIndexOf(chunk));
+    expect(beforeOutlinedCopy.split('chunk-Client').length - 1).toBe(1);
   });
 
   it('should escape strings inside client reference metadata', async () => {
     // A leading $ has to be escaped whether the string gets outlined or not.
-    const outlinedChunk = '$path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const outlinedChunk = '$shared/hashed-chunk-0f1e2d3c4b5a6978.js';
     const inlineChunk = '$chunk.js';
-    const ClientA = clientComponent('A', outlinedChunk);
-    const ClientB = clientComponent('B', outlinedChunk);
-    const ClientC = clientComponent('C', inlineChunk);
+    const outlined = await renderClients(new Array(3).fill(outlinedChunk));
+    const inline = await renderClients(new Array(3).fill(inlineChunk));
+
+    expect(outlined.split('$' + outlinedChunk).length - 1).toBe(2);
+    expect(inline.split('$' + inlineChunk).length - 1).toBe(3);
+  });
+
+  it('should not dedupe import strings below the size limit', async () => {
+    // A short string costs more to reference than to repeat.
+    const shortChunk = 'abc/chunk-15.js';
+    const longChunk = 'abcd/chunk-16.js';
+    const short = await renderClients(new Array(10).fill(shortChunk));
+    const long = await renderClients(new Array(10).fill(longChunk));
+
+    expect(short.split(shortChunk).length - 1).toBe(10);
+    expect(long.split(longChunk).length - 1).toBe(2);
+    // The longer chunk is the one that produces the smaller payload.
+    expect(long.length).toBeLessThan(short.length);
+  });
+
+  it('should not dedupe import strings above the size limit', async () => {
+    // Tracking a string this large would hold it in memory for the rest of
+    // the request.
+    const bigChunk = 'path/to/' + 'a'.repeat(40000) + '.js';
+    const big = await renderClients(new Array(3).fill(bigChunk));
+
+    expect(big.split(bigChunk).length - 1).toBe(3);
+  });
+
+  it('should stop tracking new import strings once the map is full', async () => {
+    // Every chunk is tracked in case it repeats later, so the map has room for
+    // one more entry after 255 distinct ones and none after 256.
+    const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const repeats = new Array(10).fill(chunk);
+    const filler = count =>
+      Array.from({length: count}, (_, i) => 'filler/hashed-chunk-' + i + '.js');
+    const takesTheLastSlot = await renderClients(filler(255).concat(repeats));
+    const findsItFull = await renderClients(filler(256).concat(repeats));
+
+    expect(takesTheLastSlot.split(chunk).length - 1).toBe(2);
+    expect(findsItFull.split(chunk).length - 1).toBe(10);
+  });
+
+  it('should not dedupe strings in the model', async () => {
+    // Only import metadata is deduped. Keying a map on arbitrary model strings
+    // would hold them in memory for the rest of the request.
+    const text = 'a repeated model string well past the import threshold';
+    const model = new Array(10).fill(text);
 
     const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(
-        <div>
-          <ClientA />
-          <ClientB />
-          <ClientC />
-        </div>,
-        webpackMap,
-      ),
+      ReactServerDOMServer.renderToReadableStream(model),
     );
     const [stream1, stream2] = passThrough(stream).tee();
 
-    const serializedContent = await readResult(stream1);
-    expect(serializedContent).toContain(':"$' + outlinedChunk + '"\n');
-    expect(serializedContent).toContain('"$' + inlineChunk + '"');
+    const payload = await readResult(stream1);
+    expect(payload.split(text).length - 1).toBe(10);
 
     const result = await ReactServerDOMClient.createFromReadableStream(
       stream2,
@@ -1199,23 +1245,20 @@ describe('ReactFlightDOMEdge', () => {
         },
       },
     );
-    const ssrStream = await serverAct(() =>
-      ReactDOMServer.renderToReadableStream(result),
-    );
-    expect(await readResult(ssrStream)).toBe(
-      '<div><span>A</span><span>B</span><span>C</span></div>',
-    );
+    expect(result).toEqual(model);
   });
 
   // @gate __DEV__
   it('should not dedupe import metadata on the debug channel', async () => {
     // The debug channel is a separate transport, so a row it emits can't be
     // referenced from the main stream and vice versa.
-    const chunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
-    const Client = clientComponent('Client', chunk);
+    const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const A = clientComponent('Client', chunk);
+    const B = clientComponent('Client', chunk);
+    const C = clientComponent('Client', chunk);
 
-    function Server({a, b}) {
-      return ReactServer.createElement('div', null, a, b);
+    function Server({a, b, c}) {
+      return ReactServer.createElement('div', null, a, b, c);
     }
 
     let debugContent = '';
@@ -1231,129 +1274,26 @@ describe('ReactFlightDOMEdge', () => {
       ReactServerDOMServer.renderToReadableStream(
         // We can't use JSX here because it'll use the Client React.
         ReactServer.createElement(Server, {
-          a: ReactServer.createElement(Client),
-          b: ReactServer.createElement(Client),
+          a: ReactServer.createElement(A),
+          b: ReactServer.createElement(B),
+          c: ReactServer.createElement(C),
         }),
         webpackMap,
         {debugChannel},
       ),
     );
-    await readResult(stream);
+    const payload = await readResult(stream);
 
-    expect(debugContent).toContain(':I[');
-    // Every import row on the debug channel spells the chunk out.
+    // The main stream dedupes as usual.
+    expect(payload.split(chunk).length - 1).toBe(2);
+
+    // The debug channel can't point at that row, so every import row it writes
+    // spells the chunk out. The chunk id is too short to be outlined, so it
+    // counts those rows.
+    expect(debugContent).toContain('chunk-Client');
     expect(debugContent.split(chunk).length).toBe(
-      debugContent.split(':I[').length,
+      debugContent.split('chunk-Client').length,
     );
-  });
-
-  it('should not dedupe import strings above the size limit', async () => {
-    // Tracking a string this large would hold it in memory for the rest of
-    // the request.
-    const bigChunk = 'path/to/' + 'a'.repeat(40000) + '.js';
-    const smallChunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
-    const ClientA = clientComponent('A', bigChunk);
-    const ClientB = clientComponent('B', bigChunk);
-    const ClientC = clientComponent('C', smallChunk);
-    const ClientD = clientComponent('D', smallChunk);
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(
-        <div>
-          <ClientA />
-          <ClientB />
-          <ClientC />
-          <ClientD />
-        </div>,
-        webpackMap,
-      ),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // The small chunk shows dedupe is active while the big one is passed over.
-    expect(serializedContent).toContain(
-      ':' + JSON.stringify(smallChunk) + '\n',
-    );
-    expect(serializedContent).not.toContain(
-      ':' + JSON.stringify(bigChunk) + '\n',
-    );
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    const ssrStream = await serverAct(() =>
-      ReactDOMServer.renderToReadableStream(result),
-    );
-    expect(await readResult(ssrStream)).toBe(
-      '<div><span>A</span><span>B</span><span>C</span><span>D</span></div>',
-    );
-  });
-
-  it('should stop tracking new import strings once the map is full', async () => {
-    const earlyChunk = 'early/hashed-chunk-0f1e2d3c4b5a6978.js';
-    const lateChunk = 'late/hashed-chunk-9f8e7d6c5b4a3210.js';
-    const EarlyA = clientComponent('EA', earlyChunk);
-    const EarlyB = clientComponent('EB', earlyChunk);
-    // Every filler chunk name is tracked in case it repeats later, and 255 of
-    // them plus the early chunk fill the map to its 256 entry limit.
-    const fillers = [];
-    for (let i = 0; i < 255; i++) {
-      fillers.push(
-        clientComponent('F' + i, 'filler/hashed-chunk-' + i + '.js'),
-      );
-    }
-    const LateA = clientComponent('LA', lateChunk);
-    const LateB = clientComponent('LB', lateChunk);
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(
-        <div>
-          <EarlyA />
-          <EarlyB />
-          {fillers.map((Filler, i) => (
-            <Filler key={i} />
-          ))}
-          <LateA />
-          <LateB />
-        </div>,
-        webpackMap,
-      ),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // The early chunk was tracked while there was still room, so its repeat
-    // gets outlined. The late one arrived after the map filled up.
-    expect(serializedContent).toContain(
-      ':' + JSON.stringify(earlyChunk) + '\n',
-    );
-    expect(serializedContent).not.toContain(
-      ':' + JSON.stringify(lateChunk) + '\n',
-    );
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    const ssrStream = await serverAct(() =>
-      ReactDOMServer.renderToReadableStream(result),
-    );
-    const html = await readResult(ssrStream);
-    expect(html).toContain('<span>EA</span>');
-    expect(html).toContain('<span>F254</span>');
-    expect(html).toContain('<span>LB</span>');
   });
 
   it('warns if passing a this argument to bind() of a server reference', async () => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1232,6 +1232,46 @@ describe('ReactFlightDOMEdge', () => {
     expect(result).toEqual(props);
   });
 
+  it('should not count deduped strings against the row size limit', async () => {
+    // A className shared by every row of a list, which is the common shape.
+    const testString = 'a'.repeat(250);
+    const elements = [];
+    for (let i = 0; i < 60; i++) {
+      elements.push(
+        <p key={i} className={testString}>
+          {'row ' + i}
+        </p>,
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(<div>{elements}</div>),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // A reference is a few bytes, so the list stays in one row instead of
+    // being split up as if each element still carried the whole string.
+    const modelRows = serializedContent
+      .split('\n')
+      .filter(row => row !== '')
+      // Skip the tagged rows, which includes the debug info emitted in DEV.
+      .filter(row => !/^[0-9a-f]+:[A-Z]/.test(row));
+    // In DEV each element is outlined anyway to give its debug info an ID.
+    expect(modelRows.length).toBeLessThan(__DEV__ ? 70 : 10);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result.props.children.length).toBe(60);
+  });
+
   function clientComponent(name, chunkFilename) {
     return clientExports(
       function Client() {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1241,6 +1241,26 @@ describe('ReactFlightDOMEdge', () => {
     expect(payload.split(chunk).length - 1).toBe(2);
   });
 
+  it('should error on circular client reference metadata', async () => {
+    const circular = [];
+    circular.push(circular);
+    const Client = clientComponent('Client', circular);
+
+    const errors = [];
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(<Client />, webpackMap, {
+        onError(error) {
+          errors.push(error.message);
+        },
+      }),
+    );
+    await readResult(stream);
+
+    expect(errors).toEqual([
+      expect.stringContaining('Converting circular structure to JSON'),
+    ]);
+  });
+
   it('should not dedupe strings in the model', async () => {
     // Only import metadata is deduped. Keying a map on arbitrary model strings
     // would hold them in memory for the rest of the request.

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1107,171 +1107,6 @@ describe('ReactFlightDOMEdge', () => {
     expect(items[5]).toEqual(items[10]);
   });
 
-  it('should encode repeated strings in a compact format by deduping', async () => {
-    const testString = 'a'.repeat(100);
-    const props = {texts: new Array(30).fill(testString)};
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(props),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // One inline copy, one outlined row and a reference per repetition.
-    expect(serializedContent.length).toBeLessThan(400);
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    expect(result).toEqual(props);
-  });
-
-  it('should not dedupe strings below the length threshold', async () => {
-    const testString = 'a'.repeat(63);
-    const props = {texts: new Array(30).fill(testString)};
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(props),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // Every copy is spelled out because outlining a string this short would
-    // cost more than the duplicate.
-    expect(serializedContent.length).toBeGreaterThan(30 * testString.length);
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    expect(result).toEqual(props);
-  });
-
-  it('should not outline a string that is used only once', async () => {
-    const props = {text: 'a'.repeat(100)};
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(props),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // Most strings never repeat, so the first copy stays inline rather than
-    // paying for a row and a reference to it.
-    expect(serializedContent).not.toContain('$');
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    expect(result).toEqual(props);
-  });
-
-  it('should dedupe repeated large strings', async () => {
-    const testString = 'a'.repeat(2000);
-    const props = {texts: new Array(5).fill(testString)};
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(props),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // Large strings are outlined on first use, so there's only ever one copy.
-    expect(serializedContent.length).toBeLessThan(2100);
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    expect(result).toEqual(props);
-  });
-
-  it('should escape deduped strings that start with $', async () => {
-    const testString = '$' + 'a'.repeat(100);
-    const props = {texts: new Array(30).fill(testString)};
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(props),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    expect(serializedContent).toContain('"$' + testString + '"');
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    expect(result).toEqual(props);
-  });
-
-  it('should not count deduped strings against the row size limit', async () => {
-    // A className shared by every row of a list, which is the common shape.
-    const testString = 'a'.repeat(250);
-    const elements = [];
-    for (let i = 0; i < 60; i++) {
-      elements.push(
-        <p key={i} className={testString}>
-          {'row ' + i}
-        </p>,
-      );
-    }
-
-    const stream = await serverAct(() =>
-      ReactServerDOMServer.renderToReadableStream(<div>{elements}</div>),
-    );
-    const [stream1, stream2] = passThrough(stream).tee();
-
-    const serializedContent = await readResult(stream1);
-    // A reference is a few bytes, so the list stays in one row instead of
-    // being split up as if each element still carried the whole string.
-    const modelRows = serializedContent
-      .split('\n')
-      .filter(row => row !== '')
-      // Skip the tagged rows, which includes the debug info emitted in DEV.
-      .filter(row => !/^[0-9a-f]+:[A-Z]/.test(row));
-    // In DEV each element is outlined anyway to give its debug info an ID.
-    expect(modelRows.length).toBeLessThan(__DEV__ ? 70 : 10);
-
-    const result = await ReactServerDOMClient.createFromReadableStream(
-      stream2,
-      {
-        serverConsumerManifest: {
-          moduleMap: null,
-          moduleLoading: null,
-        },
-      },
-    );
-    expect(result.props.children.length).toBe(60);
-  });
-
   function clientComponent(name, chunkFilename) {
     return clientExports(
       function Client() {
@@ -1410,6 +1245,115 @@ describe('ReactFlightDOMEdge', () => {
     expect(debugContent.split(chunk).length).toBe(
       debugContent.split(':I[').length,
     );
+  });
+
+  it('should not dedupe import strings above the size limit', async () => {
+    // Tracking a string this large would hold it in memory for the rest of
+    // the request.
+    const bigChunk = 'path/to/' + 'a'.repeat(40000) + '.js';
+    const smallChunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const ClientA = clientComponent('A', bigChunk);
+    const ClientB = clientComponent('B', bigChunk);
+    const ClientC = clientComponent('C', smallChunk);
+    const ClientD = clientComponent('D', smallChunk);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <div>
+          <ClientA />
+          <ClientB />
+          <ClientC />
+          <ClientD />
+        </div>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // The small chunk shows dedupe is active while the big one is passed over.
+    expect(serializedContent).toContain(
+      ':' + JSON.stringify(smallChunk) + '\n',
+    );
+    expect(serializedContent).not.toContain(
+      ':' + JSON.stringify(bigChunk) + '\n',
+    );
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    expect(await readResult(ssrStream)).toBe(
+      '<div><span>A</span><span>B</span><span>C</span><span>D</span></div>',
+    );
+  });
+
+  it('should stop tracking new import strings once the map is full', async () => {
+    const earlyChunk = 'early/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const lateChunk = 'late/hashed-chunk-9f8e7d6c5b4a3210.js';
+    const EarlyA = clientComponent('EA', earlyChunk);
+    const EarlyB = clientComponent('EB', earlyChunk);
+    // Every filler chunk name is tracked in case it repeats later, and 255 of
+    // them plus the early chunk fill the map to its 256 entry limit.
+    const fillers = [];
+    for (let i = 0; i < 255; i++) {
+      fillers.push(
+        clientComponent('F' + i, 'filler/hashed-chunk-' + i + '.js'),
+      );
+    }
+    const LateA = clientComponent('LA', lateChunk);
+    const LateB = clientComponent('LB', lateChunk);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <div>
+          <EarlyA />
+          <EarlyB />
+          {fillers.map((Filler, i) => (
+            <Filler key={i} />
+          ))}
+          <LateA />
+          <LateB />
+        </div>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // The early chunk was tracked while there was still room, so its repeat
+    // gets outlined. The late one arrived after the map filled up.
+    expect(serializedContent).toContain(
+      ':' + JSON.stringify(earlyChunk) + '\n',
+    );
+    expect(serializedContent).not.toContain(
+      ':' + JSON.stringify(lateChunk) + '\n',
+    );
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    const html = await readResult(ssrStream);
+    expect(html).toContain('<span>EA</span>');
+    expect(html).toContain('<span>F254</span>');
+    expect(html).toContain('<span>LB</span>');
   });
 
   it('warns if passing a this argument to bind() of a server reference', async () => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1107,6 +1107,271 @@ describe('ReactFlightDOMEdge', () => {
     expect(items[5]).toEqual(items[10]);
   });
 
+  it('should encode repeated strings in a compact format by deduping', async () => {
+    const testString = 'a'.repeat(100);
+    const props = {texts: new Array(30).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // One inline copy, one outlined row and a reference per repetition.
+    expect(serializedContent.length).toBeLessThan(400);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should not dedupe strings below the length threshold', async () => {
+    const testString = 'a'.repeat(63);
+    const props = {texts: new Array(30).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Every copy is spelled out because outlining a string this short would
+    // cost more than the duplicate.
+    expect(serializedContent.length).toBeGreaterThan(30 * testString.length);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should not outline a string that is used only once', async () => {
+    const props = {text: 'a'.repeat(100)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Most strings never repeat, so the first copy stays inline rather than
+    // paying for a row and a reference to it.
+    expect(serializedContent).not.toContain('$');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should dedupe repeated large strings', async () => {
+    const testString = 'a'.repeat(2000);
+    const props = {texts: new Array(5).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Large strings are outlined on first use, so there's only ever one copy.
+    expect(serializedContent.length).toBeLessThan(2100);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should escape deduped strings that start with $', async () => {
+    const testString = '$' + 'a'.repeat(100);
+    const props = {texts: new Array(30).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    expect(serializedContent).toContain('"$' + testString + '"');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  function clientComponent(name, chunkFilename) {
+    return clientExports(
+      function Client() {
+        return <span>{name}</span>;
+      },
+      'chunk-' + name,
+      chunkFilename,
+      Promise.resolve(),
+    );
+  }
+
+  it('should dedupe strings inside client reference metadata', async () => {
+    // Bundlers repeat the same chunk in the metadata of every client reference
+    // that needs it.
+    const chunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const ClientA = clientComponent('A', chunk);
+    const ClientB = clientComponent('B', chunk);
+    const ClientC = clientComponent('C', chunk);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <div>
+          <ClientA />
+          <ClientB />
+          <ClientC />
+        </div>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    const outlinedRow = ':' + JSON.stringify(chunk) + '\n';
+    expect(serializedContent).toContain(outlinedRow);
+    // The client resolves a client reference while parsing its row, so the
+    // outlined row has to be flushed before every row referencing it.
+    expect(serializedContent.indexOf(outlinedRow)).toBeLessThan(
+      serializedContent.lastIndexOf(':I['),
+    );
+    // An export name is too short to be worth outlining.
+    expect(serializedContent).not.toContain(':"*"\n');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    expect(await readResult(ssrStream)).toBe(
+      '<div><span>A</span><span>B</span><span>C</span></div>',
+    );
+  });
+
+  it('should escape strings inside client reference metadata', async () => {
+    // A leading $ has to be escaped whether the string gets outlined or not.
+    const outlinedChunk = '$path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const inlineChunk = '$chunk.js';
+    const ClientA = clientComponent('A', outlinedChunk);
+    const ClientB = clientComponent('B', outlinedChunk);
+    const ClientC = clientComponent('C', inlineChunk);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <div>
+          <ClientA />
+          <ClientB />
+          <ClientC />
+        </div>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    expect(serializedContent).toContain(':"$' + outlinedChunk + '"\n');
+    expect(serializedContent).toContain('"$' + inlineChunk + '"');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    expect(await readResult(ssrStream)).toBe(
+      '<div><span>A</span><span>B</span><span>C</span></div>',
+    );
+  });
+
+  // @gate __DEV__
+  it('should not dedupe import metadata on the debug channel', async () => {
+    // The debug channel is a separate transport, so a row it emits can't be
+    // referenced from the main stream and vice versa.
+    const chunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const Client = clientComponent('Client', chunk);
+
+    function Server({a, b}) {
+      return ReactServer.createElement('div', null, a, b);
+    }
+
+    let debugContent = '';
+    const debugChannel = {
+      writable: new WritableStream({
+        write(value) {
+          debugContent += Buffer.from(value).toString('utf8');
+        },
+      }),
+    };
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        // We can't use JSX here because it'll use the Client React.
+        ReactServer.createElement(Server, {
+          a: ReactServer.createElement(Client),
+          b: ReactServer.createElement(Client),
+        }),
+        webpackMap,
+        {debugChannel},
+      ),
+    );
+    await readResult(stream);
+
+    expect(debugContent).toContain(':I[');
+    // Every import row on the debug channel spells the chunk out.
+    expect(debugContent.split(chunk).length).toBe(
+      debugContent.split(':I[').length,
+    );
+  });
+
   it('warns if passing a this argument to bind() of a server reference', async () => {
     const ServerModule = serverExports({
       greet: function () {},

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1162,17 +1162,16 @@ describe('ReactFlightDOMEdge', () => {
       ),
     );
 
-    // However many references there are, the chunk goes on the wire twice:
-    // inline for the first one, then as a row that the rest point at.
-    expect(shared.split(chunk).length - 1).toBe(2);
-    expect(distinct.length - shared.length).toBeGreaterThan(6 * chunk.length);
+    // However many references there are, the chunk goes on the wire once, as a
+    // row that every import row points at.
+    expect(shared.split(chunk).length - 1).toBe(1);
+    expect(distinct.length - shared.length).toBeGreaterThan(8 * chunk.length);
 
     // The client resolves a client reference while parsing its row, so the
-    // outlined copy has to arrive before every row that points at it. Only one
-    // import row comes first, the one that spells the chunk out. The chunk id
-    // is too short to be outlined, so it counts the rows.
-    const beforeOutlinedCopy = shared.slice(0, shared.lastIndexOf(chunk));
-    expect(beforeOutlinedCopy.split('chunk-Client').length - 1).toBe(1);
+    // outlined copy has to arrive before every row that points at it. The
+    // chunk id is too short to be outlined, so it counts the rows.
+    const beforeOutlinedCopy = shared.slice(0, shared.indexOf(chunk));
+    expect(beforeOutlinedCopy).not.toContain('chunk-Client');
   });
 
   it('should escape strings inside client reference metadata', async () => {
@@ -1182,7 +1181,7 @@ describe('ReactFlightDOMEdge', () => {
     const outlined = await renderClients(new Array(3).fill(outlinedChunk));
     const inline = await renderClients(new Array(3).fill(inlineChunk));
 
-    expect(outlined.split('$' + outlinedChunk).length - 1).toBe(2);
+    expect(outlined.split('$' + outlinedChunk).length - 1).toBe(1);
     expect(inline.split('$' + inlineChunk).length - 1).toBe(3);
   });
 
@@ -1194,14 +1193,14 @@ describe('ReactFlightDOMEdge', () => {
     const long = await renderClients(new Array(10).fill(longChunk));
 
     expect(short.split(shortChunk).length - 1).toBe(10);
-    expect(long.split(longChunk).length - 1).toBe(2);
+    expect(long.split(longChunk).length - 1).toBe(1);
     // The longer chunk is the one that produces the smaller payload.
     expect(long.length).toBeLessThan(short.length);
   });
 
   it('should stop tracking new import strings once the budget is spent', async () => {
-    // Chunks that never repeat are tracked too, in case they do later.
-    // 32 fillers of 1 KiB fill the 32 KiB budget.
+    // Every chunk is outlined the first time it's seen, so chunks that never
+    // repeat spend budget too. 32 fillers of 1 KiB fill the 32 KiB budget.
     const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
     const repeats = new Array(10).fill(chunk);
     const filler = (count, length) =>
@@ -1211,16 +1210,16 @@ describe('ReactFlightDOMEdge', () => {
     const fitsInTheRest = await renderClients(filler(31, 1024).concat(repeats));
     const findsItSpent = await renderClients(filler(32, 1024).concat(repeats));
 
-    expect(fitsInTheRest.split(chunk).length - 1).toBe(2);
+    expect(fitsInTheRest.split(chunk).length - 1).toBe(1);
     expect(findsItSpent.split(chunk).length - 1).toBe(10);
 
-    // A string tracked before the budget is spent keeps deduping after.
+    // A string outlined before the budget is spent keeps deduping after.
     const lastFiller = filler(1, 32768 - 31 * 1024 - chunk.length);
     const trackedBefore = await renderClients(
       [chunk].concat(filler(31, 1024), lastFiller, repeats),
     );
 
-    expect(trackedBefore.split(chunk).length - 1).toBe(2);
+    expect(trackedBefore.split(chunk).length - 1).toBe(1);
 
     const bigChunk = 'path/to/' + 'a'.repeat(40000) + '.js';
     const big = await renderClients(new Array(3).fill(bigChunk));
@@ -1238,7 +1237,7 @@ describe('ReactFlightDOMEdge', () => {
       })),
     );
 
-    expect(payload.split(chunk).length - 1).toBe(2);
+    expect(payload.split(chunk).length - 1).toBe(1);
   });
 
   it('should error on circular client reference metadata', async () => {
@@ -1324,7 +1323,7 @@ describe('ReactFlightDOMEdge', () => {
     const payload = await readResult(stream);
 
     // The main stream dedupes as usual.
-    expect(payload.split(chunk).length - 1).toBe(2);
+    expect(payload.split(chunk).length - 1).toBe(1);
 
     // The debug channel can't point at that row, so every import row it writes
     // spells the chunk out. The chunk id is too short to be outlined, so it

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1199,27 +1199,33 @@ describe('ReactFlightDOMEdge', () => {
     expect(long.length).toBeLessThan(short.length);
   });
 
-  it('should not dedupe import strings above the size limit', async () => {
-    // Tracking a string this large would hold it in memory for the rest of
-    // the request.
+  it('should stop tracking new import strings once the budget is spent', async () => {
+    // Chunks that never repeat are tracked too, in case they do later.
+    // 32 fillers of 1 KiB fill the 32 KiB budget.
+    const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const repeats = new Array(10).fill(chunk);
+    const filler = (count, length) =>
+      Array.from({length: count}, (_, i) =>
+        ('filler/chunk-' + i + '-').padEnd(length - 3, 'x').concat('.js'),
+      );
+    const fitsInTheRest = await renderClients(filler(31, 1024).concat(repeats));
+    const findsItSpent = await renderClients(filler(32, 1024).concat(repeats));
+
+    expect(fitsInTheRest.split(chunk).length - 1).toBe(2);
+    expect(findsItSpent.split(chunk).length - 1).toBe(10);
+
+    // A string tracked before the budget is spent keeps deduping after.
+    const lastFiller = filler(1, 32768 - 31 * 1024 - chunk.length);
+    const trackedBefore = await renderClients(
+      [chunk].concat(filler(31, 1024), lastFiller, repeats),
+    );
+
+    expect(trackedBefore.split(chunk).length - 1).toBe(2);
+
     const bigChunk = 'path/to/' + 'a'.repeat(40000) + '.js';
     const big = await renderClients(new Array(3).fill(bigChunk));
 
     expect(big.split(bigChunk).length - 1).toBe(3);
-  });
-
-  it('should stop tracking new import strings once the map is full', async () => {
-    // Every chunk is tracked in case it repeats later, so the map has room for
-    // one more entry after 255 distinct ones and none after 256.
-    const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
-    const repeats = new Array(10).fill(chunk);
-    const filler = count =>
-      Array.from({length: count}, (_, i) => 'filler/hashed-chunk-' + i + '.js');
-    const takesTheLastSlot = await renderClients(filler(255).concat(repeats));
-    const findsItFull = await renderClients(filler(256).concat(repeats));
-
-    expect(takesTheLastSlot.split(chunk).length - 1).toBe(2);
-    expect(findsItFull.split(chunk).length - 1).toBe(10);
   });
 
   it('should dedupe import strings produced by toJSON', async () => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1222,6 +1222,19 @@ describe('ReactFlightDOMEdge', () => {
     expect(findsItFull.split(chunk).length - 1).toBe(10);
   });
 
+  it('should dedupe import strings produced by toJSON', async () => {
+    const chunk = 'shared/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const payload = await renderClients(
+      Array.from({length: 3}, () => ({
+        toJSON() {
+          return chunk;
+        },
+      })),
+    );
+
+    expect(payload.split(chunk).length - 1).toBe(2);
+  });
+
   it('should not dedupe strings in the model', async () => {
     // Only import metadata is deduped. Keying a map on arbitrary model strings
     // would hold them in memory for the rest of the request.
@@ -2609,6 +2622,12 @@ describe('ReactFlightDOMEdge', () => {
 
   it('can resolve a client reference while debug info is still blocked', async () => {
     const result = await renderThroughDebugChannel('path/to/chunk.js');
+
+    expect(result).toBe('<span>Client</span>');
+  });
+
+  it('should escape strings in import metadata on the debug channel', async () => {
+    const result = await renderThroughDebugChannel('$path/to/chunk.js');
 
     expect(result).toBe('<span>Client</span>');
   });

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -616,6 +616,9 @@ export type Request = {
   writtenClientReferences: Map<ClientReferenceKey, number>,
   writtenServerReferences: Map<ServerReference<any>, number>,
   writtenObjects: WeakMap<Reference, string>,
+  // A null entry means the string has been seen once and is still inline.
+  writtenStrings: Map<string, null | string>,
+  writtenImportStrings: Map<string, null | string>,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
   identifierCount: number,
@@ -741,6 +744,8 @@ function RequestInstance(
   this.writtenClientReferences = new Map();
   this.writtenServerReferences = new Map();
   this.writtenObjects = new WeakMap();
+  this.writtenStrings = new Map();
+  this.writtenImportStrings = new Map();
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
   this.identifierCount = 1;
@@ -2250,6 +2255,16 @@ let canEmitDebugInfo: boolean = false;
 let serializedSize = 0;
 const MAX_ROW_SIZE = 3200;
 
+// Strings at least this long get outlined and deduplicated when they repeat.
+// Below it the reference and row header outweigh the duplicate, and the extra
+// rows compress worse than the duplication they replace.
+const MIN_DEDUPLICATED_STRING_LENGTH = 64;
+
+// Bundler metadata repeats the same chunk URLs across every client reference of
+// a route, so it pays off much sooner. It's still bounded away from zero because
+// outlining something as short as an export name costs more than copying it.
+const MIN_DEDUPLICATED_IMPORT_STRING_LENGTH = 16;
+
 function deferTask(request: Request, task: Task): ReactJSONValue {
   // Like outlineTask but instead the item is scheduled to be serialized
   // after its parent in the stream.
@@ -3594,6 +3609,65 @@ function escapeStringValue(value: string): string {
   }
 }
 
+function serializeDeduplicatedString(request: Request, value: string): string {
+  const writtenStrings = request.writtenStrings;
+  const existing = writtenStrings.get(value);
+  if (existing !== undefined && existing !== null) {
+    return existing;
+  }
+  // $FlowFixMe[invalid-compare]
+  const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
+  if (existing === undefined && !isLarge) {
+    // Leave the first occurrence inline. Most strings never repeat, and a row
+    // header plus a reference costs more than the duplicate would have.
+    writtenStrings.set(value, null);
+    return escapeStringValue(value);
+  }
+  let ref;
+  if (isLarge) {
+    // Large strings are encoded outside the JSON payload so that we don't have
+    // to double encode and double parse them.
+    ref = serializeLargeTextString(request, value);
+  } else {
+    request.pendingChunks++;
+    const outlinedId = request.nextChunkId++;
+    // $FlowFixMe[incompatible-type] stringify can return null
+    const json: string = stringify(escapeStringValue(value));
+    emitModelChunk(request, outlinedId, json);
+    ref = serializeByValueID(outlinedId);
+  }
+  writtenStrings.set(value, ref);
+  return ref;
+}
+
+function serializeImportString(request: Request, value: string): string {
+  if (value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH) {
+    return escapeStringValue(value);
+  }
+  const writtenStrings = request.writtenImportStrings;
+  const existing = writtenStrings.get(value);
+  if (existing !== undefined) {
+    if (existing !== null) {
+      return existing;
+    }
+    request.pendingChunks++;
+    const outlinedId = request.nextChunkId++;
+    // $FlowFixMe[incompatible-type] stringify can return null
+    const json: string = stringify(escapeStringValue(value));
+    // The client reads import metadata synchronously, so this row has to have
+    // been written by the time the referencing row arrives. Import chunks are
+    // flushed ahead of regular ones, which regular chunks can't guarantee.
+    request.completedImportChunks.push(
+      stringToChunk(outlinedId.toString(16) + ':' + json + '\n'),
+    );
+    const ref = serializeByValueID(outlinedId);
+    writtenStrings.set(value, ref);
+    return ref;
+  }
+  writtenStrings.set(value, null);
+  return escapeStringValue(value);
+}
+
 let modelRoot: null | ReactClientValue = false;
 
 function renderModel(
@@ -4206,12 +4280,8 @@ function renderModelDestructive(
         return serializeDateFromDateJSON(value);
       }
     }
-    // $FlowFixMe[invalid-compare]
-    if (value.length >= 1024 && byteLengthOfChunk !== null) {
-      // For large strings, we encode them outside the JSON payload so that we
-      // don't have to double encode and double parse the strings. This can also
-      // be more compact in case the string has a lot of escaped characters.
-      return serializeLargeTextString(request, value);
+    if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
+      return serializeDeduplicatedString(request, value);
     }
     return escapeStringValue(value);
   }
@@ -4591,7 +4661,15 @@ function emitImportChunk(
   debug: boolean,
 ): void {
   // $FlowFixMe[incompatible-type] stringify can return null
-  const json: string = stringify(clientReferenceMetadata);
+  const json: string =
+    __DEV__ && debug
+      ? // The debug channel can't reference rows in the main stream.
+        stringify(clientReferenceMetadata)
+      : stringify(clientReferenceMetadata, (key: string, value: mixed) =>
+          typeof value === 'string'
+            ? serializeImportString(request, value)
+            : value,
+        );
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4635,34 +4635,16 @@ function emitErrorChunk(
   }
 }
 
-// This maps every string in the metadata through serializeImportString the
-// way a stringify replacer would, but ahead of time so that stringify can
-// run without one. A replacer would allocate a closure for every import row
-// and take stringify off its fast path. The metadata is plain JSON data or
-// unwraps to it through toJSON.
-function transformImportMetadata(request: Request, value: mixed): mixed {
+// Null on the debug channel, which can't reference rows in the main stream.
+let importStringRequest: null | Request = null;
+
+function importMetadataReplacer(key: string, value: mixed): mixed {
   if (typeof value === 'string') {
+    const request = importStringRequest;
+    if (request === null) {
+      return escapeStringValue(value);
+    }
     return serializeImportString(request, value);
-  }
-  if (typeof value === 'object' && value !== null) {
-    if (typeof (value as any).toJSON === 'function') {
-      // stringify would have called toJSON before the replacer saw the value.
-      return transformImportMetadata(request, (value as any).toJSON());
-    }
-    if (isArray(value)) {
-      const copy: Array<mixed> = [];
-      for (let i = 0; i < value.length; i++) {
-        copy.push(transformImportMetadata(request, value[i]));
-      }
-      return copy;
-    }
-    const copy: {[string]: mixed} = {};
-    for (const name in value) {
-      if (hasOwnProperty.call(value, name)) {
-        copy[name] = transformImportMetadata(request, (value as any)[name]);
-      }
-    }
-    return copy;
   }
   return value;
 }
@@ -4673,12 +4655,14 @@ function emitImportChunk(
   clientReferenceMetadata: ClientReferenceMetadata,
   debug: boolean,
 ): void {
-  const json: string =
-    __DEV__ && debug
-      ? // The debug channel can't reference rows in the main stream.
-        stringify(clientReferenceMetadata)
-      : // $FlowFixMe[incompatible-type] stringify can return null
-        stringify(transformImportMetadata(request, clientReferenceMetadata));
+  importStringRequest = __DEV__ && debug ? null : request;
+  let json: string;
+  try {
+    // $FlowFixMe[incompatible-type] stringify can return null
+    json = stringify(clientReferenceMetadata, importMetadataReplacer);
+  } finally {
+    importStringRequest = null;
+  }
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -615,6 +615,9 @@ export type Request = {
   writtenClientReferences: Map<ClientReferenceKey, number>,
   writtenServerReferences: Map<ServerReference<any>, number>,
   writtenObjects: WeakMap<Reference, string>,
+  // A null entry means the string has been seen once and is still inline.
+  writtenStrings: Map<string, null | string>,
+  writtenImportStrings: Map<string, null | string>,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
   identifierCount: number,
@@ -740,6 +743,8 @@ function RequestInstance(
   this.writtenClientReferences = new Map();
   this.writtenServerReferences = new Map();
   this.writtenObjects = new WeakMap();
+  this.writtenStrings = new Map();
+  this.writtenImportStrings = new Map();
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
   this.identifierCount = 1;
@@ -2155,6 +2160,16 @@ let canEmitDebugInfo: boolean = false;
 let serializedSize = 0;
 const MAX_ROW_SIZE = 3200;
 
+// Strings at least this long get outlined and deduplicated when they repeat.
+// Below it the reference and row header outweigh the duplicate, and the extra
+// rows compress worse than the duplication they replace.
+const MIN_DEDUPLICATED_STRING_LENGTH = 64;
+
+// Bundler metadata repeats the same chunk URLs across every client reference of
+// a route, so it pays off much sooner. It's still bounded away from zero because
+// outlining something as short as an export name costs more than copying it.
+const MIN_DEDUPLICATED_IMPORT_STRING_LENGTH = 16;
+
 function deferTask(request: Request, task: Task): ReactJSONValue {
   // Like outlineTask but instead the item is scheduled to be serialized
   // after its parent in the stream.
@@ -3468,6 +3483,65 @@ function escapeStringValue(value: string): string {
   }
 }
 
+function serializeDeduplicatedString(request: Request, value: string): string {
+  const writtenStrings = request.writtenStrings;
+  const existing = writtenStrings.get(value);
+  if (existing !== undefined && existing !== null) {
+    return existing;
+  }
+  // $FlowFixMe[invalid-compare]
+  const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
+  if (existing === undefined && !isLarge) {
+    // Leave the first occurrence inline. Most strings never repeat, and a row
+    // header plus a reference costs more than the duplicate would have.
+    writtenStrings.set(value, null);
+    return escapeStringValue(value);
+  }
+  let ref;
+  if (isLarge) {
+    // Large strings are encoded outside the JSON payload so that we don't have
+    // to double encode and double parse them.
+    ref = serializeLargeTextString(request, value);
+  } else {
+    request.pendingChunks++;
+    const outlinedId = request.nextChunkId++;
+    // $FlowFixMe[incompatible-type] stringify can return null
+    const json: string = stringify(escapeStringValue(value));
+    emitModelChunk(request, outlinedId, json);
+    ref = serializeByValueID(outlinedId);
+  }
+  writtenStrings.set(value, ref);
+  return ref;
+}
+
+function serializeImportString(request: Request, value: string): string {
+  if (value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH) {
+    return escapeStringValue(value);
+  }
+  const writtenStrings = request.writtenImportStrings;
+  const existing = writtenStrings.get(value);
+  if (existing !== undefined) {
+    if (existing !== null) {
+      return existing;
+    }
+    request.pendingChunks++;
+    const outlinedId = request.nextChunkId++;
+    // $FlowFixMe[incompatible-type] stringify can return null
+    const json: string = stringify(escapeStringValue(value));
+    // The client reads import metadata synchronously, so this row has to have
+    // been written by the time the referencing row arrives. Import chunks are
+    // flushed ahead of regular ones, which regular chunks can't guarantee.
+    request.completedImportChunks.push(
+      stringToChunk(outlinedId.toString(16) + ':' + json + '\n'),
+    );
+    const ref = serializeByValueID(outlinedId);
+    writtenStrings.set(value, ref);
+    return ref;
+  }
+  writtenStrings.set(value, null);
+  return escapeStringValue(value);
+}
+
 let modelRoot: null | ReactClientValue = false;
 
 function renderModel(
@@ -4070,12 +4144,8 @@ function renderModelDestructive(
         return serializeDateFromDateJSON(value);
       }
     }
-    // $FlowFixMe[invalid-compare]
-    if (value.length >= 1024 && byteLengthOfChunk !== null) {
-      // For large strings, we encode them outside the JSON payload so that we
-      // don't have to double encode and double parse the strings. This can also
-      // be more compact in case the string has a lot of escaped characters.
-      return serializeLargeTextString(request, value);
+    if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
+      return serializeDeduplicatedString(request, value);
     }
     return escapeStringValue(value);
   }
@@ -4455,7 +4525,15 @@ function emitImportChunk(
   debug: boolean,
 ): void {
   // $FlowFixMe[incompatible-type] stringify can return null
-  const json: string = stringify(clientReferenceMetadata);
+  const json: string =
+    __DEV__ && debug
+      ? // The debug channel can't reference rows in the main stream.
+        stringify(clientReferenceMetadata)
+      : stringify(clientReferenceMetadata, (key: string, value: mixed) =>
+          typeof value === 'string'
+            ? serializeImportString(request, value)
+            : value,
+        );
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -618,6 +618,8 @@ export type Request = {
   writtenObjects: WeakMap<Reference, string>,
   // A null entry means the string has been seen once and is still inline.
   writtenImportStrings: Map<string, null | string>,
+  // The combined length of the keys in writtenImportStrings.
+  writtenImportStringsSize: number,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
   identifierCount: number,
@@ -744,6 +746,7 @@ function RequestInstance(
   this.writtenServerReferences = new Map();
   this.writtenObjects = new WeakMap();
   this.writtenImportStrings = new Map();
+  this.writtenImportStringsSize = 0;
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
   this.identifierCount = 1;
@@ -2259,11 +2262,9 @@ const MAX_ROW_SIZE = 3200;
 // something as short as an export name costs more than copying it.
 const MIN_DEDUPLICATED_IMPORT_STRING_LENGTH = 16;
 
-// The dedupe map retains every tracked string for the rest of the request, so
-// both the entry size and the entry count are bounded. Anything past these
-// limits is pathological input and simply doesn't dedupe.
-const MAX_DEDUPLICATED_IMPORT_STRING_LENGTH = 32768;
-const MAX_DEDUPLICATED_IMPORT_STRINGS = 256;
+// Tracked strings are retained for the rest of the request, so their combined
+// length is capped.
+const MAX_DEDUPLICATED_IMPORT_STRINGS_SIZE = 32768;
 
 function deferTask(request: Request, task: Task): ReactJSONValue {
   // Like outlineTask but instead the item is scheduled to be serialized
@@ -3610,10 +3611,7 @@ function escapeStringValue(value: string): string {
 }
 
 function serializeImportString(request: Request, value: string): string {
-  if (
-    value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH ||
-    value.length > MAX_DEDUPLICATED_IMPORT_STRING_LENGTH
-  ) {
+  if (value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH) {
     return escapeStringValue(value);
   }
   const writtenStrings = request.writtenImportStrings;
@@ -3636,11 +3634,13 @@ function serializeImportString(request: Request, value: string): string {
     writtenStrings.set(value, ref);
     return ref;
   }
-  if (writtenStrings.size >= MAX_DEDUPLICATED_IMPORT_STRINGS) {
+  const size = request.writtenImportStringsSize + value.length;
+  if (size > MAX_DEDUPLICATED_IMPORT_STRINGS_SIZE) {
     // The map is full. Strings already tracked keep deduping; new ones are
     // written out every time.
     return escapeStringValue(value);
   }
+  request.writtenImportStringsSize = size;
   writtenStrings.set(value, null);
   return escapeStringValue(value);
 }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -616,8 +616,7 @@ export type Request = {
   writtenClientReferences: Map<ClientReferenceKey, number>,
   writtenServerReferences: Map<ServerReference<any>, number>,
   writtenObjects: WeakMap<Reference, string>,
-  // A null entry means the string has been seen once and is still inline.
-  writtenImportStrings: Map<string, null | string>,
+  writtenImportStrings: Map<string, string>,
   // The combined length of the keys in writtenImportStrings.
   writtenImportStringsSize: number,
   temporaryReferences: void | TemporaryReferenceSet,
@@ -3630,32 +3629,30 @@ function serializeImportString(request: Request, value: string): string {
   const writtenStrings = request.writtenImportStrings;
   const existing = writtenStrings.get(value);
   if (existing !== undefined) {
-    if (existing !== null) {
-      return existing;
-    }
-    request.pendingChunks++;
-    const outlinedId = request.nextChunkId++;
-    // $FlowFixMe[incompatible-type] stringify can return null
-    const json: string = stringify(escapeStringValue(value));
-    // The client reads import metadata synchronously, so this row has to have
-    // been written by the time the referencing row arrives. Import chunks are
-    // flushed ahead of regular ones, which regular chunks can't guarantee.
-    request.completedImportChunks.push(
-      stringToChunk(outlinedId.toString(16) + ':' + json + '\n'),
-    );
-    const ref = serializeByValueID(outlinedId);
-    writtenStrings.set(value, ref);
-    return ref;
+    return existing;
   }
   const size = request.writtenImportStringsSize + value.length;
   if (size > MAX_DEDUPLICATED_IMPORT_STRINGS_SIZE) {
-    // The map is full. Strings already tracked keep deduping; new ones are
+    // The map is full. Strings already outlined keep deduping; new ones are
     // written out every time.
     return escapeStringValue(value);
   }
   request.writtenImportStringsSize = size;
-  writtenStrings.set(value, null);
-  return escapeStringValue(value);
+  // Chunk names are almost always shared, so the first occurrence is outlined
+  // right away instead of waiting for a repeat.
+  request.pendingChunks++;
+  const outlinedId = request.nextChunkId++;
+  // $FlowFixMe[incompatible-type] stringify can return null
+  const json: string = stringify(escapeStringValue(value));
+  // The client reads import metadata synchronously, so this row has to have
+  // been written by the time the referencing row arrives. Import chunks are
+  // flushed ahead of regular ones, which regular chunks can't guarantee.
+  request.completedImportChunks.push(
+    stringToChunk(outlinedId.toString(16) + ':' + json + '\n'),
+  );
+  const ref = serializeByValueID(outlinedId);
+  writtenStrings.set(value, ref);
+  return ref;
 }
 
 let modelRoot: null | ReactClientValue = false;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4661,22 +4661,50 @@ function emitErrorChunk(
   }
 }
 
+// This maps every string in the metadata through serializeImportString the
+// way a stringify replacer would, but ahead of time so that stringify can
+// run without one. A replacer would allocate a closure for every import row
+// and take stringify off its fast path. The metadata is plain JSON data or
+// unwraps to it through toJSON.
+function transformImportMetadata(request: Request, value: mixed): mixed {
+  if (typeof value === 'string') {
+    return serializeImportString(request, value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    if (typeof (value as any).toJSON === 'function') {
+      // stringify would have called toJSON before the replacer saw the value.
+      return transformImportMetadata(request, (value as any).toJSON());
+    }
+    if (isArray(value)) {
+      const copy: Array<mixed> = [];
+      for (let i = 0; i < value.length; i++) {
+        copy.push(transformImportMetadata(request, value[i]));
+      }
+      return copy;
+    }
+    const copy: {[string]: mixed} = {};
+    for (const name in value) {
+      if (hasOwnProperty.call(value, name)) {
+        copy[name] = transformImportMetadata(request, (value as any)[name]);
+      }
+    }
+    return copy;
+  }
+  return value;
+}
+
 function emitImportChunk(
   request: Request,
   id: number,
   clientReferenceMetadata: ClientReferenceMetadata,
   debug: boolean,
 ): void {
-  // $FlowFixMe[incompatible-type] stringify can return null
   const json: string =
     __DEV__ && debug
       ? // The debug channel can't reference rows in the main stream.
         stringify(clientReferenceMetadata)
-      : stringify(clientReferenceMetadata, (key: string, value: mixed) =>
-          typeof value === 'string'
-            ? serializeImportString(request, value)
-            : value,
-        );
+      : // $FlowFixMe[incompatible-type] stringify can return null
+        stringify(transformImportMetadata(request, clientReferenceMetadata));
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -617,7 +617,6 @@ export type Request = {
   writtenServerReferences: Map<ServerReference<any>, number>,
   writtenObjects: WeakMap<Reference, string>,
   // A null entry means the string has been seen once and is still inline.
-  writtenStrings: Map<string, null | string>,
   writtenImportStrings: Map<string, null | string>,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
@@ -744,7 +743,6 @@ function RequestInstance(
   this.writtenClientReferences = new Map();
   this.writtenServerReferences = new Map();
   this.writtenObjects = new WeakMap();
-  this.writtenStrings = new Map();
   this.writtenImportStrings = new Map();
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
@@ -2255,15 +2253,17 @@ let canEmitDebugInfo: boolean = false;
 let serializedSize = 0;
 const MAX_ROW_SIZE = 3200;
 
-// Strings at least this long get outlined and deduplicated when they repeat.
-// Below it the reference and row header outweigh the duplicate, and the extra
-// rows compress worse than the duplication they replace.
-const MIN_DEDUPLICATED_STRING_LENGTH = 64;
-
 // Bundler metadata repeats the same chunk URLs across every client reference of
-// a route, so it pays off much sooner. It's still bounded away from zero because
-// outlining something as short as an export name costs more than copying it.
+// a route, so strings in it at least this long get outlined and deduplicated
+// when they repeat. The threshold is bounded away from zero because outlining
+// something as short as an export name costs more than copying it.
 const MIN_DEDUPLICATED_IMPORT_STRING_LENGTH = 16;
+
+// The dedupe map retains every tracked string for the rest of the request, so
+// both the entry size and the entry count are bounded. Anything past these
+// limits is pathological input and simply doesn't dedupe.
+const MAX_DEDUPLICATED_IMPORT_STRING_LENGTH = 32768;
+const MAX_DEDUPLICATED_IMPORT_STRINGS = 256;
 
 function deferTask(request: Request, task: Task): ReactJSONValue {
   // Like outlineTask but instead the item is scheduled to be serialized
@@ -3609,44 +3609,11 @@ function escapeStringValue(value: string): string {
   }
 }
 
-function serializeDeduplicatedString(request: Request, value: string): string {
-  const writtenStrings = request.writtenStrings;
-  const existing = writtenStrings.get(value);
-  if (existing !== undefined && existing !== null) {
-    // The row it refers to was already emitted so only the reference is new here.
-    serializedSize += existing.length;
-    return existing;
-  }
-  // The string still has to arrive before this row can be used, whether it's
-  // written inline or into its own row, so either way it counts in full.
-  serializedSize += value.length;
-  // $FlowFixMe[invalid-compare]
-  const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
-  if (existing === undefined && !isLarge) {
-    // Leave the first occurrence inline. Most strings never repeat, and a row
-    // header plus a reference costs more than the duplicate would have.
-    writtenStrings.set(value, null);
-    return escapeStringValue(value);
-  }
-  let ref;
-  if (isLarge) {
-    // Large strings are encoded outside the JSON payload so that we don't have
-    // to double encode and double parse them.
-    ref = serializeLargeTextString(request, value);
-  } else {
-    request.pendingChunks++;
-    const outlinedId = request.nextChunkId++;
-    // $FlowFixMe[incompatible-type] stringify can return null
-    const json: string = stringify(escapeStringValue(value));
-    emitModelChunk(request, outlinedId, json);
-    ref = serializeByValueID(outlinedId);
-  }
-  writtenStrings.set(value, ref);
-  return ref;
-}
-
 function serializeImportString(request: Request, value: string): string {
-  if (value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH) {
+  if (
+    value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH ||
+    value.length > MAX_DEDUPLICATED_IMPORT_STRING_LENGTH
+  ) {
     return escapeStringValue(value);
   }
   const writtenStrings = request.writtenImportStrings;
@@ -3668,6 +3635,11 @@ function serializeImportString(request: Request, value: string): string {
     const ref = serializeByValueID(outlinedId);
     writtenStrings.set(value, ref);
     return ref;
+  }
+  if (writtenStrings.size >= MAX_DEDUPLICATED_IMPORT_STRINGS) {
+    // The map is full. Strings already tracked keep deduping; new ones are
+    // written out every time.
+    return escapeStringValue(value);
   }
   writtenStrings.set(value, null);
   return escapeStringValue(value);
@@ -4275,21 +4247,23 @@ function renderModelDestructive(
         throwTaintViolation(tainted.message);
       }
     }
+    serializedSize += value.length;
     // TODO: Maybe too clever. If we support URL there's no similar trick.
     if (value[value.length - 1] === 'Z') {
       // Possibly a Date, whose toJSON automatically calls toISOString
       // $FlowFixMe[incompatible-use]
       const originalValue = parent[parentPropertyName];
       if (originalValue instanceof Date) {
-        serializedSize += value.length;
         return serializeDateFromDateJSON(value);
       }
     }
-    if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
-      // This path does its own accounting since it might only write a reference.
-      return serializeDeduplicatedString(request, value);
+    // $FlowFixMe[invalid-compare]
+    if (value.length >= 1024 && byteLengthOfChunk !== null) {
+      // For large strings, we encode them outside the JSON payload so that we
+      // don't have to double encode and double parse the strings. This can also
+      // be more compact in case the string has a lot of escaped characters.
+      return serializeLargeTextString(request, value);
     }
-    serializedSize += value.length;
     return escapeStringValue(value);
   }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3188,9 +3188,15 @@ function serializeClientReference(
   try {
     const clientReferenceMetadata: ClientReferenceMetadata =
       resolveClientReferenceMetadata(request.bundlerConfig, clientReference);
+    // Stringify before claiming a chunk id so a throw can't leave it pending.
+    const json = stringifyImportMetadata(
+      request,
+      clientReferenceMetadata,
+      false,
+    );
     request.pendingChunks++;
     const importId = request.nextChunkId++;
-    emitImportChunk(request, importId, clientReferenceMetadata, false);
+    emitImportChunk(request, importId, json, false);
     writtenClientReferences.set(clientReferenceKey, importId);
     if (parent[0] === REACT_ELEMENT_TYPE && parentPropertyName === '1') {
       // If we're encoding the "type" of an element, we can refer
@@ -3238,9 +3244,14 @@ function serializeDebugClientReference(
   try {
     const clientReferenceMetadata: ClientReferenceMetadata =
       resolveClientReferenceMetadata(request.bundlerConfig, clientReference);
+    const json = stringifyImportMetadata(
+      request,
+      clientReferenceMetadata,
+      true,
+    );
     request.pendingDebugChunks++;
     const importId = request.nextChunkId++;
-    emitImportChunk(request, importId, clientReferenceMetadata, true);
+    emitImportChunk(request, importId, json, true);
     if (parent[0] === REACT_ELEMENT_TYPE && parentPropertyName === '1') {
       // If we're encoding the "type" of an element, we can refer
       // to that by a lazy reference instead of directly since React
@@ -4649,20 +4660,26 @@ function importMetadataReplacer(key: string, value: mixed): mixed {
   return value;
 }
 
-function emitImportChunk(
+function stringifyImportMetadata(
   request: Request,
-  id: number,
   clientReferenceMetadata: ClientReferenceMetadata,
   debug: boolean,
-): void {
+): string {
   importStringRequest = __DEV__ && debug ? null : request;
-  let json: string;
   try {
     // $FlowFixMe[incompatible-type] stringify can return null
-    json = stringify(clientReferenceMetadata, importMetadataReplacer);
+    return stringify(clientReferenceMetadata, importMetadataReplacer);
   } finally {
     importStringRequest = null;
   }
+}
+
+function emitImportChunk(
+  request: Request,
+  id: number,
+  json: string,
+  debug: boolean,
+): void {
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4659,7 +4659,7 @@ function importMetadataReplacer(key: string, value: mixed): mixed {
   return value;
 }
 
-function stringifyImportMetadata(
+function stringifyImportMetadataWithReplacer(
   request: Request,
   clientReferenceMetadata: ClientReferenceMetadata,
   debug: boolean,
@@ -4672,6 +4672,105 @@ function stringifyImportMetadata(
   } finally {
     importStringRequest = prevRequest;
   }
+}
+
+// Bundler metadata is two or three levels deep. The bound is only there so a
+// cycle ends up in stringify itself, which throws its own error for it.
+const MAX_IMPORT_METADATA_DEPTH = 16;
+
+const NOT_PLAIN_IMPORT_METADATA = {};
+
+// Copies the metadata with every string replaced by its serialized form, so
+// that stringify can run without a replacer. Anything stringify would treat
+// specially (toJSON, boxed primitives, class instances) makes this give up
+// instead, because the copy would not reproduce that treatment.
+function transformImportMetadata(
+  request: Request,
+  value: mixed,
+  depth: number,
+): mixed {
+  switch (typeof value) {
+    case 'string':
+      return serializeImportString(request, value);
+    case 'number':
+    case 'boolean':
+    case 'undefined':
+      return value;
+    case 'object': {
+      if (value === null) {
+        return null;
+      }
+      if (depth > MAX_IMPORT_METADATA_DEPTH) {
+        return NOT_PLAIN_IMPORT_METADATA;
+      }
+      if (typeof (value as any).toJSON === 'function') {
+        return NOT_PLAIN_IMPORT_METADATA;
+      }
+      if (isArray(value)) {
+        const length = value.length;
+        const copy: Array<mixed> = new Array(length);
+        for (let i = 0; i < length; i++) {
+          const element = value[i];
+          if (typeof element === 'string') {
+            copy[i] = serializeImportString(request, element);
+            continue;
+          }
+          const child = transformImportMetadata(request, element, depth + 1);
+          if (child === NOT_PLAIN_IMPORT_METADATA) {
+            return NOT_PLAIN_IMPORT_METADATA;
+          }
+          copy[i] = child;
+        }
+        return copy;
+      }
+      const proto = getPrototypeOf(value);
+      if (proto !== ObjectPrototype && proto !== null) {
+        return NOT_PLAIN_IMPORT_METADATA;
+      }
+      const keys = Object.keys(value);
+      const copy: {[string]: mixed} = {};
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        if (key in ObjectPrototype) {
+          // The copy inherits from Object.prototype, so assigning this key would
+          // hit an accessor like __proto__ or, if the prototype is frozen, throw.
+          return NOT_PLAIN_IMPORT_METADATA;
+        }
+        const element = (value as any)[key];
+        if (typeof element === 'string') {
+          copy[key] = serializeImportString(request, element);
+          continue;
+        }
+        const child = transformImportMetadata(request, element, depth + 1);
+        if (child === NOT_PLAIN_IMPORT_METADATA) {
+          return NOT_PLAIN_IMPORT_METADATA;
+        }
+        copy[key] = child;
+      }
+      return copy;
+    }
+    default:
+      return NOT_PLAIN_IMPORT_METADATA;
+  }
+}
+
+function stringifyImportMetadata(
+  request: Request,
+  clientReferenceMetadata: ClientReferenceMetadata,
+  debug: boolean,
+): string {
+  if (!(__DEV__ && debug)) {
+    const copy = transformImportMetadata(request, clientReferenceMetadata, 0);
+    if (copy !== NOT_PLAIN_IMPORT_METADATA) {
+      // $FlowFixMe[incompatible-type] stringify can return null
+      return stringify(copy);
+    }
+  }
+  return stringifyImportMetadataWithReplacer(
+    request,
+    clientReferenceMetadata,
+    debug,
+  );
 }
 
 function emitImportChunk(

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3622,6 +3622,8 @@ function escapeStringValue(value: string): string {
 }
 
 function serializeImportString(request: Request, value: string): string {
+  // No maximum length because import strings are short and repeat often.
+  // Deduping model strings too would need one to skip very long strings.
   if (value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH) {
     return escapeStringValue(value);
   }
@@ -4665,12 +4667,13 @@ function stringifyImportMetadata(
   clientReferenceMetadata: ClientReferenceMetadata,
   debug: boolean,
 ): string {
+  const prevRequest = importStringRequest;
   importStringRequest = __DEV__ && debug ? null : request;
   try {
     // $FlowFixMe[incompatible-type] stringify can return null
     return stringify(clientReferenceMetadata, importMetadataReplacer);
   } finally {
-    importStringRequest = null;
+    importStringRequest = prevRequest;
   }
 }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3613,8 +3613,13 @@ function serializeDeduplicatedString(request: Request, value: string): string {
   const writtenStrings = request.writtenStrings;
   const existing = writtenStrings.get(value);
   if (existing !== undefined && existing !== null) {
+    // The row it refers to was already emitted so only the reference is new here.
+    serializedSize += existing.length;
     return existing;
   }
+  // The string still has to arrive before this row can be used, whether it's
+  // written inline or into its own row, so either way it counts in full.
+  serializedSize += value.length;
   // $FlowFixMe[invalid-compare]
   const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
   if (existing === undefined && !isLarge) {
@@ -4270,19 +4275,21 @@ function renderModelDestructive(
         throwTaintViolation(tainted.message);
       }
     }
-    serializedSize += value.length;
     // TODO: Maybe too clever. If we support URL there's no similar trick.
     if (value[value.length - 1] === 'Z') {
       // Possibly a Date, whose toJSON automatically calls toISOString
       // $FlowFixMe[incompatible-use]
       const originalValue = parent[parentPropertyName];
       if (originalValue instanceof Date) {
+        serializedSize += value.length;
         return serializeDateFromDateJSON(value);
       }
     }
     if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
+      // This path does its own accounting since it might only write a reference.
       return serializeDeduplicatedString(request, value);
     }
+    serializedSize += value.length;
     return escapeStringValue(value);
   }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3487,8 +3487,13 @@ function serializeDeduplicatedString(request: Request, value: string): string {
   const writtenStrings = request.writtenStrings;
   const existing = writtenStrings.get(value);
   if (existing !== undefined && existing !== null) {
+    // The row it refers to was already emitted so only the reference is new here.
+    serializedSize += existing.length;
     return existing;
   }
+  // The string still has to arrive before this row can be used, whether it's
+  // written inline or into its own row, so either way it counts in full.
+  serializedSize += value.length;
   // $FlowFixMe[invalid-compare]
   const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
   if (existing === undefined && !isLarge) {
@@ -4134,19 +4139,21 @@ function renderModelDestructive(
         throwTaintViolation(tainted.message);
       }
     }
-    serializedSize += value.length;
     // TODO: Maybe too clever. If we support URL there's no similar trick.
     if (value[value.length - 1] === 'Z') {
       // Possibly a Date, whose toJSON automatically calls toISOString
       // $FlowFixMe[incompatible-use]
       const originalValue = parent[parentPropertyName];
       if (originalValue instanceof Date) {
+        serializedSize += value.length;
         return serializeDateFromDateJSON(value);
       }
     }
     if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
+      // This path does its own accounting since it might only write a reference.
       return serializeDeduplicatedString(request, value);
     }
+    serializedSize += value.length;
     return escapeStringValue(value);
   }
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -592,5 +592,6 @@
   "604": "The server render could not complete because client rendering was requested outside a Suspense boundary. See this error's cause for additional details.",
   "605": "Recoverable Exception: This is not a real error! It's an implementation detail of `use` to interrupt the current render so a downstream renderer can recover it. You must either rethrow it immediately, or move the `use` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.",
   "606": "Expected a suspended recoverable. This is a bug in React. Please file an issue.",
-  "607": "This library called use() to suspend in a previous render but did not call use() when it finished. This indicates an incorrect use of use(). Learn more: https://react.dev/warnings/conditional-use-of-use"
+  "607": "This library called use() to suspend in a previous render but did not call use() when it finished. This indicates an incorrect use of use(). Learn more: https://react.dev/warnings/conditional-use-of-use",
+  "608": "A client reference was blocked on a row that has not been received yet. This is a bug in React."
 }


### PR DESCRIPTION
Flight has two ways to write a string:

1. Small ones are inlined into the JSON model.
2. Large ones (>= 1024 chars) are outlined into a binary text row so they don't get double-encoded and double-parsed.

Neither is ever deduplicated. That's most visible in client reference metadata, where a route repeats the same bundler chunk URLs across every client reference (for example, https://github.com/vercel/next.js/issues/95559).

**This PR adds a dedupe map for strings inside import metadata.** A string is written once into its own row, and every occurrence is a reference to it.

## How it works

When we're about to write a string in import metadata at least as long as the threshold, we look it up in the request's map:

- **If it's not in the map:** Emit a row containing the string, store that row's reference in the map, and write the reference here.
- **If it is:** Write the reference.

So every string goes on the wire once, and every occurrence costs a few bytes. An earlier version waited for the second occurrence before outlining, which is the right default for arbitrary strings where most never repeat (it's what #27537 does for objects). Import metadata is the opposite case: a chunk is listed by every client module that lives in it, so a chunk name that appears once is the exception. In the bench app's three routes, every chunk string at least 16 characters long appears more than 20 times and none appears once. Outlining on first sight saves the inline copy, and a string that never repeats costs 7 bytes more than inlining it.

Import metadata needs its own map and its own queue. The client resolves a client reference as soon as it parses the import row, and import chunks flush ahead of model rows, so the string row has to be in the same queue to arrive first.

The client needs no protocol changes. It already resolves `$N` references, and a row holding a string resolves to that string. It does get a check that import metadata never blocks on a row that hasn't arrived, which is the other end of the queue ordering above, and `getOutlinedModel` stops allocating a path array for references without one.

Model strings are left alone. An earlier version of this PR deduped them too, but we're not going to do this now per review (maybe in a follow-up). Metadata on the debug channel is also left alone: it's a separate serialization path, and deduping across the two would make the main payload depend on whether a debug channel is attached.

## Threshold

The trigger is 16, low compared to what a model-side threshold would want, because import metadata is repetitive but its parts are short. How much this saves depends on how many client references share a chunk list, so measuring one string on its own is misleading. For a chunk path of realistic length today:

| references sharing the chunk | before | after |
|---|---|---|
| 1 | 80 B | 87 B |
| 2 | 160 B | 122 B |
| 3 | 240 B | 157 B |
| 5 | 401 B | 228 B |
| 10 | 813 B | 416 B |
| 40 | 3273 B | 1526 B |
| 80 | 6594 B | 3047 B |

(Import and string rows only.) It costs 7 bytes at 1 reference and wins from 2. Chunk paths in this app are 47 characters, so a threshold of 48 or higher saves nothing at all here. That's why it's 16: picking a number just under one bundler's path length gives you something that quietly stops working on the next bundler.

The map is bounded by the combined length of the strings it holds, 32 KiB. Once the budget is spent, new strings are written inline every time while strings already outlined keep deduping. That makes the savings depend on the order strings are first seen: a shared chunk URL first encountered after 32 KiB of unique module ids won't be deduped. That's main's behavior, so it's a missed win rather than a regression, but a manifest-heavy dev route could hit it.

## Byte measurements

Three routes of a Next.js app, serial requests:

| route | Flight | document | document (gzip) |
|---|---|---|---|
| `/dashboard` | −48.4% (710.1 → 366.5 KB) | −34.3% | −7.8% |
| `/docs` | −5.8% (555.2 → 523.1 KB) | −5.0% | −0.7% |
| `/blog` | −5.4% (878.8 → 831.7 KB) | −4.4% | −1.7% |

The difference between the routes is how many client references each one has. On `/dashboard` the import rows shrink from 388.0 KB to about 32 KB with the row *count* unchanged at 114, because every client reference repeats the same 49 chunk URLs.

gzip already collapses repeated strings, so −48.4% raw is only −7.8% compressed. The bytes still have to be escaped, encoded and copied before they reach the compressor, which is where most of the speedup below comes from.

## Speed measurements

Benchmarked end-to-end through a Next.js app on Vercel Sandbox VMs (x86 Xeon), 16 boots, paired ABBA within each boot, boot as the unit of replication. Base is the merge-base with main, `eafeac09`; candidate is the current head, `e0b4614c`.

| cell | effect | 95% CI | p |
|---|---|---|---|
| `/dashboard` serial req/s | **+16.9%** | ±1.7 | <0.0001 |
| `/dashboard` serial p95 latency | −18.2% | ±2.4 | <0.0001 |
| `/dashboard` serial TTFB | −23.2% | ±1.2 | <0.0001 |
| `/dashboard` under load req/s | **+17.0%** | ±3.4 | <0.0001 |
| `/dashboard` under load median latency | −13.9% | ±2.5 | <0.0001 |
| `/docs` serial req/s | +3.0% | ±1.4 | 0.0003 |
| `/docs` serial TTFB | −3.1% | ±1.0 | <0.0001 |
| `/blog` serial req/s | +2.4% | ±1.0 | 0.0001 |
| `/blog` serial median latency | −2.4% | ±0.7 | <0.0001 |

No detected difference: `/blog` and `/docs` under load (p=0.13–0.56). All 16 boots are positive on both `/dashboard` cells. The `/dashboard` headline has now been measured in four separate 16-boot runs across four heads of this branch and is p<0.0001 in each; the small routes cleared p<0.01 only on this head, after the serializer change below, having sat at p=0.02–0.06 on the three earlier heads.

The previous head, `4569e1d6`, which outlined on the second occurrence rather than the first, measured +14.9% ±2.3 on `/dashboard` serial req/s and −17.3% ±5.7 on TTFB against the same base. Those intervals overlap the ones above, so the switch is not a measurable speedup on its own; the bytes it saves are about 1% of the payload.

In a real browser on `/dashboard` (measured on an earlier commit of this branch, `aed4d523`), hydration is −2.8% ±1.3 (p=0.0003) / −2.4% ±0.9 (p=0.0001) and LCP is −5.3% ±2.0 (p<0.0001) / −3.6% ±2.6 (p=0.009). Client navigation is under the noise floor in both.

### Where the time goes

32 CPU profiles, taken after the timed runs with an identical request count in both arms, so absolute sampled milliseconds are comparable. One pass per boot, no replication statistics — directional, not a claim. These profiles are from `aed4d523`. The current head also walks the metadata into a copy before a plain `stringify`, after a detour through a `stringify` replacer that measured 2.3× slower in isolation (a replacer function takes V8 off its fast path for the whole call); the `transformImportMetadata` frame below is a fair proxy for the current cost.

Cheaper:

| base | candidate | frame |
| ---: | ---: | --- |
| 23.6 s | 5.7 s | ReactDOM `preinitScript` |
| 24.9 s | 10.6 s | `serializeClientReference` |
| 81.8 s | 67.3 s | `utf8Write` |
| 93.9 s | 80.8 s | `createFromString` |
| 50.7 s | 39.2 s | Next's `htmlEscapeJsonString` |

More expensive:

| base | candidate | frame |
| ---: | ---: | --- |
| 0 | 9.3 s | `transformImportMetadata` |
| 2.0 s | 10.3 s | `getOutlinedModel` (SSR-side Flight client) |
| 7.7 s | 11.7 s | `parseModelString` |
| 154.8 s | 158.2 s | `resolveModelToJSON` |

About +31 s of new work against −79 s inside the runtime bundle and −45 s in node's buffer and string layer.

`getOutlinedModel` resolving references is the mechanism working, not a warning sign. Next.js runs a Flight client on the server to read its own payload, and a `/dashboard` payload goes from 0 references inside import rows to 4964, so a frame that barely ran before now runs once per reference. Each call is a lookup on a row that has already been initialized: the string row goes into the import queue ahead of the import row that reads it, so it has always arrived and nothing blocks. `parseModelString` grows for the same reason.

`preinitScript` doesn't get cheaper from writing fewer bytes. It does two dictionary lookups keyed by the chunk URL per call, and the call count and argument values are unchanged — the resolved models are identical. What changes is string identity: in the base build every one of the 5013 chunk-URL occurrences is a fresh string out of `JSON.parse` whose hash has to be computed before the lookup, and with dedupe the 49 distinct URLs are parsed once and every reference yields the same string, so V8's cached hash makes the repeat lookups nearly free. Some of the `htmlEscapeJsonString` and buffer-layer drops have the same cause.

### React-level CPU in isolation

The e2e numbers above include everything downstream of React (escaping, encoding, compression, the SSR client). To see React's own serialization cost, 114 import rows of dashboard-shaped metadata (49 shared 74-character chunk names per row) were rendered against one request on the production bundles with a no-op destination, arms interleaved, median of 5 rounds × 200:

| | main | this PR |
|---|---|---|
| 49 names shared by all rows | 0.502 ms | **0.322 ms** (−36%) |
| 5586 unique names, nothing to dedupe | 0.477 ms | 0.771 ms (+62%) |

The second row is the worst case for this change, a manifest where every chunk name appears once. It costs about 40 ns per unique string, plus about 130 ns for each row the budget lets it outline, against a payload that is otherwise unchanged.

The metadata is serialized by copying it with the strings already replaced and then calling plain `JSON.stringify`; a `stringify` replacer function would keep V8 off its fast path for the whole call (measured 2.3× slower than plain in isolation, even writing a sixth of the bytes). The copy covers plain JSON only and falls back to the replacer for anything else (`toJSON`, class instances, keys that exist on `Object.prototype`, depth over four, which is how cycles end up throwing stringify's own error). Equivalence of the two paths was checked by a harness that runs both on identical requests and compares the JSON and the resulting request state: 2,656,142 cases, including exhaustive enumeration of small trees over adversarial atoms, 100k seeded random values, and the cases from two independent adversarial reviews — 0 divergences outside four stated assumptions that no bundler manifest violates (no Proxies, no index accessors polluted onto `Array.prototype`, no primitive wrappers with a swapped prototype, side-effect-free property access).

## Cost where there's nothing to dedupe

React's own `flight-ssr-bench` fixture has about ten client modules and no repeated chunk paths, so the dedupe never fires and the change can only cost. It costs a little, if anything. Over 16 boots at `aed4d523` the Flight+Fizz Node sync variant was +0.9% ±0.7 on median inject time (p=0.008), worse on 14 of 16 boots. On the current head the four Flight+Fizz inject cells are between +0.4% and +0.8% on the median, none below p=0.07; across all 88 fixture metrics (Fizz and Flight+Fizz, Node and Edge, sync and async, inject and HTTP at c=1/c=10) nothing reaches p<0.01 and `heapMb` is flat to ±0.1%. So the no-dedupe cost is somewhere around half a percent of inject time on this fixture, at the edge of what it can resolve.

I couldn't localize it past that. It isn't the per-request `Map`, which is about 22 ns against a 14 ms render, and it isn't allocation — `gcMs` and `heapMb` are flat. Using the Fizz-only variants as a within-boot control, since nothing in `ReactFlightServer.js` can reach them, the Flight-specific residual on that cell is +0.8% ±0.5 and the other three variants scatter around zero (+0.4%, +0.1%, −0.2%). A build that re-inlines `escapeStringValue` back into the string branch, which is the only change here that runs for every string in the model rather than only for import metadata, doesn't recover it either (+0.2% ±0.3 on the same cell, another 16 boots). So this looks like code layout rather than a specific added operation, and it's near the resolution limit of the fixture.

<details>
<summary>Verification</summary>

- Both arms' payloads for `/dashboard` were parsed and their `$`-references resolved recursively, then deep-compared: the resolved models are identical. The 49 extra model rows are exactly the 49 distinct chunk URLs. All 114 import rows match after resolution.
- Arms fingerprint distinctly (`a898f40a7bbd` vs `87fb4b7ba15e`), so the two builds are genuinely different.
- Build fingerprints differ between arms (`04440a11435d` vs `43d09027ce58`) and the arm version strings carry the expected shas.
- Per-boot deltas are printed by the harness; on `/dashboard` serial req/s all 16 boots are positive (range +11.2% to +22.9%).
- The bench fixture sets a deployment id, so every chunk URL carries a `?dpl=` query param that exactly doubles its length (74 chars vs 37). An app without one would see roughly half the absolute byte saving on this route. The CPU wins that come from string identity rather than byte count should degrade less than proportionally, but that wasn't measured.
- Not measured: payloads that exceed the 32 KiB tracking budget, and whether 16 is optimal rather than merely low enough.

</details>


