### PR TITLE
[react-is] Recognize elements created by React 17 and 18

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -19,6 +19,7 @@ import {
   REACT_PORTAL_TYPE,
   REACT_PROFILER_TYPE,
   REACT_CONSUMER_TYPE,
+  REACT_LEGACY_ELEMENT_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
@@ -41,6 +42,11 @@ export function typeOf(object: any): mixed {
   if (typeof object === 'object' && object !== null) {
     const $$typeof = object.$$typeof;
     switch ($$typeof) {
+      // React 19 renamed the element symbol from `react.element` to
+      // `react.transitional.element`. Elements created by React 17 and 18 still
+      // use the legacy symbol, so accept both: brand checking a foreign element
+      // is valid even though rendering one isn't.
+      case REACT_LEGACY_ELEMENT_TYPE:
       case REACT_ELEMENT_TYPE:
         const type = object.type;
 
@@ -65,7 +71,10 @@ export function typeOf(object: any): mixed {
                 return $$typeofType;
               // Fall through
               default:
-                return $$typeof;
+                // Normalize legacy elements to `Element` so that callers can
+                // compare against the exported constant regardless of which
+                // version of React created the element.
+                return REACT_ELEMENT_TYPE;
             }
         }
       case REACT_PORTAL_TYPE:
@@ -140,7 +149,8 @@ export function isElement(object: any): boolean {
   return (
     typeof object === 'object' &&
     object !== null &&
-    object.$$typeof === REACT_ELEMENT_TYPE
+    (object.$$typeof === REACT_ELEMENT_TYPE ||
+      object.$$typeof === REACT_LEGACY_ELEMENT_TYPE)
   );
 }
 export function isForwardRef(object: any): boolean {

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -116,6 +116,42 @@ describe('ReactIs', () => {
     expect(ReactIs.isElement(<React.Suspense />)).toBe(true);
   });
 
+  it('should identify elements created by React 17 and 18', () => {
+    // React 19 renamed the element symbol, but tooling is frequently used
+    // against elements created by an older copy of React.
+    const createLegacyElement = type => ({
+      $$typeof: Symbol.for('react.element'),
+      type,
+      key: null,
+      ref: null,
+      props: {},
+      _owner: null,
+    });
+
+    expect(ReactIs.isElement(createLegacyElement('div'))).toBe(true);
+    expect(ReactIs.typeOf(createLegacyElement('div'))).toBe(ReactIs.Element);
+
+    // Types whose symbols are unchanged across versions still resolve.
+    expect(ReactIs.isFragment(createLegacyElement(React.Fragment))).toBe(true);
+    expect(ReactIs.isStrictMode(createLegacyElement(React.StrictMode))).toBe(
+      true,
+    );
+    expect(ReactIs.isSuspense(createLegacyElement(React.Suspense))).toBe(true);
+    expect(ReactIs.isProfiler(createLegacyElement(React.Profiler))).toBe(true);
+    expect(
+      ReactIs.isForwardRef(createLegacyElement(React.forwardRef(() => null))),
+    ).toBe(true);
+    expect(ReactIs.isMemo(createLegacyElement(React.memo(() => null)))).toBe(
+      true,
+    );
+    expect(ReactIs.isLazy(createLegacyElement(React.lazy(() => null)))).toBe(
+      true,
+    );
+
+    // An element is still not a valid element *type*.
+    expect(ReactIs.isValidElementType(createLegacyElement('div'))).toBe(false);
+  });
+
   it('should identify ref forwarding component', () => {
     const RefForwardingComponent = React.forwardRef((props, ref) => null);
     expect(ReactIs.isValidElementType(RefForwardingComponent)).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #36409.

React 19 renamed the element brand from `Symbol.for('react.element')` to `Symbol.for('react.transitional.element')`, but `react-is` only checks the new symbol. Any tool that upgrades to `react-is@19` therefore stops recognizing elements produced by consumers still on React 17/18:

```js
isElement(react19Element); // true
isElement(react18Element); // false  <- expected true
```

This surfaced in [jestjs/jest#15402](https://github.com/jestjs/jest/issues/15402): `pretty-format`'s `ReactElement` plugin silently falls back to printing elements as plain objects, and the workaround in [jestjs/jest#16123](https://github.com/jestjs/jest/pull/16123) is to depend on *both* `react-is@18` and `react-is@19`.

`react-is` is a brand-checking utility — it inspects values rather than rendering them, so it should be able to identify an element regardless of which copy of React created it. React core already recognizes the legacy symbol where it needs to (`ReactChildFiber`, `ReactFlightServer`, `react-devtools-shared`); notably `react-devtools-shared/src/utils.js` carries a hand-maintained fork of this very function named `typeOfWithLegacyElementSymbol` for exactly this reason.

## Changes

- `typeOf` and `isElement` accept `REACT_LEGACY_ELEMENT_TYPE` in addition to `REACT_ELEMENT_TYPE`.
- `typeOf` normalizes the fallthrough case to `REACT_ELEMENT_TYPE`, so `typeOf(legacyElement) === ReactIs.Element` holds and callers can compare against the exported constant regardless of the element's origin. For React 19 elements this is a no-op — `$$typeof` already *was* `REACT_ELEMENT_TYPE` on that path.

Types whose symbols are unchanged across versions (`react.fragment`, `react.suspense`, `react.memo`, `react.forward_ref`, `react.lazy`, `react.profiler`, `react.strict_mode`, `react.portal`) resolve correctly for legacy elements as a result, so `isFragment`, `isMemo`, `isForwardRef`, etc. work too.

This is deliberately scoped to brand checking. Rendering an element from another React copy is still unsupported and still throws in the reconciler.

### Not covered

React 18 context providers used `Symbol.for('react.provider')`, which React 19 removed entirely (`react.context` is now the provider). `isContextProvider` therefore still returns `false` for a React 18 `<Ctx.Provider>` element — the same as today. Resurrecting that symbol felt like a separate decision, so I left it out; happy to add it if you'd prefer.

## How did you test this change?

Added `should identify elements created by React 17 and 18` to `packages/react-is/src/__tests__/ReactIs-test.js`, constructing a React 17/18-shaped element object. The test fails on `main` and passes with this change.

```
yarn test packages/react-is   # 15 passed
yarn lint                     # Lint passed
yarn prettier-check           # clean
flow check                    # No errors!
```
