### PR TITLE
React Compiler: Avoid unnecessary clone in effect inference

### DIFF
--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -185,7 +185,7 @@ pub fn infer_mutation_aliasing_effects(
             };
 
             states_by_block.insert(block_id, incoming_state.clone());
-            let mut state = incoming_state.clone();
+            let mut state = incoming_state;
 
             infer_block(&mut context, &mut state, block_id, func, env)?;
 


### PR DESCRIPTION
## Summary

In the mutation / aliasing inference, the state is used twice, and both get cloned. Only one clone is necessary, the second can be safely moved.

This has minimal impact on peak memory usage, but it does reduce wall time by *10%* on real Next.js benchmark apps.

## How did you test this change?

Ran against benchmark apps to confirm identical byte output.
Ran against the 1800+ Rust Compiler test fixtures.