### PR TITLE
fix[compiler]: recognize aliased React imports

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Environment.ts
@@ -908,8 +908,10 @@ export class Environment {
       case 'ImportNamespace': {
         if (this.#isKnownReactModule(binding.module)) {
           // only resolve imports to modules we know about
+          const globalName =
+            binding.module.toLowerCase() === 'react' ? 'React' : binding.name;
           return (
-            this.#globals.get(binding.name) ??
+            this.#globals.get(globalName) ??
             (isHookName(binding.name) ? this.#getCustomHookType() : null)
           );
         } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-aliased-react-import.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-aliased-react-import.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+import ReactAlias from 'react';
+
+const Context = ReactAlias.createContext(null);
+
+function Component() {
+  const value = ReactAlias.use(Context);
+  return <div>{value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import ReactAlias from "react";
+
+const Context = ReactAlias.createContext(null);
+
+function Component() {
+  const $ = _c(2);
+  const value = ReactAlias.use(Context);
+  let t0;
+  if ($[0] !== value) {
+    t0 = <div>{value}</div>;
+    $[0] = value;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div></div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-aliased-react-import.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-aliased-react-import.js
@@ -1,0 +1,13 @@
+import ReactAlias from 'react';
+
+const Context = ReactAlias.createContext(null);
+
+function Component() {
+  const value = ReactAlias.use(Context);
+  return <div>{value}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};


### PR DESCRIPTION
## Summary

Default and namespace imports from `react` were typed using their local binding name. An alias such as `ReactAlias` therefore missed the canonical `React` object shape, causing `ReactAlias.use()` to be treated as an ordinary method and moved inside a conditional memo-cache block.

Resolve imports from `react` through the canonical `React` global type regardless of their local alias. This preserves `use()` semantics for genuine React imports while leaving unrelated `someObj.use()` calls unchanged.

Fixes #36137.

## How did you test this change?

- Added `use-operator-aliased-react-import` fixture; the focused snapshot run reports `1 Tests, 1 Passed, 0 Failed` (the local snapshot CLI subsequently encounters a duplicate `Worker.end()` shutdown race).
- `yarn snap:build`
- `yarn workspace snap run snap compile packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/use-operator-aliased-react-import.js`
- `yarn build` in `babel-plugin-react-compiler`
- `yarn eslint src/HIR/Environment.ts`
- `git diff --check`