### PR TITLE
React Compiler: enable cargo clippy

### DIFF
--- a/.github/workflows/compiler_rust.yml
+++ b/.github/workflows/compiler_rust.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.node_modules.outputs.cache-hit != 'true'
 
       # --- Build & test ---
-      - run: cargo check
+      - run: cargo clippy
       - run: cargo build
       - run: bash scripts/test-babel-ast.sh
       - run: bash scripts/test-rust-port.sh

--- a/.github/workflows/compiler_rust.yml
+++ b/.github/workflows/compiler_rust.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.node_modules.outputs.cache-hit != 'true'
 
       # --- Build & test ---
-      - run: cargo clippy
+      - run: cargo clippy -- -Dwarnings
       - run: cargo build
       - run: bash scripts/test-babel-ast.sh
       - run: bash scripts/test-rust-port.sh

--- a/compiler/.claude/settings.json
+++ b/compiler/.claude/settings.json
@@ -8,7 +8,8 @@
       "Bash(yarn prettier-all:*)",
       "Bash(bash compiler/scripts/test-babel-ast.sh:*)",
       "Bash(cargo test:*)",
-      "Bash(cargo check:*)"
+      "Bash(cargo check:*)",
+      "Bash(cargo clippy:*)"
     ],
     "deny": [
       "Skill(extract-errors)",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.0.1-oidc.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.91"
 license = "MIT"
 repository = "https://github.com/facebook/react"
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,15 +58,11 @@ iter_cloned_collect = "allow"
 map_entry = "allow"
 needless_range_loop = "allow"
 only_used_in_recursion = "allow"
-replace_box = "allow"
 result_large_err = "allow"
 unnecessary_mut_passed = "allow"
-unnecessary_sort_by = "allow"
-unnecessary_unwrap = "allow"
 implicit_saturating_sub = "allow"
 useless_format = "allow"
 useless_conversion = "allow"
-manual_contains = "allow"
 
 # Sizes the shipped napi binary (index.node). Measured on arm64 macOS:
 # default release is 11.2MB; fat LTO + one codegen unit + stripping symbols

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-  "crates/*",
-  "packages/babel-plugin-react-compiler-rust/native",
-]
+members = ["crates/*", "packages/babel-plugin-react-compiler-rust/native"]
 resolver = "3"
 
 [workspace.package]
@@ -25,6 +22,52 @@ react_compiler_typeinference = { version = "0.0.1-oidc.0", path = "crates/react_
 react_compiler_utils = { version = "0.0.1-oidc.0", path = "crates/react_compiler_utils" }
 react_compiler_validation = { version = "0.0.1-oidc.0", path = "crates/react_compiler_validation" }
 
+[workspace.lints.clippy]
+collapsible_if = "allow"
+collapsible_match = "allow"
+manual_flatten = "allow"
+redundant_field_names = "allow"
+while_let_loop = "allow"
+needless_borrow = "allow"
+manual_strip = "allow"
+single_match = "allow"
+for_kv_map = "allow"
+if_same_then_else = "allow"
+let_and_return = "allow"
+needless_borrows_for_generic_args = "allow"
+redundant_closure = "allow"
+too_many_arguments = "allow"
+type_complexity = "allow"
+unnecessary_map_or = "allow"
+unwrap_or_default = "allow"
+new_without_default = "allow"
+derivable_impls = "allow"
+ptr_arg = "allow"
+needless_question_mark = "allow"
+needless_return = "allow"
+mem_replace_with_default = "allow"
+manual_range_contains = "allow"
+bind_instead_of_map = "allow"
+neg_multiply = "allow"
+manual_map = "allow"
+match_like_matches_macro = "allow"
+
+clone_on_copy = "allow"
+large_enum_variant = "allow"
+iter_cloned_collect = "allow"
+map_entry = "allow"
+needless_range_loop = "allow"
+only_used_in_recursion = "allow"
+replace_box = "allow"
+result_large_err = "allow"
+unnecessary_mut_passed = "allow"
+unnecessary_sort_by = "allow"
+unnecessary_unwrap = "allow"
+implicit_saturating_sub = "allow"
+useless_format = "allow"
+useless_conversion = "allow"
+manual_contains = "allow"
+
 # Sizes the shipped napi binary (index.node). Measured on arm64 macOS:
 # default release is 11.2MB; fat LTO + one codegen unit + stripping symbols
 # lands at 7.2MB with no runtime cost. Release builds get slower; debug
@@ -33,4 +76,3 @@ react_compiler_validation = { version = "0.0.1-oidc.0", path = "crates/react_com
 lto = "fat"
 codegen-units = 1
 strip = true
-

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -63,6 +63,7 @@ unnecessary_mut_passed = "allow"
 implicit_saturating_sub = "allow"
 useless_format = "allow"
 useless_conversion = "allow"
+manual_pop_if = "allow"
 
 # Sizes the shipped napi binary (index.node). Measured on arm64 macOS:
 # default release is 11.2MB; fat LTO + one codegen unit + stripping symbols

--- a/compiler/crates/react_compiler/Cargo.toml
+++ b/compiler/crates/react_compiler/Cargo.toml
@@ -22,3 +22,6 @@ indexmap = "2"
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler/src/entrypoint/gating.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/gating.rs
@@ -55,7 +55,7 @@ pub fn apply_gating_rewrites(
 ) -> Result<(), CompilerDiagnostic> {
     // Sort rewrites in reverse order by original_index so that insertions
     // at higher indices don't invalidate lower indices.
-    rewrites.sort_by(|a, b| b.original_index.cmp(&a.original_index));
+    rewrites.sort_by_key(|b| std::cmp::Reverse(b.original_index));
 
     for rewrite in rewrites {
         let gating_imported_name = context

--- a/compiler/crates/react_compiler/src/entrypoint/imports.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/imports.rs
@@ -342,7 +342,7 @@ pub fn add_imports_to_program(program: &mut Program, context: &ProgramContext) {
 
     let mut stmts: Vec<Statement> = Vec::new();
     let mut sorted_modules: Vec<_> = context.imports.iter().collect();
-    sorted_modules.sort_by(|(a, _), (b, _)| a.to_lowercase().cmp(&b.to_lowercase()));
+    sorted_modules.sort_by_key(|(a, _)| a.to_lowercase());
 
     for (module_name, imports_map) in sorted_modules {
         let sorted_imports = {

--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -1585,8 +1585,10 @@ fn process_fn(
         }
         Ok(codegen_fn) => {
             // Check opt-out
-            if !context.opts.ignore_use_no_forget && opt_out.is_some() {
-                let opt_out_value = &opt_out.unwrap().value.value;
+            if let Some(opt_out) = opt_out
+                && !context.opts.ignore_use_no_forget
+            {
+                let opt_out_value = &opt_out.value.value;
                 let source_filename = source
                     .fn_ast_loc
                     .as_ref()
@@ -1594,7 +1596,7 @@ fn process_fn(
                 context.log_event(LoggerEvent::CompileSkip {
                     fn_loc: to_logger_loc(source.fn_ast_loc.as_ref(), source_filename),
                     reason: format!("Skipped due to '{}' directive.", opt_out_value),
-                    loc: opt_out.and_then(|d| to_logger_loc(d.base.loc.as_ref(), source_filename)),
+                    loc: to_logger_loc(opt_out.base.loc.as_ref(), source_filename),
                 });
                 // The function is skipped due to opt-out. Do NOT register the memo
                 // cache import here — it will be registered in apply_compiled_functions()
@@ -2907,9 +2909,8 @@ impl MutVisitor for ReplaceWithGatedVisitor<'_> {
                         });
                         return VisitResult::Stop;
                     } else {
-                        export.declaration = Box::new(ExportDefaultDecl::Expression(Box::new(
-                            self.gating_expression.clone(),
-                        )));
+                        *export.declaration =
+                            ExportDefaultDecl::Expression(Box::new(self.gating_expression.clone()));
                         return VisitResult::Stop;
                     }
                 }
@@ -2929,7 +2930,7 @@ impl MutVisitor for ReplaceWithGatedVisitor<'_> {
                             optional: None,
                             decorators: None,
                         });
-                        *decl = Box::new(Declaration::VariableDeclaration(VariableDeclaration {
+                        **decl = Declaration::VariableDeclaration(VariableDeclaration {
                             base: BaseNode::typed("VariableDeclaration"),
                             kind: VariableDeclarationKind::Const,
                             declarations: vec![VariableDeclarator {
@@ -2939,7 +2940,7 @@ impl MutVisitor for ReplaceWithGatedVisitor<'_> {
                                 definite: None,
                             }],
                             declare: None,
-                        }));
+                        });
                         return VisitResult::Stop;
                     }
                 }
@@ -3709,7 +3710,7 @@ impl MutVisitor for ReplaceFnVisitor {
             Expression::ArrowFunctionExpression(f) if f.base.node_id == Some(self.node_id) => {
                 let compiled = self.take();
                 f.params = compiled.params;
-                f.body = Box::new(ArrowFunctionBody::BlockStatement(compiled.body));
+                *f.body = ArrowFunctionBody::BlockStatement(compiled.body);
                 f.generator = compiled.generator;
                 f.is_async = compiled.is_async;
                 f.expression = Some(false);

--- a/compiler/crates/react_compiler/src/entrypoint/validate_source_locations.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/validate_source_locations.rs
@@ -67,13 +67,7 @@ pub fn validate_source_locations(
     for entry in &sorted_entries {
         let generated_node_types = generated.get(&entry.key);
 
-        if generated_node_types.is_none() {
-            // Location is completely missing
-            let mut node_types_str: Vec<&str> = entry.node_types.iter().copied().collect();
-            node_types_str.sort();
-            report_missing_location(env, &entry.loc, &node_types_str.join(", "));
-        } else {
-            let generated_node_types = generated_node_types.unwrap();
+        if let Some(generated_node_types) = generated_node_types {
             // Location exists, check each strict node type
             for &node_type in &entry.node_types {
                 if strict_node_types.contains(node_type)
@@ -92,6 +86,11 @@ pub fn validate_source_locations(
                     }
                 }
             }
+        } else {
+            // Location is completely missing
+            let mut node_types_str: Vec<&str> = entry.node_types.iter().copied().collect();
+            node_types_str.sort();
+            report_missing_location(env, &entry.loc, &node_types_str.join(", "));
         }
     }
 }

--- a/compiler/crates/react_compiler_ast/Cargo.toml
+++ b/compiler/crates/react_compiler_ast/Cargo.toml
@@ -18,3 +18,6 @@ rustc-hash = "2"
 [dev-dependencies]
 walkdir = "2"
 similar = "3"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_diagnostics/Cargo.toml
+++ b/compiler/crates/react_compiler_diagnostics/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 [dependencies]
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_hir/Cargo.toml
+++ b/compiler/crates/react_compiler_hir/Cargo.toml
@@ -13,3 +13,6 @@ indexmap = { version = "2", features = ["serde"] }
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_inference/Cargo.toml
+++ b/compiler/crates/react_compiler_inference/Cargo.toml
@@ -16,3 +16,6 @@ react_compiler_ssa.workspace = true
 react_compiler_utils.workspace = true
 indexmap = "2"
 rustc-hash = "2"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_inference/src/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/align_reactive_scopes_to_block_scopes_hir.rs
@@ -260,6 +260,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                     env.new_mutable_range(terminal_eval_order, next_id)
                 } else {
                     // Value -> value transition (ternary/logical/optional): reuse range
+                    #[allow(clippy::unnecessary_unwrap)]
                     node.as_ref().unwrap().value_range.clone()
                 };
 

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -2471,7 +2471,7 @@ fn compute_signature_for_instruction(
                 }
             }
         }
-        InstructionValue::JsxFragment { children: _, .. } => {
+        InstructionValue::JsxFragment { .. } => {
             effects.push(AliasingEffect::Create {
                 into: lvalue.clone(),
                 value: ValueKind::Frozen,
@@ -2647,7 +2647,6 @@ fn compute_signature_for_instruction(
         InstructionValue::StoreGlobal {
             name,
             value: sg_value,
-            loc: _,
             ..
         } => {
             let variable = format!("`{}`", name);

--- a/compiler/crates/react_compiler_inference/src/merge_overlapping_reactive_scopes_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/merge_overlapping_reactive_scopes_hir.rs
@@ -159,13 +159,13 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
         .into_iter()
         .map(|(id, scopes)| ScopeStartEntry { id, scopes })
         .collect();
-    scope_starts.sort_by(|a, b| b.id.cmp(&a.id));
+    scope_starts.sort_by_key(|b| std::cmp::Reverse(b.id));
 
     let mut scope_ends: Vec<ScopeEndEntry> = scope_ends_map
         .into_iter()
         .map(|(id, scopes)| ScopeEndEntry { id, scopes })
         .collect();
-    scope_ends.sort_by(|a, b| b.id.cmp(&a.id));
+    scope_ends.sort_by_key(|b| std::cmp::Reverse(b.id));
 
     ScopeInfo {
         scope_starts,

--- a/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
@@ -1294,20 +1294,23 @@ fn collect_non_nulls_in_blocks(
                 if ctx.assumed_invoked_fns.contains(&lowered_func.func) {
                     let inner_func = &env.functions[lowered_func.func.0 as usize];
                     // Build nested fn immutable context
-                    let nested_fn_immutable_context: FxHashSet<IdentifierId> =
-                        if ctx.nested_fn_immutable_context.is_some() {
-                            // Already in a nested fn context, use existing
-                            ctx.nested_fn_immutable_context.unwrap().clone()
-                        } else {
-                            inner_func
-                                .context
-                                .iter()
-                                .filter(|place| {
-                                    is_immutable_at_instr(place.identifier, instr.id, env, ctx)
-                                })
-                                .map(|place| place.identifier)
-                                .collect()
-                        };
+                    let nested_fn_immutable_context: FxHashSet<IdentifierId> = if let Some(
+                        nested_fn_immutable_context,
+                    ) =
+                        ctx.nested_fn_immutable_context
+                    {
+                        // Already in a nested fn context, use existing
+                        nested_fn_immutable_context.clone()
+                    } else {
+                        inner_func
+                            .context
+                            .iter()
+                            .filter(|place| {
+                                is_immutable_at_instr(place.identifier, instr.id, env, ctx)
+                            })
+                            .map(|place| place.identifier)
+                            .collect()
+                    };
                     let inner_assumed = get_assumed_invoked_functions(inner_func, env);
                     let inner_ctx = CollectHoistableContext {
                         temporaries: ctx.temporaries,

--- a/compiler/crates/react_compiler_lowering/Cargo.toml
+++ b/compiler/crates/react_compiler_lowering/Cargo.toml
@@ -14,3 +14,6 @@ react_compiler_diagnostics.workspace = true
 indexmap = "2"
 rustc-hash = "2"
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -1253,7 +1253,7 @@ fn lower_expression(
                                         loc: ident_loc.clone(),
                                         description: Some(format!(
                                             "`{}` is declared as const",
-                                            &ident.name
+                                            ident.name
                                         )),
                                         suggestions: None,
                                     })?;

--- a/compiler/crates/react_compiler_optimization/Cargo.toml
+++ b/compiler/crates/react_compiler_optimization/Cargo.toml
@@ -14,3 +14,6 @@ react_compiler_lowering.workspace = true
 react_compiler_ssa.workspace = true
 indexmap = "2"
 rustc-hash = "2"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
+++ b/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
@@ -563,10 +563,7 @@ fn evaluate_instruction(
                 // No subexpressions: join all cooked quasis
                 let mut result_string = String::new();
                 for q in quasis {
-                    match &q.cooked {
-                        Some(cooked) => result_string.push_str(cooked),
-                        None => return None,
-                    }
+                    result_string.push_str(q.cooked.as_ref()?)
                 }
                 let loc = *loc;
                 let result = Constant::Primitive {
@@ -608,10 +605,7 @@ fn evaluate_instruction(
                     PrimitiveValue::Undefined => return None,
                 };
 
-                let suffix = match &quasis[quasi_index].cooked {
-                    Some(s) => s.clone(),
-                    None => return None,
-                };
+                let suffix = quasis[quasi_index].cooked.clone()?;
                 quasi_index += 1;
 
                 result_string.push_str(&expression_str);

--- a/compiler/crates/react_compiler_optimization/src/inline_iifes.rs
+++ b/compiler/crates/react_compiler_optimization/src/inline_iifes.rs
@@ -175,7 +175,7 @@ pub fn inline_immediately_invoked_function_expressions(
                         let inner_blocks: Vec<(BlockId, BasicBlock)> =
                             inner_func.body.blocks.drain(..).collect();
                         let inner_instructions: Vec<Instruction> =
-                            inner_func.instructions.drain(..).collect();
+                            std::mem::take(&mut inner_func.instructions);
 
                         // Append inner instructions first, then remap block instruction IDs
                         let instr_offset = func.instructions.len() as u32;
@@ -248,7 +248,7 @@ pub fn inline_immediately_invoked_function_expressions(
                         let inner_blocks: Vec<(BlockId, BasicBlock)> =
                             inner_func.body.blocks.drain(..).collect();
                         let inner_instructions: Vec<Instruction> =
-                            inner_func.instructions.drain(..).collect();
+                            std::mem::take(&mut inner_func.instructions);
 
                         // Append inner instructions first, then remap block instruction IDs
                         let instr_offset = func.instructions.len() as u32;

--- a/compiler/crates/react_compiler_optimization/src/name_anonymous_functions.rs
+++ b/compiler/crates/react_compiler_optimization/src/name_anonymous_functions.rs
@@ -32,9 +32,11 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
     let nodes = name_anonymous_functions_impl(func, env);
 
     fn visit(node: &Node, prefix: &str, updates: &mut Vec<(FunctionId, String)>) {
-        if node.generated_name.is_some() && node.existing_name_hint.is_none() {
+        if let Some(generated_name) = &node.generated_name
+            && node.existing_name_hint.is_none()
+        {
             // Only add the prefix to anonymous functions regardless of nesting depth
-            let name = format!("{}{}]", prefix, node.generated_name.as_ref().unwrap());
+            let name = format!("{}{}]", prefix, generated_name);
             updates.push((node.function_id, name));
         }
         // Whether or not we generated a name for the function at this node,

--- a/compiler/crates/react_compiler_reactive_scopes/Cargo.toml
+++ b/compiler/crates/react_compiler_reactive_scopes/Cargo.toml
@@ -15,3 +15,6 @@ indexmap = "2"
 rustc-hash = "2"
 serde_json = "1"
 hmac-sha256 = "1"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -219,10 +219,10 @@ pub fn codegen_function(
     // enableEmitHookGuards: wrap entire function body in try/finally with
     // $dispatcherGuard(PushHookGuard=0) / $dispatcherGuard(PopHookGuard=1).
     // Per-hook-call wrapping is done inline during codegen (CallExpression/MethodCall).
-    if cx.env.hook_guard_name.is_some()
+    if let Some(hook_guard_name) = &cx.env.hook_guard_name
         && cx.env.output_mode == react_compiler_hir::environment::OutputMode::Client
     {
-        let guard_name = cx.env.hook_guard_name.as_ref().unwrap().clone();
+        let guard_name = hook_guard_name.clone();
         let body_stmts = std::mem::replace(&mut compiled.body.body, Vec::new());
         compiled.body.body = vec![create_function_body_hook_guard(
             &guard_name,

--- a/compiler/crates/react_compiler_ssa/Cargo.toml
+++ b/compiler/crates/react_compiler_ssa/Cargo.toml
@@ -12,3 +12,6 @@ react_compiler_diagnostics.workspace = true
 react_compiler_hir.workspace = true
 indexmap = "2"
 rustc-hash = "2"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_ssa/src/enter_ssa.rs
+++ b/compiler/crates/react_compiler_ssa/src/enter_ssa.rs
@@ -249,13 +249,8 @@ impl SSABuilder {
     }
 
     fn fix_incomplete_phis(&mut self, block_id: BlockId, env: &mut Environment) {
-        let incomplete_phis: Vec<IncompletePhi> = self
-            .states
-            .get_mut(&block_id)
-            .unwrap()
-            .incomplete_phis
-            .drain(..)
-            .collect();
+        let incomplete_phis: Vec<IncompletePhi> =
+            std::mem::take(&mut self.states.get_mut(&block_id).unwrap().incomplete_phis);
         for phi in &incomplete_phis {
             self.add_phi(block_id, &phi.old_place, &phi.new_place, env);
         }

--- a/compiler/crates/react_compiler_typeinference/Cargo.toml
+++ b/compiler/crates/react_compiler_typeinference/Cargo.toml
@@ -12,3 +12,6 @@ rustc-hash = "2"
 react_compiler_diagnostics.workspace = true
 react_compiler_hir.workspace = true
 react_compiler_ssa.workspace = true
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_utils/Cargo.toml
+++ b/compiler/crates/react_compiler_utils/Cargo.toml
@@ -10,3 +10,6 @@ repository.workspace = true
 [dependencies]
 indexmap = "2"
 rustc-hash = "2"
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_validation/Cargo.toml
+++ b/compiler/crates/react_compiler_validation/Cargo.toml
@@ -12,3 +12,6 @@ indexmap = "2"
 rustc-hash = "2"
 react_compiler_diagnostics.workspace = true
 react_compiler_hir.workspace = true
+
+[lints]
+workspace = true

--- a/compiler/crates/react_compiler_validation/src/validate_exhaustive_dependencies.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_exhaustive_dependencies.rs
@@ -1378,10 +1378,7 @@ fn validate_dependencies(
                 continue;
             }
             InferredDependency::Local {
-                identifier,
-                path,
-                loc: _,
-                ..
+                identifier, path, ..
             } => {
                 // Skip effect event functions
                 let ty = get_identifier_type(*identifier, identifiers, types);

--- a/compiler/crates/react_compiler_validation/src/validate_no_derived_computations_in_effects.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_no_derived_computations_in_effects.rs
@@ -1271,7 +1271,7 @@ fn validate_effect_non_exp(
         let ctx_ty = &tys[ids[ctx.identifier.0 as usize].type_.0 as usize];
         if is_set_state_type(ctx_ty) {
             continue;
-        } else if effect_deps.iter().any(|d| *d == ctx.identifier) {
+        } else if effect_deps.contains(&ctx.identifier) {
             continue;
         } else {
             return Vec::new();

--- a/compiler/crates/react_compiler_validation/src/validate_preserved_manual_memoization.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_preserved_manual_memoization.rs
@@ -288,13 +288,12 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState) {
         }
         ReactiveValue::Instruction(InstructionValue::StoreLocal { lvalue, value, .. }) => {
             // Track reassignments from inlining of manual memo
-            if state.manual_memo_state.is_some() && lvalue.kind == InstructionKind::Reassign {
+            if let Some(manual_memo_state) = &mut state.manual_memo_state
+                && lvalue.kind == InstructionKind::Reassign
+            {
                 let decl_id =
                     state.env.identifiers[lvalue.place.identifier.0 as usize].declaration_id;
-                state
-                    .manual_memo_state
-                    .as_mut()
-                    .unwrap()
+                manual_memo_state
                     .reassignments
                     .entry(decl_id)
                     .or_default()
@@ -302,15 +301,12 @@ fn visit_instruction(instr: &ReactiveInstruction, state: &mut VisitorState) {
             }
         }
         ReactiveValue::Instruction(InstructionValue::LoadLocal { place, .. }) => {
-            if state.manual_memo_state.is_some() {
+            if let Some(manual_memo_state) = &mut state.manual_memo_state {
                 let place_ident = &state.env.identifiers[place.identifier.0 as usize];
                 if let Some(ref lvalue) = instr.lvalue {
                     let lvalue_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
                     if place_ident.scope.is_some() && lvalue_ident.scope.is_none() {
-                        state
-                            .manual_memo_state
-                            .as_mut()
-                            .unwrap()
+                        manual_memo_state
                             .reassignments
                             .entry(lvalue_ident.declaration_id)
                             .or_default()
@@ -352,13 +348,10 @@ fn record_temporaries(instr: &ReactiveInstruction, state: &mut VisitorState) {
 
     if let Some(ref lvalue) = instr.lvalue {
         let lv_ident = &state.env.identifiers[lvalue.identifier.0 as usize];
-        if is_named(lv_ident) && state.manual_memo_state.is_some() {
-            state
-                .manual_memo_state
-                .as_mut()
-                .unwrap()
-                .decls
-                .insert(lv_ident.declaration_id);
+        if let Some(manual_memo_state) = &mut state.manual_memo_state
+            && is_named(lv_ident)
+        {
+            manual_memo_state.decls.insert(lv_ident.declaration_id);
         }
     }
 


### PR DESCRIPTION
## Summary

1. Use cargo clippy in CI
2. Whitelist some of the existing warnings (some of which really are purely stylistic)
3. Fix some of the unnecessary `unwrap()`s

## How did you test this change?

The existing test suite