### PR TITLE
fix(react-compiler-healthcheck): use current ErrorSeverity enum values

### DIFF
--- a/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
+++ b/compiler/packages/react-compiler-healthcheck/src/checks/reactCompiler.ts
@@ -10,10 +10,12 @@ import {transformFromAstSync} from '@babel/core';
 import * as BabelParser from '@babel/parser';
 import BabelPluginReactCompiler, {
   ErrorSeverity,
-  type CompilerErrorDetailOptions,
   type PluginOptions,
 } from 'babel-plugin-react-compiler/src';
-import {LoggerEvent as RawLoggerEvent} from 'babel-plugin-react-compiler/src/Entrypoint';
+import {
+  type LoggerEvent as RawLoggerEvent,
+  type CompileErrorDetail,
+} from 'babel-plugin-react-compiler/src/Entrypoint';
 import chalk from 'chalk';
 
 type LoggerEvent = RawLoggerEvent & {filename: string | null};
@@ -53,18 +55,19 @@ const COMPILER_OPTIONS: PluginOptions = {
   logger,
 };
 
-function isActionableDiagnostic(detail: CompilerErrorDetailOptions) {
+function isActionableDiagnostic(detail: CompileErrorDetail) {
   switch (detail.severity) {
-    case ErrorSeverity.InvalidReact:
-    case ErrorSeverity.InvalidJS:
+    case ErrorSeverity.Error:
       return true;
-    case ErrorSeverity.InvalidConfig:
-    case ErrorSeverity.Invariant:
-    case ErrorSeverity.CannotPreserveMemoization:
-    case ErrorSeverity.Todo:
+    case ErrorSeverity.Warning:
+    case ErrorSeverity.Hint:
+    case ErrorSeverity.Off:
       return false;
     default:
-      throw new Error(`Unhandled error severity \`${detail.severity}\``);
+      // Unknown severity — count as non-actionable but don't throw,
+      // since throwing here is swallowed by the caller and silently
+      // loses the diagnostic.
+      return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the `react-compiler-healthcheck` tool which always reports 100% success because `isActionableDiagnostic` switches on removed `ErrorSeverity` member names.

Fixes #37138

## Problem

`isActionableDiagnostic` switches on old pre-1.0 enum members (`InvalidReact`, `InvalidJS`, `InvalidConfig`, `Invariant`, `CannotPreserveMemoization`, `Todo`). The current `ErrorSeverity` enum only has:
- `Error`
- `Warning`
- `Hint`
- `Off`

All six case labels evaluate to `undefined`. A real severity of `"Error"` hits `default:` and throws. The throw is swallowed by `compile()`'s empty `catch {}`, so `ActionableFailures` and `OtherFailures` are always empty → 100% reported.

## Fix

1. Switch on current enum values: `ErrorSeverity.Error` (actionable), `Warning`/`Hint`/`Off` (non-actionable)
2. Replace deprecated `CompilerErrorDetailOptions` import with `CompileErrorDetail` (which has the `severity` field)
3. Make `default` non-fatal — returns `false` instead of throwing

## How did you test this change?

- Verified that after this fix, a codebase with known bail-outs correctly reports failures (e.g., "24 out of 30 components" instead of "30 out of 30")
- Verified `ErrorSeverity.Error` maps to actionable and other severities map to non-actionable