### PR TITLE
[devtools] Fix crash in prepare-release version bump

### DIFF
--- a/scripts/devtools/prepare-release.js
+++ b/scripts/devtools/prepare-release.js
@@ -45,7 +45,7 @@ async function main() {
 
   const path = join(ROOT_PATH, PACKAGE_PATHS[0]);
   const previousVersion = readJsonSync(path).version;
-  const {major, minor, patch} = semver(previousVersion);
+  const {major, minor, patch} = semver.parse(previousVersion);
   const nextVersion =
     releaseType === 'minor'
       ? `${major}.${minor + 1}.0`


### PR DESCRIPTION
## Summary

`prepare-release.js` calls `semver(previousVersion)`, but semver v7 exports an object rather than a callable, so the script throws `semver is not a function` as soon as it reads the previous version. The root `package.json` pins `semver@^7.1.1` and the script resolves to it, so this fails on every run. The script is documented in `scripts/devtools/README.md` and `build-and-test.js` prompts for it, so the DevTools release flow can't get past this line.

This switches to `semver.parse()`, which returns the `major`/`minor`/`patch` the version bump destructures.

## How did you test this change?

- `node -e "require('semver')('1.2.3')"` → `TypeError: semver is not a function` (semver 7.1.1 resolved from the repo root)
- Reproduced the script's code path against the real `packages/react-devtools/package.json` version (`7.0.1`): before the change it throws; after it yields `7.1.0` for a minor bump and `7.0.2` for a patch bump
- `node ./scripts/tasks/eslint.js scripts/devtools/prepare-release.js`
- `yarn prettier`
- `yarn linc`