### PR TITLE
[DOM] Fix Fragment dispatchEvent when the container is a Document

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3156,7 +3156,14 @@ FragmentInstance.prototype.dispatchEvent = function (
     (eventListeners !== null && eventListeners.length > 0) ||
     !event.bubbles
   ) {
-    const temp = document.createTextNode('');
+    // The temporary node stands in for the fragment's position so that its own
+    // listeners fire before the event propagates to the parent. A Document can
+    // only hold comments and processing instructions alongside its
+    // documentElement, so a Text node would be an invalid child there.
+    const temp =
+      parentHostInstance.nodeType === DOCUMENT_NODE
+        ? (parentHostInstance as any as Document).createComment('')
+        : document.createTextNode('');
     if (eventListeners) {
       for (let i = 0; i < eventListeners.length; i++) {
         const {type, listener, optionsOrUseCapture} = eventListeners[i];

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
@@ -34,6 +34,7 @@ describe('FragmentRefs', () => {
     global.document = global.window.document;
     global.navigator = global.window.navigator;
     global.Event = global.window.Event;
+    global.MouseEvent = global.window.MouseEvent;
     global.Node = Node;
   });
 
@@ -102,6 +103,106 @@ describe('FragmentRefs', () => {
 
         expect(fragmentListener).toHaveBeenCalledTimes(1);
         expect(bodyListener).toHaveBeenCalledTimes(1);
+      });
+
+      // @gate enableFragmentRefs
+      it('dispatches to its own listeners when the container is a Document', async () => {
+        const fragmentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(document);
+        const logs = [];
+
+        await act(() => {
+          root.render(
+            <>
+              <Fragment ref={fragmentRef} />
+              <html>
+                <body>
+                  <div id="child" />
+                </body>
+              </html>
+            </>,
+          );
+        });
+
+        fragmentRef.current.addEventListener('click', () => {
+          logs.push('fragment');
+        });
+        document.addEventListener('click', () => {
+          logs.push('document');
+        });
+
+        const isCancelable = !fragmentRef.current.dispatchEvent(
+          new MouseEvent('click', {bubbles: true}),
+        );
+
+        expect(logs).toEqual(['fragment', 'document']);
+        expect(isCancelable).toBe(false);
+      });
+
+      // @gate enableFragmentRefs
+      it('does not propagate through its own children when wrapping documentElement', async () => {
+        const fragmentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(document);
+        const logs = [];
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <html>
+                <body>
+                  <div id="child" />
+                </body>
+              </html>
+            </Fragment>,
+          );
+        });
+
+        // This also registers the listener on the <html> child. Because the
+        // fragment's position is a sibling of <html>, the event must not
+        // propagate through it and fire the listener a second time.
+        fragmentRef.current.addEventListener('click', () => {
+          logs.push('fragment');
+        });
+        document.addEventListener('click', () => {
+          logs.push('document');
+        });
+
+        fragmentRef.current.dispatchEvent(
+          new MouseEvent('click', {bubbles: true}),
+        );
+
+        expect(logs).toEqual(['fragment', 'document']);
+      });
+
+      // @gate enableFragmentRefs
+      it('dispatches non-bubbling events when the container is a Document', async () => {
+        const fragmentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(document);
+        const logs = [];
+
+        await act(() => {
+          root.render(
+            <>
+              <Fragment ref={fragmentRef} />
+              <html>
+                <body>
+                  <div id="child" />
+                </body>
+              </html>
+            </>,
+          );
+        });
+
+        document.addEventListener('click', () => {
+          logs.push('document');
+        });
+
+        const isCancelable = !fragmentRef.current.dispatchEvent(
+          new MouseEvent('click', {bubbles: false}),
+        );
+
+        expect(logs).toEqual([]);
+        expect(isCancelable).toBe(false);
       });
     });
 


### PR DESCRIPTION
dispatchEvent appends a temporary Text node to the fragment's nearest host parent, but a Document can't contain Text, so createRoot(document) threw HierarchyRequestError whenever the fragment had a listener or the event didn't bubble.

Use a Comment node for Document containers: it is a legal document child and sits at the fragment's own position, unlike documentElement, which would put the target inside the fragment and fire its listeners twice.