### PR TITLE
[test] Assert client-rendered content for a rejected lazy element

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1738,7 +1738,7 @@ describe('ReactDOMFizzServer', () => {
     );
 
     // The client rendered HTML is now in place.
-    // expect(getVisibleChildren(container)).toEqual(<div>Hello</div>);
+    expect(getVisibleChildren(container)).toEqual(<div>Hello</div>);
 
     expect(loggedErrors).toEqual([theError]);
   });


### PR DESCRIPTION
## Summary

`should client render a boundary if a lazy element rejects` left its client-render assertion commented out, so the test only checked `loggedErrors`. The sibling test `should client render a boundary if a lazy component rejects` has the same comment 100 lines above with the assertion live.

This enables the assertion so the test covers the client render too.

## How did you test this change?

- `yarn test ReactDOMFizzServer` (216 tests passed)
- `yarn test ReactDOMFizzServer --prod` (216 tests passed)
- Confirmed the assertion is meaningful by changing the expected value to `<div>WRONG</div>`, which fails
- `yarn prettier`
- `yarn linc`