### PR TITLE
[Fizz] Cancel suspended fallback tasks when flushing a completed boundary

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -10266,6 +10266,69 @@ Unfortunately that previous paragraph wasn't quite long enough so I'll continue 
     );
   });
 
+  // Regression test for https://github.com/facebook/react/issues/37178
+  // Same as above but with content large enough to make the inner boundary
+  // eligible for outlining, in which case the suspended fallback is not
+  // cancelled when the boundary completes but when it flushes.
+  it('completes the outer boundary when an outlined boundary abandons its suspended fallback', async () => {
+    function SuspendForever() {
+      React.use(new Promise(() => {}));
+    }
+
+    let resolve = () => {};
+    const suspendPromise = new Promise(r => {
+      resolve = r;
+    });
+    function Suspend() {
+      return React.use(suspendPromise);
+    }
+
+    const bigText = 'x'.repeat(1024);
+
+    function App() {
+      return (
+        <div>
+          <Suspense fallback="outer">
+            <Suspense fallback={<SuspendForever />}>
+              <span>{bigText}</span>
+              <span>
+                <Suspend />
+              </span>
+            </Suspense>
+          </Suspense>
+        </div>
+      );
+    }
+
+    let allReady = false;
+    await act(async () => {
+      const {pipe} = renderToPipeableStream(<App />, {
+        progressiveChunkSize: 256,
+        onAllReady() {
+          allReady = true;
+        },
+        onError() {},
+      });
+      pipe(writable);
+    });
+
+    // The shell flushed with the outer fallback while the content was pending.
+    expect(getVisibleChildren(container)).toEqual(<div>outer</div>);
+    expect(allReady).toBe(false);
+
+    await act(() => {
+      resolve('!');
+    });
+
+    expect(allReady).toBe(true);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <span>{bigText}</span>
+        <span>!</span>
+      </div>,
+    );
+  });
+
   // @gate enableCPUSuspense
   it('outlines deferred Suspense boundaries', async () => {
     function Log({text}) {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -4631,7 +4631,11 @@ function abortTaskSoft(this: Request, task: Task): void {
   const request: Request = this;
   const boundary = task.blockedBoundary;
   const segment = task.blockedSegment;
-  if (segment !== null) {
+  if (segment !== null && segment.status === PENDING) {
+    // Only abort tasks that haven't finished yet. Aborting can reentrantly
+    // trigger a flush which can abort the remaining tasks of the same set
+    // before we get to them (e.g. from onShellReady), so we might see tasks
+    // that have already been aborted.
     segment.status = ABORTED;
     finishedTask(request, boundary, task.row, segment);
   }
@@ -5948,6 +5952,18 @@ function flushSegment(
       }
     }
 
+    if (boundary.fallbackAbortableTasks.size > 0) {
+      // We're emitting the completed content, so the fallback will never be
+      // needed. If it has tasks that are still pending (e.g. the fallback
+      // itself suspended), cancel them now. Otherwise they would keep the
+      // parent boundary and the request pending forever. If the boundary was
+      // not eligible for outlining this already happened when the boundary
+      // completed. This may finish the parent boundary and schedule new
+      // completed boundaries.
+      boundary.fallbackAbortableTasks.forEach(abortTaskSoft, request);
+      boundary.fallbackAbortableTasks.clear();
+    }
+
     // We can inline this boundary's content as a complete boundary.
     writeStartCompletedSuspenseBoundary(destination, request.renderState);
 
@@ -6033,6 +6049,21 @@ function flushCompletedBoundary(
     if (--row.pendingTasks === 0) {
       finishSuspenseListRow(request, row);
     }
+  }
+
+  if (
+    boundary.status === COMPLETED &&
+    boundary.fallbackAbortableTasks.size > 0
+  ) {
+    // We're emitting the completed content, so the fallback will never be
+    // needed. If it has tasks that are still pending (e.g. the fallback
+    // itself suspended), cancel them now. Otherwise they would keep the
+    // parent boundary and the request pending forever. If the boundary was
+    // not eligible for outlining this already happened when the boundary
+    // completed. This may finish the parent boundary and schedule new
+    // completed boundaries.
+    boundary.fallbackAbortableTasks.forEach(abortTaskSoft, request);
+    boundary.fallbackAbortableTasks.clear();
   }
 
   writeHoistablesForBoundary(


### PR DESCRIPTION
## Summary

Fixes #37178.

When a Suspense boundary completes while it is eligible for outlining, `finishedTask` deliberately keeps its fallback tasks alive, because the fallback may still need to be written if the boundary is outlined during flush:

https://github.com/facebook/react/blob/3a717e42438afac81020cdec297dadb5613a4304/packages/react-server/src/ReactFizzServer.js#L5198-L5200

But nothing cancelled those tasks once the boundary's content actually flushed. If the fallback itself suspended (and never resolved), the abandoned fallback task kept the parent boundary's pending task count from draining: the parent boundary never completed, no `$RC` was emitted for it, `onAllReady` never fired, and the request hung with the content sitting unreferenced in the stream — with no error surfaced anywhere. Small boundaries are unaffected because the non-outlineable path cancels fallbacks at completion time, which is why #34694's test (tiny content) passes while the same shape with >500 bytes of content hangs.

This cancels the fallback tasks at the two places where the decision to show the content over the fallback becomes final:

- `flushSegment`, when a completed boundary is inlined (the fallback is never written), and
- `flushCompletedBoundary`, when the completion instruction is written (the outlined fallback has already been written and is about to be replaced).

Both places already mutate row/task state during flush (`finishSuspenseListRow`), and the flush loops explicitly support new completed boundaries being scheduled mid-loop, so the parent boundary completing reentrantly is handled by the existing machinery.

`abortTaskSoft` is also guarded to only abort tasks whose segment is still `PENDING`: aborting can reentrantly trigger a flush (e.g. `completeShell` → `onShellReady` → `pipe`), which can now abort the remaining tasks of the same `fallbackAbortableTasks` set before the outer `forEach` reaches them. Without the guard the second abort double-finishes the task and corrupts `pendingRootTasks`/`allPendingTasks` (caught by the existing "two containers" reentrancy test). This mirrors the status guard `finishAbortedTask` already uses.

## How did you test this change?

- Added a regression test next to #34694's test: same nested-boundary shape with a suspending-forever fallback, but with content large enough to be outlining-eligible and a small `progressiveChunkSize`. It fails on `main` (`onAllReady` never fires, outer boundary never completes) and passes with this change.
- Ran the repro script from #37178 against a locally built `NODE_DEV` bundle: on `main` it reproduces the hang (`events: ['onShellReady']`, only the inner `$RC`); with this change it completes (`events: ['onShellReady', 'onAllReady']`, `$RC` for both boundaries, content revealed). Also confirmed the repro against published `react-dom@19.2.8` and `19.3.0-canary-cbb046ab-20260731` to verify the bug exists as reported.
- `yarn test Fizz` — 14 suites, 333 tests pass (including the "two containers" reentrancy test).
- `yarn test ReactDOMFizzServer --prod` — 217 tests pass.
- `yarn test ReactDOMServerIntegration` — 1602 tests pass.
- `yarn linc`, `yarn flow dom-node`, `yarn prettier` — clean.