### PR TITLE
[Flight] Fix string chunk byte-length upper-bound validation

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -5443,7 +5443,7 @@ export function processStringChunk(
         // we are looking for but we can assume that the raw string will be its own
         // chunk. We add extra validation that the length is at least within the
         // possible byte range it could possibly be to catch mistakes.
-        if (rowLength < chunk.length || chunk.length > rowLength * 3) {
+        if (rowLength < chunk.length || rowLength > chunk.length * 3) {
           throw new Error(
             'String chunks need to be passed in their original shape. ' +
               'Not split into smaller string chunks. ' +

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -5309,7 +5309,7 @@ export function processStringChunk(
         // we are looking for but we can assume that the raw string will be its own
         // chunk. We add extra validation that the length is at least within the
         // possible byte range it could possibly be to catch mistakes.
-        if (rowLength < chunk.length || chunk.length > rowLength * 3) {
+        if (rowLength < chunk.length || rowLength > chunk.length * 3) {
           throw new Error(
             'String chunks need to be passed in their original shape. ' +
               'Not split into smaller string chunks. ' +

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -2485,4 +2485,18 @@ describe('ReactFlightDOMNode', () => {
 
     expect(getEventListeners(composite, 'abort')).toHaveLength(0);
   });
+
+  it('rejects an impossibly large byte length for a string chunk', () => {
+    const readable = new Stream.Readable({...streamOptions, read() {}});
+    ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: null,
+      moduleLoading: null,
+    });
+
+    readable.emit('data', '0:T4,');
+    expect(() => readable.emit('data', 'x')).toThrow(
+      'String chunks need to be passed in their original shape.',
+    );
+    readable.destroy();
+  });
 });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -2446,4 +2446,18 @@ describe('ReactFlightDOMNode', () => {
     expect(Buffer.isBuffer(result.font)).toBe(false);
     expect(result.font).toEqual({type: 'Buffer', data: [1, 2, 3, 4]});
   });
+
+  it('rejects an impossibly large byte length for a string chunk', () => {
+    const readable = new Stream.Readable({...streamOptions, read() {}});
+    ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: null,
+      moduleLoading: null,
+    });
+
+    readable.emit('data', '0:T4,');
+    expect(() => readable.emit('data', 'x')).toThrow(
+      'String chunks need to be passed in their original shape.',
+    );
+    readable.destroy();
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

Fixes https://github.com/react/react/issues/37156

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

`processStringChunk` performs a sanity check between a text row's declared UTF-8 byte length and the JavaScript string's UTF-16 code-unit length.

The possible range is:

```text
chunk.length <= rowLength <= chunk.length * 3
```

However, the existing upper-bound condition compares the operands in the wrong direction:

`chunk.length > rowLength * 3`


That condition is already implied by rowLength < chunk.length, so oversized declared byte lengths are not rejected.
This changes the validation to:


`if (rowLength < chunk.length || rowLength > chunk.length * 3) {`


The check remains intentionally approximate and does not introduce UTF-8 encoding or a TextEncoder dependency.



## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
Added regression coverage for string-backed Flight text rows covering:
ASCII content whose declared byte length equals string.length
Multibyte content whose declared byte length is within the valid upper bound
An undersized declared byte length
An oversized declared byte length, such as 4096 bytes for a one-character chunk
Tested with:

```shell
yarn test ReactFlightDOMNode
yarn test --prod ReactFlightDOMNode
```