### PR TITLE
[Compiler] Preserve manual useMemo dependency semantics

### DIFF
--- a/compiler/crates/react_compiler_validation/src/validate_preserved_manual_memoization.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_preserved_manual_memoization.rs
@@ -46,6 +46,8 @@ struct VisitorState<'a> {
     pruned_scopes: FxHashSet<ScopeId>,
     /// Map from identifier ID to its normalized manual memo dependency.
     temporaries: FxHashMap<IdentifierId, ManualMemoDependency>,
+    /// Alias and property-load dependencies used to validate pruned memo outputs.
+    memo_dependencies: FxHashMap<IdentifierId, ManualMemoDependency>,
 }
 
 /// Validate that manual memoization (useMemo/useCallback) is preserved.
@@ -62,6 +64,7 @@ pub fn validate_preserved_manual_memoization(func: &ReactiveFunction, env: &mut 
         scopes: FxHashSet::default(),
         pruned_scopes: FxHashSet::default(),
         temporaries: FxHashMap::default(),
+        memo_dependencies: FxHashMap::default(),
     };
     visit_block(&func.body, &mut state);
 }
@@ -260,7 +263,28 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState) {
 
             let memo_state = state.manual_memo_state.take().unwrap();
 
-            if !pruned {
+            if *pruned {
+                if let Some(ref deps_from_source) = memo_state.deps_from_source {
+                    if let Some(output_dependency) =
+                        state.memo_dependencies.get(&decl.identifier).cloned()
+                    {
+                        if let ManualMemoDependencyRoot::NamedLocal { value, .. } =
+                            output_dependency.root
+                        {
+                            let temporaries = state.temporaries.clone();
+                            validate_inferred_dep(
+                                value.identifier,
+                                &output_dependency.path,
+                                &temporaries,
+                                &memo_state.decls,
+                                deps_from_source,
+                                state.env,
+                                memo_state.loc,
+                            );
+                        }
+                    }
+                }
+            } else {
                 // Check if the declared value is unmemoized
                 let decl_ident = &state.env.identifiers[decl.identifier.0 as usize];
 
@@ -362,27 +386,36 @@ fn record_temporaries(instr: &ReactiveInstruction, state: &mut VisitorState) {
     }
 
     // Record deps from the instruction value first (before setting lvalue temporary)
-    record_deps_in_value(&instr.value, state);
+    let dependency = record_deps_in_value(&instr.value, state);
 
-    // Then set the lvalue temporary (TS always sets this, even for unnamed lvalues)
+    // Then set the existing temporary map exactly as before, and separately retain
+    // aliases and property paths for validating pruned manual memo outputs.
     if let Some(ref lvalue) = instr.lvalue {
-        state.temporaries.insert(
-            lvalue.identifier,
-            ManualMemoDependency {
-                root: ManualMemoDependencyRoot::NamedLocal {
-                    value: lvalue.clone(),
-                    constant: false,
-                },
-                path: Vec::new(),
-                loc: lvalue.loc,
+        let local_dependency = ManualMemoDependency {
+            root: ManualMemoDependencyRoot::NamedLocal {
+                value: lvalue.clone(),
+                constant: false,
             },
-        );
+            path: Vec::new(),
+            loc: lvalue.loc,
+        };
+        state
+            .temporaries
+            .insert(lvalue.identifier, local_dependency.clone());
+        if let Some(dependency) = dependency {
+            state
+                .memo_dependencies
+                .insert(lvalue.identifier, dependency);
+        }
     }
 }
 
 /// Record dependencies from a reactive value.
 /// TS: `recordDepsInValue`
-fn record_deps_in_value(value: &ReactiveValue, state: &mut VisitorState) {
+fn record_deps_in_value(
+    value: &ReactiveValue,
+    state: &mut VisitorState,
+) -> Option<ManualMemoDependency> {
     match value {
         ReactiveValue::SequenceExpression {
             instructions,
@@ -392,10 +425,10 @@ fn record_deps_in_value(value: &ReactiveValue, state: &mut VisitorState) {
             for instr in instructions {
                 visit_instruction(instr, state);
             }
-            record_deps_in_value(value, state);
+            record_deps_in_value(value, state)
         }
         ReactiveValue::OptionalExpression { value: inner, .. } => {
-            record_deps_in_value(inner, state);
+            record_deps_in_value(inner, state)
         }
         ReactiveValue::ConditionalExpression {
             test,
@@ -406,18 +439,16 @@ fn record_deps_in_value(value: &ReactiveValue, state: &mut VisitorState) {
             record_deps_in_value(test, state);
             record_deps_in_value(consequent, state);
             record_deps_in_value(alternate, state);
+            None
         }
         ReactiveValue::LogicalExpression { left, right, .. } => {
             record_deps_in_value(left, state);
             record_deps_in_value(right, state);
+            None
         }
         ReactiveValue::Instruction(iv) => {
-            // TS: collectMaybeMemoDependencies(value, this.temporaries, false)
-            // Called for side-effect of building up the dependency chain through
-            // LoadGlobal -> PropertyLoad -> ... The return value is discarded here
-            // (only used in DropManualMemoization's caller), but we need to store
-            // the result in temporaries for the lvalue of the enclosing instruction.
-            // That storage is handled by record_temporaries after this function returns.
+            let dependency =
+                collect_maybe_memo_dependency(iv, &state.memo_dependencies, false, state.env);
 
             // Track store targets within manual memo blocks
             // TS: if (value.kind === 'StoreLocal' || value.kind === 'StoreContext' || value.kind === 'Destructure')
@@ -465,7 +496,68 @@ fn record_deps_in_value(value: &ReactiveValue, state: &mut VisitorState) {
                 }
                 _ => {}
             }
+            dependency
         }
+    }
+}
+
+fn collect_maybe_memo_dependency(
+    value: &InstructionValue,
+    maybe_deps: &FxHashMap<IdentifierId, ManualMemoDependency>,
+    optional: bool,
+    env: &Environment,
+) -> Option<ManualMemoDependency> {
+    match value {
+        InstructionValue::LoadGlobal { binding, loc, .. } => Some(ManualMemoDependency {
+            root: ManualMemoDependencyRoot::Global {
+                identifier_name: binding.name().to_string(),
+            },
+            path: Vec::new(),
+            loc: *loc,
+        }),
+        InstructionValue::PropertyLoad {
+            object,
+            property,
+            loc,
+            ..
+        } => maybe_deps.get(&object.identifier).map(|object_dependency| {
+            let mut path = object_dependency.path.clone();
+            path.push(DependencyPathEntry {
+                property: property.clone(),
+                optional,
+                loc: *loc,
+            });
+            ManualMemoDependency {
+                root: object_dependency.root.clone(),
+                path,
+                loc: *loc,
+            }
+        }),
+        InstructionValue::LoadLocal { place, .. } | InstructionValue::LoadContext { place, .. } => {
+            if let Some(source) = maybe_deps.get(&place.identifier) {
+                Some(source.clone())
+            } else if is_named(&env.identifiers[place.identifier.0 as usize]) {
+                Some(ManualMemoDependency {
+                    root: ManualMemoDependencyRoot::NamedLocal {
+                        value: place.clone(),
+                        constant: false,
+                    },
+                    path: Vec::new(),
+                    loc: place.loc,
+                })
+            } else {
+                None
+            }
+        }
+        InstructionValue::StoreLocal { lvalue, value, .. } => {
+            let lvalue_ident = &env.identifiers[lvalue.place.identifier.0 as usize];
+            if !is_named(lvalue_ident) {
+                maybe_deps.get(&value.identifier).cloned()
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
@@ -324,6 +324,7 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
   scopes: Set<ScopeId> = new Set();
   prunedScopes: Set<ScopeId> = new Set();
   temporaries: Map<IdentifierId, ManualMemoDependency> = new Map();
+  memoDependencies: Map<IdentifierId, ManualMemoDependency> = new Map();
 
   /**
    * Recursively visit values and instructions to collect declarations
@@ -331,32 +332,38 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
    * @returns a @{ManualMemoDependency} representing the variable +
    * property reads represented by @value
    */
-  recordDepsInValue(value: ReactiveValue, state: VisitorState): void {
+  recordDepsInValue(
+    value: ReactiveValue,
+    state: VisitorState,
+  ): ManualMemoDependency | null {
     switch (value.kind) {
       case 'SequenceExpression': {
         for (const instr of value.instructions) {
           this.visitInstruction(instr, state);
         }
-        this.recordDepsInValue(value.value, state);
-        break;
+        return this.recordDepsInValue(value.value, state);
       }
       case 'OptionalExpression': {
-        this.recordDepsInValue(value.value, state);
-        break;
+        return this.recordDepsInValue(value.value, state);
       }
       case 'ConditionalExpression': {
         this.recordDepsInValue(value.test, state);
         this.recordDepsInValue(value.consequent, state);
         this.recordDepsInValue(value.alternate, state);
-        break;
+        return null;
       }
       case 'LogicalExpression': {
         this.recordDepsInValue(value.left, state);
         this.recordDepsInValue(value.right, state);
-        break;
+        return null;
       }
       default: {
         collectMaybeMemoDependencies(value, this.temporaries, false);
+        const dependency = collectMaybeMemoDependencies(
+          value,
+          this.memoDependencies,
+          false,
+        );
         if (
           value.kind === 'StoreLocal' ||
           value.kind === 'StoreContext' ||
@@ -379,7 +386,7 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
             }
           }
         }
-        break;
+        return dependency;
       }
     }
   }
@@ -396,9 +403,9 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
       state.manualMemoState.decls.add(lvalue.identifier.declarationId);
     }
 
-    this.recordDepsInValue(value, state);
+    const dependency = this.recordDepsInValue(value, state);
     if (lvalue != null) {
-      temporaries.set(lvalue.identifier.id, {
+      const localDependency: ManualMemoDependency = {
         root: {
           kind: 'NamedLocal',
           value: {...lvalue},
@@ -406,7 +413,11 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
         },
         path: [],
         loc: lvalue.loc,
-      });
+      };
+      temporaries.set(lvalue.identifier.id, localDependency);
+      if (dependency != null) {
+        this.memoDependencies.set(lvalue.identifier.id, dependency);
+      }
     }
   }
 
@@ -568,8 +579,29 @@ class Visitor extends ReactiveFunctionVisitor<VisitorState> {
           loc: value.loc,
         },
       );
-      const reassignments = state.manualMemoState.reassignments;
+      const memoState = state.manualMemoState;
+      const reassignments = memoState.reassignments;
       state.manualMemoState = null;
+      if (value.pruned && memoState.depsFromSource != null) {
+        const outputDependency = this.memoDependencies.get(
+          value.decl.identifier.id,
+        );
+        if (outputDependency?.root.kind === 'NamedLocal') {
+          validateInferredDep(
+            {
+              identifier: outputDependency.root.value.identifier,
+              reactive: outputDependency.root.value.reactive,
+              path: outputDependency.path,
+              loc: outputDependency.loc,
+            },
+            this.temporaries,
+            memoState.decls,
+            memoState.depsFromSource,
+            state.env,
+            memoState.loc,
+          );
+        }
+      }
       if (!value.pruned) {
         for (const {identifier, loc} of eachInstructionValueOperand(
           value as InstructionValue,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-identity.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-identity.expect.md
@@ -1,0 +1,58 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees @validateExhaustiveMemoizationDependencies:false
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+type Value = {
+  id: number;
+  label: string;
+};
+
+function getIdentity(value: Value): number {
+  return value.id;
+}
+
+function Component({value}: {value: Value}) {
+  const identity = getIdentity(value);
+  const result = useMemo(() => value, [identity]);
+
+  return <ValidateMemoization inputs={[identity]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {id: 1, label: 'first'}}],
+  sequentialRenders: [
+    {value: {id: 1, label: 'first'}},
+    {value: {id: 1, label: 'second'}},
+    {value: {id: 2, label: 'third'}},
+  ],
+};
+
+```
+
+
+## Error
+
+```
+Found 1 error:
+
+Compilation Skipped: Existing memoization could not be preserved
+
+React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `value`, but the source dependencies were [identity]. Inferred different dependency than source.
+
+error.useMemo-preserve-derived-identity.ts:17:25
+  15 | function Component({value}: {value: Value}) {
+  16 |   const identity = getIdentity(value);
+> 17 |   const result = useMemo(() => value, [identity]);
+     |                          ^^^^^^^^^^^ Could not preserve existing manual memoization
+  18 |
+  19 |   return <ValidateMemoization inputs={[identity]} output={result} />;
+  20 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-identity.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-identity.tsx
@@ -1,0 +1,30 @@
+// @validatePreserveExistingMemoizationGuarantees @validateExhaustiveMemoizationDependencies:false
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+type Value = {
+  id: number;
+  label: string;
+};
+
+function getIdentity(value: Value): number {
+  return value.id;
+}
+
+function Component({value}: {value: Value}) {
+  const identity = getIdentity(value);
+  const result = useMemo(() => value, [identity]);
+
+  return <ValidateMemoization inputs={[identity]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {id: 1, label: 'first'}}],
+  sequentialRenders: [
+    {value: {id: 1, label: 'first'}},
+    {value: {id: 1, label: 'second'}},
+    {value: {id: 2, label: 'third'}},
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-property-identity.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-property-identity.expect.md
@@ -1,0 +1,59 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees @validateExhaustiveMemoizationDependencies:false
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+type Value = {
+  id: number;
+  label: string;
+};
+
+function getIdentity(value: Value): number {
+  return value.id;
+}
+
+function Component({value}: {value: Value}) {
+  const alias = value;
+  const identity = getIdentity(value);
+  const result = useMemo(() => alias.label, [identity]);
+
+  return <ValidateMemoization inputs={[identity]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {id: 1, label: 'first'}}],
+  sequentialRenders: [
+    {value: {id: 1, label: 'first'}},
+    {value: {id: 1, label: 'second'}},
+    {value: {id: 2, label: 'third'}},
+  ],
+};
+
+```
+
+
+## Error
+
+```
+Found 1 error:
+
+Compilation Skipped: Existing memoization could not be preserved
+
+React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `alias.label`, but the source dependencies were [identity]. Inferred different dependency than source.
+
+error.useMemo-preserve-derived-property-identity.ts:18:25
+  16 |   const alias = value;
+  17 |   const identity = getIdentity(value);
+> 18 |   const result = useMemo(() => alias.label, [identity]);
+     |                          ^^^^^^^^^^^^^^^^^ Could not preserve existing manual memoization
+  19 |
+  20 |   return <ValidateMemoization inputs={[identity]} output={result} />;
+  21 | }
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-property-identity.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/error.useMemo-preserve-derived-property-identity.tsx
@@ -1,0 +1,31 @@
+// @validatePreserveExistingMemoizationGuarantees @validateExhaustiveMemoizationDependencies:false
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+type Value = {
+  id: number;
+  label: string;
+};
+
+function getIdentity(value: Value): number {
+  return value.id;
+}
+
+function Component({value}: {value: Value}) {
+  const alias = value;
+  const identity = getIdentity(value);
+  const result = useMemo(() => alias.label, [identity]);
+
+  return <ValidateMemoization inputs={[identity]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {id: 1, label: 'first'}}],
+  sequentialRenders: [
+    {value: {id: 1, label: 'first'}},
+    {value: {id: 1, label: 'second'}},
+    {value: {id: 2, label: 'third'}},
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-dependency.expect.md
@@ -1,0 +1,69 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+function Component({value}: {value: {label: string}}) {
+  const result = useMemo(() => value, [value]);
+
+  return <ValidateMemoization inputs={[value]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {label: 'first'}}],
+  sequentialRenders: [{value: {label: 'first'}}, {value: {label: 'second'}}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMemoizationGuarantees
+
+import { useMemo } from "react";
+import { ValidateMemoization } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(5);
+  const { value } = t0;
+  const result = value;
+  let t1;
+  if ($[0] !== value) {
+    t1 = [value];
+    $[0] = value;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== result || $[3] !== t1) {
+    t2 = <ValidateMemoization inputs={t1} output={result} />;
+    $[2] = result;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ value: { label: "first" } }],
+  sequentialRenders: [
+    { value: { label: "first" } },
+    { value: { label: "second" } },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"inputs":[{"label":"first"}],"output":"[[ cyclic ref *2 ]]"}</div>
+<div>{"inputs":[{"label":"second"}],"output":"[[ cyclic ref *2 ]]"}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-dependency.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-dependency.tsx
@@ -1,0 +1,16 @@
+// @validatePreserveExistingMemoizationGuarantees
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+function Component({value}: {value: {label: string}}) {
+  const result = useMemo(() => value, [value]);
+
+  return <ValidateMemoization inputs={[value]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {label: 'first'}}],
+  sequentialRenders: [{value: {label: 'first'}}, {value: {label: 'second'}}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-property-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-property-dependency.expect.md
@@ -1,0 +1,71 @@
+
+## Input
+
+```javascript
+// @validatePreserveExistingMemoizationGuarantees
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+function Component({value}: {value: {label: string}}) {
+  const alias = value;
+  const result = useMemo(() => alias.label, [alias.label]);
+
+  return <ValidateMemoization inputs={[alias.label]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {label: 'first'}}],
+  sequentialRenders: [{value: {label: 'first'}}, {value: {label: 'second'}}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validatePreserveExistingMemoizationGuarantees
+
+import { useMemo } from "react";
+import { ValidateMemoization } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(5);
+  const { value } = t0;
+  const alias = value;
+  const result = alias.label;
+  let t1;
+  if ($[0] !== alias.label) {
+    t1 = [alias.label];
+    $[0] = alias.label;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== result || $[3] !== t1) {
+    t2 = <ValidateMemoization inputs={t1} output={result} />;
+    $[2] = result;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ value: { label: "first" } }],
+  sequentialRenders: [
+    { value: { label: "first" } },
+    { value: { label: "second" } },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"inputs":["first"],"output":"first"}</div>
+<div>{"inputs":["second"],"output":"second"}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-property-dependency.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-validation/useMemo-pruned-matching-property-dependency.tsx
@@ -1,0 +1,17 @@
+// @validatePreserveExistingMemoizationGuarantees
+
+import {useMemo} from 'react';
+import {ValidateMemoization} from 'shared-runtime';
+
+function Component({value}: {value: {label: string}}) {
+  const alias = value;
+  const result = useMemo(() => alias.label, [alias.label]);
+
+  return <ValidateMemoization inputs={[alias.label]} output={result} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: {label: 'first'}}],
+  sequentialRenders: [{value: {label: 'first'}}, {value: {label: 'second'}}],
+};


### PR DESCRIPTION
## Summary

Fixes #33559.

React Compiler currently removes `useMemo(() => value, [identity])` when the callback only returns an existing value. That changes behavior when `value` changes but `identity` does not. Normal React keeps returning the previous value until `identity` changes, while the compiled output immediately returns the new value.

This change tracks direct aliases and property reads for manual memo outputs that get pruned. If the output depends on something different from the dependency array, the compiler now skips that optimization and uses the existing preserve-memoization diagnostic.

The TypeScript and Rust implementations stay in sync. I also added regression tests for direct values and aliased property reads, plus control cases where the dependencies match.

## How did you test this change?

- `yarn snap`: 1,814 passed
- `yarn snap --rust`: 1,814 passed
- `yarn snap --sync -p 'preserve-memo-validation/**'`: 66 passed
- `yarn snap --sync --rust -p 'preserve-memo-validation/**'`: 66 passed
- `yarn workspace babel-plugin-react-compiler lint`
- `cargo check -p react_compiler_validation`
- `cargo fmt --all --check`
- `bash compiler/scripts/test-babel-ast.sh`
- TypeScript/Rust pipeline comparison: 1,811 passed

I also ran the compiler workspace tests. The relevant compiler, ESLint, and utility suites passed. The command later stopped in the unrelated `react-forgive` VS Code extension test because the downloaded macOS app was missing its expected Electron executable.
