### PR TITLE
[Flight] Limit async hook Promise stacks to 10 frames

### DIFF
--- a/packages/react-server/src/ReactFlightServerConfigDebugNode.js
+++ b/packages/react-server/src/ReactFlightServerConfigDebugNode.js
@@ -54,6 +54,11 @@ function resolvePromiseOrAwaitNode(
 
 const emptyStack: ReactStackTrace = [];
 
+// The higher the limit, the slower Error() is when not inspecting with a
+// debugger. V8 defaults to 10, but the ambient limit can be configured by
+// user code.
+const asyncStackTraceLimit = 10;
+
 // Initialize the tracing of async operations.
 // We do this globally since the async work can potentially eagerly
 // start before the first request and once requests start they can interleave.
@@ -104,7 +109,12 @@ export function initAsyncDebugInfo(): void {
               if (request === null) {
                 // We don't collect stacks for awaits that weren't in the scope of a specific render.
               } else {
-                stack = parseStackTracePrivate(new Error(), 5);
+                let error;
+                const previousStackTraceLimit = Error.stackTraceLimit;
+                Error.stackTraceLimit = asyncStackTraceLimit;
+                error = new Error(); // eslint-disable-line prefer-const
+                Error.stackTraceLimit = previousStackTraceLimit;
+                stack = parseStackTracePrivate(error, 5);
                 if (stack !== null && !isAwaitInUserspace(request, stack)) {
                   // If this await was not done directly in user space, then clear the stack. We won't use it
                   // anyway. This lets future awaits on this await know that we still need to get their stacks
@@ -126,11 +136,19 @@ export function initAsyncDebugInfo(): void {
             } as UnresolvedAwaitNode;
           } else {
             const owner = resolveOwner();
+            let stack = null;
+            if (owner !== null) {
+              let error;
+              const previousStackTraceLimit = Error.stackTraceLimit;
+              Error.stackTraceLimit = asyncStackTraceLimit;
+              error = new Error(); // eslint-disable-line prefer-const
+              Error.stackTraceLimit = previousStackTraceLimit;
+              stack = parseStackTracePrivate(error, 5);
+            }
             node = {
               tag: UNRESOLVED_PROMISE_NODE,
               owner: owner,
-              stack:
-                owner === null ? null : parseStackTracePrivate(new Error(), 5),
+              stack: stack,
               start: performance.now(),
               end: -1.1, // Set when we resolve.
               promise: new WeakRef(resource as Promise<any>),


### PR DESCRIPTION
## Summary

Limit RSC async debug Promise stack captures to 10 frames and restore the ambient `Error.stackTraceLimit` immediately afterward.

Higher ambient stack trace limits make `new Error()` significantly slower inside the synchronous Promise `async_hooks` init callback. The before and after paths otherwise create and parse the same Error.

## Benchmark

The standalone benchmark isolates the Promise init hook. It creates Promises beneath a 64-frame JavaScript call stack with an ambient `Error.stackTraceLimit` of 50.

The two variants both run the same `new Error()` in the same hook. The after variant differs only by setting `Error.stackTraceLimit` to 10 immediately before constructing the Error and restoring the previous value immediately afterward.

- 5 samples per variant
- Alternating before/after execution order
- One warmup per variant
- No debugger or inspector attached
- Node 24.13.0

| Promises | Before | After | Improvement |
| ---: | ---: | ---: | ---: |
| 5,000 | 83.5 ms | 21.4 ms | 74.4% |
| 10,000 | 180.5 ms | 42.8 ms | 76.3% |
| 20,000 | 335.3 ms | 84.9 ms | 74.7% |
| 40,000 | 670.9 ms | 170.1 ms | 74.6% |
| 80,000 | 1339.5 ms | 337.9 ms | 74.8% |

This is a deliberately stack-heavy microbenchmark. It demonstrates the cost of honoring a high ambient stack trace limit inside the Promise init hook; it does not imply the same percentage improvement for an entire RSC render.

## How did you test this change?

- `yarn eslint packages/react-server/src/ReactFlightServerConfigDebugNode.js`
- `yarn flow dom-node`
