### PR TITLE
fix(devtools): preserve unmatched specifiers in formatConsoleArgumentsToSingleString

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -180,6 +180,30 @@ describe('utils', () => {
         formatConsoleArgumentsToSingleString('%o', Object.create(null)),
       ).toEqual('%o [object Object]');
     });
+
+    it('should leave unmatched %s specifiers as literals', () => {
+      expect(
+        formatConsoleArgumentsToSingleString('%s %s', 'value'),
+      ).toEqual('value %s');
+    });
+
+    it('should leave unmatched %d specifiers as literals', () => {
+      expect(formatConsoleArgumentsToSingleString('%d %d', 1)).toEqual(
+        '1 %d',
+      );
+    });
+
+    it('should leave unmatched %f specifiers as literals', () => {
+      expect(formatConsoleArgumentsToSingleString('%f %f', 3.14)).toEqual(
+        '3.14 %f',
+      );
+    });
+
+    it('should leave all specifiers literal when no args provided', () => {
+      expect(formatConsoleArgumentsToSingleString('%s %d %f')).toEqual(
+        '%s %d %f',
+      );
+    });
   });
 
   describe('formatWithStyles', () => {

--- a/packages/react-devtools-shared/src/backend/utils/index.js
+++ b/packages/react-devtools-shared/src/backend/utils/index.js
@@ -197,6 +197,11 @@ export function formatConsoleArgumentsToSingleString(
 
       // $FlowFixMe[incompatible-type]
       formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+        if (!args.length) {
+          // No argument left for this specifier. Keep it as a literal,
+          // matching browser console behavior (not 'undefined' / 'NaN').
+          return match;
+        }
         let arg = args.shift();
         switch (flag) {
           case 's':


### PR DESCRIPTION
## Summary

Fixes #37126

When `formatConsoleArgumentsToSingleString` has more substitution specifiers than arguments, it now leaves the unmatched specifiers as literal text instead of consuming `undefined` from an empty array.

## Before
```js
formatConsoleArgumentsToSingleString('%s %s', 'value') // => 'value undefined'
formatConsoleArgumentsToSingleString('%d %d', 1)       // => '1 NaN'
```

## After
```js
formatConsoleArgumentsToSingleString('%s %s', 'value') // => 'value %s'
formatConsoleArgumentsToSingleString('%d %d', 1)       // => '1 %d'
```

This matches browser console behavior and Node `util.format`, and aligns with the sibling `formatConsoleArguments` helper which was already fixed in #36930.

## Changes

- `packages/react-devtools-shared/src/backend/utils/index.js`: Added early return in the `replace` callback when `args` is empty
- `packages/react-devtools-shared/src/__tests__/utils-test.js`: Added 4 test cases covering unmatched specifiers

## How did you test this change?

Added unit tests:
- `should leave unmatched %s specifiers as literals`
- `should leave unmatched %d specifiers as literals`
- `should leave unmatched %f specifiers as literals`
- `should leave all specifiers literal when no args provided`