### PR TITLE
docs: fix stale react-server and eslint-plugin-react-compiler READMEs

### DIFF
--- a/compiler/packages/eslint-plugin-react-compiler/README.md
+++ b/compiler/packages/eslint-plugin-react-compiler/README.md
@@ -2,62 +2,7 @@
 
 ESLint plugin surfacing problematic React code found by the React compiler.
 
-## Installation
-
-You'll first need to install [ESLint](https://eslint.org/):
-
-```sh
-npm i eslint --save-dev
-```
-
-Next, install `eslint-plugin-react-compiler`:
-
-```sh
-npm install eslint-plugin-react-compiler --save-dev
-```
-
-## Usage
-
-### Flat config
-
-Edit your eslint 8+ config (for example `eslint.config.mjs`) with the recommended configuration:
-
-```diff
-+ import reactCompiler from "eslint-plugin-react-compiler"
-import react from "eslint-plugin-react"
-
-export default [
-    // Your existing config
-    { ...pluginReact.configs.flat.recommended, settings: { react: { version: "detect" } } },
-+   reactCompiler.configs.recommended    
-]
-```
-
-### Legacy config (`.eslintrc`)
-
-Add `react-compiler` to the plugins section of your configuration file. You can omit the `eslint-plugin-` prefix:
-
-```json
-{
-    "plugins": [
-        "react-compiler"
-    ]
-}
-```
-
-
-Then configure the rules you want to use under the rules section.
-
-```json
-{
-    "rules": {
-        "react-compiler/react-compiler": "error"
-    }
-}
-```
-
-## Rules
-
-<!-- begin auto-generated rules list -->
-TODO: Run eslint-doc-generator to generate the rules list.
-<!-- end auto-generated rules list -->
+This package is used internally by the React Compiler workspace and is no
+longer published to npm. External users should use
+[`eslint-plugin-react-hooks`](../../../packages/eslint-plugin-react-hooks) for
+React Compiler lint rules.

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -44,8 +44,10 @@ function render(
     options ? options.onError : undefined,
     options ? options.identifierPrefix : undefined,
     options ? options.temporaryReferences : undefined,
+    options ? options.startTime : undefined,
     __DEV__ && options ? options.environmentName : undefined,
     __DEV__ && options ? options.filterStackFrame : undefined,
+    false,
   );
   const stream = new ReadableStream(
     {
@@ -214,8 +216,10 @@ function prerender(
       options ? options.onError : undefined,
       options ? options.identifierPrefix : undefined,
       options ? options.temporaryReferences : undefined,
+      options ? options.startTime : undefined,
       __DEV__ && options ? options.environmentName : undefined,
       __DEV__ && options ? options.filterStackFrame : undefined,
+      false,
     );
     startWork(request);
   });


### PR DESCRIPTION
## Summary

Fixes #36549. Three documentation inconsistencies reported in that issue:

- `packages/react-server/README.md` examples for `createRequest`/`createPrerenderRequest` were missing the `debugStartTime` (`options.startTime`) and `keepDebugAlive` arguments that exist in the current signatures (`ReactFlightServer.js`) and are used across every `react-server-dom-*` implementation (e.g. `ReactFlightDOMServerNode.js`).
- `compiler/packages/eslint-plugin-react-compiler/README.md` still told users to `npm install eslint-plugin-react-compiler`, but this package was removed from `PUBLISHABLE_PACKAGES` and is no longer published.
- The same README also still documented the old single `react-compiler/react-compiler` rule, which no longer exists — the rules now live in `eslint-plugin-react-hooks`.

## Changes

- Added the missing arguments to both `createRequest` and `createPrerenderRequest` example calls in `packages/react-server/README.md`.
- Replaced the outdated installation/usage/rules section in `compiler/packages/eslint-plugin-react-compiler/README.md` with a short note pointing to `eslint-plugin-react-hooks`.

## Test plan

- Docs-only change, no code behavior affected.
- Verified both READMEs against current `main` (function signatures in `ReactFlightServer.js`, and `PUBLISHABLE_PACKAGES` in `compiler/scripts/release/shared/packages.js`).