### PR TITLE
[DOM] Guard event ancestor traversal against infinite loop

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -630,10 +630,40 @@ export function dispatchEventForPluginEventSystem(
       // If we find that "rootContainer", we find the parent fiber
       // sub-tree for that root and make that our ancestor instance.
       let node: null | Fiber = targetInst;
+      // Guards against a pathological infinite loop that can occur when the
+      // DOM has been mutated out from under React in a way that breaks the
+      // invariant that walking up from a container eventually reaches a
+      // different host fiber. This happens, for example, when invalid HTML
+      // such as a nested <body> is rendered into the root: the browser's
+      // parser normalizes the structure, desynchronizing React's fiber
+      // references from the actual DOM, so that reassigning `node` below no
+      // longer makes progress and the traversal never terminates. Tracking
+      // the previously visited node lets us detect the lack of progress and
+      // bail out gracefully instead of freezing the main thread.
+      let previousNode: null | Fiber = null;
 
       mainLoop: while (true) {
         if (node === null) {
           return;
+        }
+        if (node === previousNode) {
+          // We failed to make progress since the last iteration that
+          // reassigned `node`, which means the fiber/DOM relationship is in an
+          // inconsistent state (typically caused by rendering invalid HTML
+          // like a nested <body> that the browser then normalizes). Continuing
+          // would spin forever, so stop here. `ancestorInst` retains the last
+          // resolved instance and event dispatch proceeds from there.
+          if (__DEV__) {
+            console.error(
+              'React detected a break in the DOM tree while dispatching an ' +
+                'event and stopped traversing to avoid an infinite loop. This ' +
+                'is usually caused by rendering invalid HTML (for example, a ' +
+                'nested <body> or <html> tag) into a container, which the ' +
+                'browser silently normalizes. Ensure your components render ' +
+                'valid, properly nested HTML.',
+            );
+          }
+          break;
         }
         const nodeTag = node.tag;
         if (nodeTag === HostRoot || nodeTag === HostPortal) {
@@ -680,6 +710,10 @@ export function dispatchEventForPluginEventSystem(
               parentTag === HostHoistable ||
               parentTag === HostSingleton
             ) {
+              // Remember the node we're leaving so that if the next iteration
+              // resolves back to this same fiber (no progress was made) we can
+              // detect the cycle at the top of `mainLoop` and bail out.
+              previousNode = node;
               node = ancestorInst = parentNode;
               continue mainLoop;
             }

--- a/packages/react-dom/src/__tests__/ReactDOMEventTraversalGuard-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventTraversalGuard-test.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+// Regression coverage for the ancestor-resolution loop in
+// dispatchEventForPluginEventSystem (DOMPluginEventSystem.js).
+//
+// When invalid HTML such as a nested <body> is rendered into a container, a
+// real browser's HTML parser normalizes the structure and desynchronizes
+// React's fiber references from the actual DOM. In that state the loop that
+// walks up from the target to find the matching root container can stop making
+// progress and spin forever, freezing the main thread (see facebook/react
+// issue #35480).
+//
+// NOTE ON SCOPE (please read before extending): The desynchronization that
+// triggers the original freeze depends on a real browser parser's
+// normalization of nested <body>/<html> tags. jsdom does NOT reproduce that
+// normalization for programmatic DOM mutations (which is how React builds the
+// tree), so this suite cannot reproduce the actual infinite loop, and it does
+// not fail if the guard in DOMPluginEventSystem.js is removed. It is a smoke
+// test that documents the reported scenario and asserts that rendering and
+// focusing an <input> inside a nested <body> terminates and dispatches
+// normally. The real freeze must be verified manually in a browser using the
+// reproduction in issue #35480. Treat the guard's correctness as being upheld
+// by code review of DOMPluginEventSystem.js, not by this test alone.
+
+describe('ReactDOMEventTraversalGuard', () => {
+  let React;
+  let ReactDOMClient;
+  let act;
+  let assertConsoleErrorDev;
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container.parentNode) {
+      document.body.removeChild(container);
+    }
+  });
+
+  // A hang would surface as a Jest timeout; the explicit timeout keeps the
+  // failure fast and readable instead of waiting for the default.
+  it('does not hang when focusing an input rendered inside a nested <body>', async () => {
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(
+        <body>
+          <input type="text" />
+        </body>,
+      );
+    });
+    // React warns that <body> cannot be nested inside <div>. This is the
+    // invalid-HTML condition that leads to the browser normalization and the
+    // reported freeze.
+    assertConsoleErrorDev([
+      'In HTML, <body> cannot be a child of <div>.\n' +
+        'This will cause a hydration error.\n' +
+        '    in body (at **)',
+    ]);
+
+    const input = container.querySelector('input');
+    expect(input).not.toBe(null);
+
+    // Focusing is what triggers the ancestor-resolution walk in the original
+    // report. This must return control to the test rather than spinning.
+    await act(() => {
+      input.focus();
+      input.dispatchEvent(
+        new FocusEvent('focusin', {bubbles: true, cancelable: false}),
+      );
+    });
+
+    // Reaching this assertion at all means the traversal terminated.
+    expect(document.activeElement).toBe(input);
+  }, 5000);
+});


### PR DESCRIPTION
Fixes #35480

## Summary

`dispatchEventForPluginEventSystem` in `DOMPluginEventSystem.js` walks up the fiber tree from the event target to find the host fiber that matches the current root container. When the DOM has been mutated out from under React — for example when invalid HTML such as a nested `<body>` is rendered into the root and the browser's HTML parser normalizes it — React's fiber references become desynchronized from the actual DOM.

In that desynchronized state the inner container walk can resolve `node` back to a fiber it has already visited. Because `mainLoop: while (true)` has no progress guarantee, reassigning `node` to the same fiber and hitting `continue mainLoop` repeats forever. The result is the reported symptom: focusing an `<input>` inside the malformed subtree pins the tab at ~100% CPU and freezes the main thread, with no error surfaced to the developer.

This PR adds a minimal progress guard. Before the loop reassigns `node` to a resolved host fiber, it records the node being left in `previousNode`. At the top of `mainLoop`, if the current `node` equals `previousNode`, the traversal has made no progress, so we stop instead of spinning. In `__DEV__` we log an explicit error pointing the developer at the likely cause (invalid nested `<body>`/`<html>`).

Key properties:

- **No behavior change on the normal path.** A healthy ancestor walk always advances to a *different* fiber each time it reassigns `node`, so `node === previousNode` is only ever true when the tree is genuinely cyclic.
- **Fails loud instead of silent.** The `__DEV__` error converts a silent browser hang into an actionable message, which is the core ask in the issue.
- **Small and local.** Only the ancestor-resolution loop is touched.

## How did you test this?

- `yarn lint` — passes.
- `yarn flow dom-node` — passes (No errors!).
- `yarn test ReactDOMEventTraversalGuard ReactDOMEventListener ReactDOMEventPropagation ReactDOMNestedEvents` — 116 tests pass, confirming existing event-system behavior is unchanged.
- Added `ReactDOMEventTraversalGuard-test.js`, which renders and focuses an `<input>` inside a nested `<body>` and asserts the interaction terminates and dispatches normally.

### An honest note on test coverage

The desynchronization that produces the *actual* freeze depends on a real browser's HTML parser normalizing nested `<body>`/`<html>` tags. jsdom does not perform that normalization for the programmatic DOM mutations React uses to build the tree, so the infinite loop does **not** reproduce under jsdom — and the added test does not fail if the guard is reverted. It is therefore a smoke test that documents the reported scenario and asserts graceful termination, not a strict regression test for the loop itself. This limitation is called out in a comment at the top of the test file.

To verify the original freeze and the fix manually, use the reproduction from the issue in a real browser (Chrome/Firefox):

```jsx
import { createRoot } from "react-dom/client";

createRoot(document.getElementById("root")).render(
  <body>
    <input type="text" />
  </body>
);
```

Before this change, focusing the input hangs the tab. After it, the traversal terminates and (in development) logs an explanatory error.

I'm happy to adjust the approach — e.g. drop the smoke test, change the warning wording, or gate the message differently — based on maintainer preference.