### PR TITLE
React Compiler: avoid deep ast clone and quadratic-time codegen

### DIFF
--- a/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
@@ -1472,32 +1472,36 @@ fn recursively_propagate_non_null(
     }
 
     // Compute intersection of 'done' neighbors only (filter out 'active' = cycle nodes)
-    let done_neighbor_sets: Vec<BTreeSet<usize>> = neighbors
-        .iter()
-        .filter(|n| traversal_state.get(n) == Some(&TraversalState::Done))
-        .filter_map(|n| working.get(n).cloned())
-        .collect();
+    let neighbor_intersection = {
+        let done_neighbor_sets: Vec<&BTreeSet<usize>> = neighbors
+            .iter()
+            .filter(|n| traversal_state.get(n) == Some(&TraversalState::Done))
+            .filter_map(|n| working.get(n))
+            .collect();
 
-    let neighbor_intersection = if done_neighbor_sets.is_empty() {
-        BTreeSet::new()
-    } else {
-        let mut iter = done_neighbor_sets.into_iter();
-        let first = iter.next().unwrap();
-        iter.fold(first, |acc, s| acc.intersection(&s).copied().collect())
+        match done_neighbor_sets.split_first() {
+            None => BTreeSet::new(),
+            Some((first, rest)) => rest.iter().fold((*first).clone(), |acc, s| {
+                acc.intersection(s).copied().collect()
+            }),
+        }
     };
 
-    let prev_objects = working.get(&node_id).cloned().unwrap_or_default();
+    // Temporarily remove the previous set out of the map so it can be safely
+    // borrowed and compared without a heavy deep clone.
+    let prev_objects = working.remove(&node_id).unwrap_or_default();
     let mut merged: BTreeSet<usize> = prev_objects
         .union(&neighbor_intersection)
         .copied()
         .collect();
     reduce_maybe_optional_chains(&mut merged, registry);
 
-    working.insert(node_id, merged.clone());
-    traversal_state.insert(node_id, TraversalState::Done);
-
     // Compare with previous value — can't just check size due to reduce_maybe_optional_chains
     changed |= prev_objects != merged;
+
+    working.insert(node_id, merged);
+    traversal_state.insert(node_id, TraversalState::Done);
+
     changed
 }
 

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -555,12 +555,119 @@ pub fn codegen_function(
 // Context
 // =============================================================================
 
-type Temporaries = FxHashMap<DeclarationId, Option<ExpressionOrJsxText>>;
-
 #[derive(Clone)]
 enum ExpressionOrJsxText {
     Expression(Expression),
     JsxText(JSXText),
+}
+
+/// The entry a write to [`Temporaries`] displaced, kept so the write can be
+/// undone.
+///
+/// The expression is boxed because `ExpressionOrJsxText` is ~900 bytes (it
+/// inlines an `Expression`). Unboxed, the undo log would be a `Vec` of
+/// ~900-byte slots that are almost always `Absent`, costing more peak heap than
+/// the copy it replaces on shallow functions. Boxed, an entry is 16 bytes and
+/// only allocates when a write actually displaces a buffered expression.
+enum Displaced {
+    /// The key was not present before the write.
+    Absent,
+    /// The key was present as a declared temporary with no buffered value.
+    Empty,
+    /// The key was present with this buffered value.
+    Value(Box<ExpressionOrJsxText>),
+}
+
+/// A position in a [`Temporaries`] undo log, produced by [`Temporaries::mark`].
+#[derive(Clone, Copy)]
+struct TempMark(usize);
+
+/// Expressions buffered for temporaries that have not been emitted yet, plus an
+/// undo log allowing a nested block or scope to be codegen'd and its additions
+/// discarded.
+///
+/// The TypeScript implementation snapshots this with `new Map(cx.temp)`, which
+/// is a *shallow* copy: it duplicates references, not the AST nodes behind them.
+/// The equivalent Rust `.clone()` deep-copies every buffered `Expression` tree,
+/// which made codegen quadratic in component size and dominated both allocation
+/// volume and peak heap.
+///
+/// `TS CodegenReactiveFunction.codegenBlock` asserts that pre-existing entries
+/// are never mutated ("Expected temporary value to be unchanged"), so a
+/// snapshot's only job is to discard entries added by the nested block. Because
+/// entries are only ever inserted (never removed, nor mutated in place),
+/// rewinding an insert log restores the map exactly, with no copying.
+///
+/// All writes go through [`Temporaries::set`] so the log cannot drift out of
+/// sync with the map.
+#[derive(Default)]
+struct Temporaries {
+    values: FxHashMap<DeclarationId, Option<ExpressionOrJsxText>>,
+    journal: Vec<(DeclarationId, Displaced)>,
+}
+
+impl Temporaries {
+    fn get(&self, declaration_id: DeclarationId) -> Option<&Option<ExpressionOrJsxText>> {
+        self.values.get(&declaration_id)
+    }
+
+    fn contains_key(&self, declaration_id: DeclarationId) -> bool {
+        self.values.contains_key(&declaration_id)
+    }
+
+    /// Buffers `value` for `declaration_id`, journaling the displaced entry.
+    /// `HashMap::insert` returns that entry by move, so journaling costs no
+    /// clones.
+    fn set(&mut self, declaration_id: DeclarationId, value: Option<ExpressionOrJsxText>) {
+        let displaced = match self.values.insert(declaration_id, value) {
+            None => Displaced::Absent,
+            Some(None) => Displaced::Empty,
+            Some(Some(previous)) => Displaced::Value(Box::new(previous)),
+        };
+        self.journal.push((declaration_id, displaced));
+    }
+
+    /// Marks the current state, for a later [`Temporaries::rewind`].
+    fn mark(&self) -> TempMark {
+        TempMark(self.journal.len())
+    }
+
+    /// Restores the state captured by `mark`, discarding every write since.
+    fn rewind(&mut self, mark: TempMark) {
+        while self.journal.len() > mark.0 {
+            let (declaration_id, displaced) = self.journal.pop().unwrap();
+            match displaced {
+                Displaced::Absent => {
+                    self.values.remove(&declaration_id);
+                }
+                Displaced::Empty => {
+                    self.values.insert(declaration_id, None);
+                }
+                Displaced::Value(previous) => {
+                    self.values.insert(declaration_id, Some(*previous));
+                }
+            }
+        }
+    }
+
+    /// Hands the buffered expressions to a nested function's context, which may
+    /// read them but must not leak its own additions back out.
+    ///
+    /// The borrower gets a fresh log, so [`Temporaries::reclaim`] can undo
+    /// exactly the borrower's writes rather than the lender's whole history.
+    fn lend(&mut self) -> Temporaries {
+        Temporaries {
+            values: std::mem::take(&mut self.values),
+            journal: Vec::new(),
+        }
+    }
+
+    /// Takes back expressions handed out by [`Temporaries::lend`], discarding
+    /// every write the borrower made.
+    fn reclaim(&mut self, mut lent: Temporaries) {
+        lent.rewind(TempMark(0));
+        self.values = lent.values;
+    }
 }
 
 struct Context<'env> {
@@ -594,7 +701,7 @@ impl<'env> Context<'env> {
             fn_name,
             next_cache_index: 0,
             declarations: FxHashSet::default(),
-            temp: FxHashMap::default(),
+            temp: Temporaries::default(),
             object_methods: FxHashMap::default(),
             unique_identifiers,
             fbt_operands,
@@ -653,8 +760,8 @@ fn codegen_reactive_function(
             ParamPattern::Place(p) => p,
             ParamPattern::Spread(sp) => &sp.place,
         };
-        let ident = &cx.env.identifiers[place.identifier.0 as usize];
-        cx.temp.insert(ident.declaration_id, None);
+        let declaration_id = cx.env.identifiers[place.identifier.0 as usize].declaration_id;
+        cx.temp.set(declaration_id, None);
         cx.declare(place.identifier);
     }
 
@@ -732,9 +839,9 @@ fn convert_parameter(
 // =============================================================================
 
 fn codegen_block(cx: &mut Context, block: &ReactiveBlock) -> Result<BlockStatement, CompilerError> {
-    let temp_snapshot: Temporaries = cx.temp.clone();
+    let mark = cx.temp.mark();
     let result = codegen_block_no_reset(cx, block)?;
-    cx.temp = temp_snapshot;
+    cx.temp.rewind(mark);
     Ok(result)
 }
 
@@ -758,9 +865,9 @@ fn codegen_block_no_reset(
                 scope,
                 instructions,
             }) => {
-                let temp_snapshot = cx.temp.clone();
+                let mark = cx.temp.mark();
                 codegen_reactive_scope(cx, &mut statements, *scope, instructions)?;
-                cx.temp = temp_snapshot;
+                cx.temp.rewind(mark);
             }
             ReactiveStatement::Terminal(term_stmt) => {
                 let stmt = codegen_terminal(cx, &term_stmt.terminal)?;
@@ -1258,8 +1365,9 @@ fn codegen_terminal(
         } => {
             let catch_param = match handler_binding.as_ref() {
                 Some(binding) => {
-                    let ident = &cx.env.identifiers[binding.identifier.0 as usize];
-                    cx.temp.insert(ident.declaration_id, None);
+                    let declaration_id =
+                        cx.env.identifiers[binding.identifier.0 as usize].declaration_id;
+                    cx.temp.set(declaration_id, None);
                     Some(PatternLike::Identifier(convert_identifier(
                         binding.identifier,
                         cx.env,
@@ -1724,8 +1832,10 @@ fn codegen_store_or_declare(
             // Register temporaries for unnamed pattern operands
             for place in react_compiler_hir::visitors::each_pattern_operand(&lvalue.pattern) {
                 let ident = &cx.env.identifiers[place.identifier.0 as usize];
-                if kind != InstructionKind::Reassign && ident.name.is_none() {
-                    cx.temp.insert(ident.declaration_id, None);
+                let declaration_id = ident.declaration_id;
+                let is_unnamed = ident.name.is_none();
+                if kind != InstructionKind::Reassign && is_unnamed {
+                    cx.temp.set(declaration_id, None);
                 }
             }
             let rhs = codegen_place_to_expression(cx, val)?;
@@ -1838,11 +1948,10 @@ fn emit_store(
                     ReactiveValue::Instruction(InstructionValue::StoreContext { .. })
                 );
                 if !is_store_context {
-                    let ident = &cx.env.identifiers[lvalue_place.identifier.0 as usize];
-                    cx.temp.insert(
-                        ident.declaration_id,
-                        Some(ExpressionOrJsxText::Expression(expr)),
-                    );
+                    let declaration_id =
+                        cx.env.identifiers[lvalue_place.identifier.0 as usize].declaration_id;
+                    cx.temp
+                        .set(declaration_id, Some(ExpressionOrJsxText::Expression(expr)));
                     return Ok(None);
                 } else {
                     let stmt =
@@ -1886,9 +1995,10 @@ fn codegen_instruction(
         }));
     };
     let ident = &cx.env.identifiers[lvalue.identifier.0 as usize];
+    let declaration_id = ident.declaration_id;
     if ident.name.is_none() {
         // temporary
-        cx.temp.insert(ident.declaration_id, Some(value));
+        cx.temp.set(declaration_id, Some(value));
         return Ok(Statement::EmptyStatement(EmptyStatement {
             base: BaseNode::typed("EmptyStatement"),
         }));
@@ -2663,9 +2773,16 @@ fn codegen_function_expression(
         cx.unique_identifiers.clone(),
         cx.fbt_operands.clone(),
     );
-    inner_cx.temp = cx.temp.clone();
+    // The inner function reads the enclosing temporaries but must not leak its
+    // own back out. Lend the map to `inner_cx` and rewind its writes on the way
+    // out, rather than deep-cloning every buffered expression tree. The map is
+    // restored on the error path too, so `cx` is never left empty.
+    inner_cx.temp = cx.temp.lend();
 
-    let fn_result = codegen_reactive_function(&mut inner_cx, &reactive_fn_mut)?;
+    let fn_result = codegen_reactive_function(&mut inner_cx, &reactive_fn_mut);
+
+    cx.temp.reclaim(std::mem::take(&mut inner_cx.temp));
+    let fn_result = fn_result?;
 
     let value = match expr_type {
         FunctionExpressionType::ArrowFunctionExpression => {
@@ -2798,9 +2915,12 @@ fn codegen_object_expression(
                             cx.unique_identifiers.clone(),
                             cx.fbt_operands.clone(),
                         );
-                        inner_cx.temp = cx.temp.clone();
+                        inner_cx.temp = cx.temp.lend();
 
-                        let fn_result = codegen_reactive_function(&mut inner_cx, &reactive_fn_mut)?;
+                        let fn_result = codegen_reactive_function(&mut inner_cx, &reactive_fn_mut);
+
+                        cx.temp.reclaim(std::mem::take(&mut inner_cx.temp));
+                        let fn_result = fn_result?;
 
                         ast_properties.push(ast_expr::ObjectExpressionProperty::ObjectMethod(
                             ast_expr::ObjectMethod {
@@ -3309,14 +3429,14 @@ fn codegen_place_to_expression(
 
 fn codegen_place(cx: &mut Context, place: &Place) -> Result<ExpressionOrJsxText, CompilerError> {
     let ident = &cx.env.identifiers[place.identifier.0 as usize];
-    if let Some(tmp) = cx.temp.get(&ident.declaration_id) {
+    if let Some(tmp) = cx.temp.get(ident.declaration_id) {
         if let Some(val) = tmp {
             return Ok(val.clone());
         }
         // tmp is None — means declared but no temp value, fall through
     }
     // Check if it's an unnamed identifier without a temp
-    if ident.name.is_none() && !cx.temp.contains_key(&ident.declaration_id) {
+    if ident.name.is_none() && !cx.temp.contains_key(ident.declaration_id) {
         return Err(invariant_err(
             &format!(
                 "[Codegen] No value found for temporary, identifier id={}",

--- a/compiler/crates/react_compiler_validation/src/validate_preserved_manual_memoization.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_preserved_manual_memoization.rs
@@ -142,18 +142,19 @@ fn visit_scope(scope_block: &ReactiveScopeBlock, state: &mut VisitorState) {
     if let Some(ref memo_state) = state.manual_memo_state {
         if let Some(ref deps_from_source) = memo_state.deps_from_source {
             let scope = &state.env.scopes[scope_block.scope.0 as usize];
+            // `dependencies` still has to be cloned because `env` is passed
+            // mutably below. `temporaries`, `decls` and `deps_from_source` do
+            // not: they live in fields disjoint from `env`, so they can simply
+            // be borrowed.
             let deps = scope.dependencies.clone();
             let memo_loc = memo_state.loc;
-            let decls = memo_state.decls.clone();
-            let deps_from_source = deps_from_source.clone();
-            let temporaries = state.temporaries.clone();
             for dep in &deps {
                 validate_inferred_dep(
                     dep.identifier,
                     &dep.path,
-                    &temporaries,
-                    &decls,
-                    &deps_from_source,
+                    &state.temporaries,
+                    &memo_state.decls,
+                    deps_from_source,
                     state.env,
                     memo_loc,
                 );


### PR DESCRIPTION
tl;dr this reduces peak memory allocation by 5-15%, and reduces codegen time by 30-70% depending on payload. On heavy components with deep ASTs the impact is more exaggerated.

## Summary

Codegen of temp vars records the expressions they replaced, so that they can be unwound. In the TS version this uses a `Map` and stores pointers to AST nodes - relatively cheap. For borrow-checking reasons, the Rust version clones the AST. This results in recurring deep clones, making codegen accidentally quadratic and using significant amounts of memory.

This introduces a convenience data structure for emitting temp vars in an unwindable manner, without heavy AST allocation.

It also avoids a separate AST deep clone when propagating null values.

## How did you test this change?

All fixtures pass with byte-identical outputs.

Ran this against real codebases and pathological benchmark cases, confirming byte-identical output as well.
