### PR TITLE
[Flight] Avoid per-reference and per-import-row allocations in string dedupe

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -2071,6 +2071,9 @@ function transferReferencedDebugInfo(
   }
 }
 
+// Never mutated: path walks start at index 1.
+const EMPTY_REFERENCE_PATH: Array<string> = [];
+
 function getOutlinedModel<T>(
   response: Response,
   reference: string,
@@ -2078,8 +2081,10 @@ function getOutlinedModel<T>(
   key: string,
   map: (response: Response, model: any, parentObject: Object, key: string) => T,
 ): T {
-  const path = reference.split(':');
-  const id = parseInt(path[0], 16);
+  // parseInt stops at ':' so the common no-path case needs no split.
+  const id = parseInt(reference, 16);
+  const path =
+    reference.indexOf(':') === -1 ? EMPTY_REFERENCE_PATH : reference.split(':');
   const chunk = getChunk(response, id);
   if (enableProfilerTimer && enableComponentPerformanceTrack) {
     if (initializingChunk !== null && isArray(initializingChunk._children)) {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1232,6 +1232,46 @@ describe('ReactFlightDOMEdge', () => {
     expect(result).toEqual(props);
   });
 
+  it('should not count deduped strings against the row size limit', async () => {
+    // A className shared by every row of a list, which is the common shape.
+    const testString = 'a'.repeat(250);
+    const elements = [];
+    for (let i = 0; i < 60; i++) {
+      elements.push(
+        <p key={i} className={testString}>
+          {'row ' + i}
+        </p>,
+      );
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(<div>{elements}</div>),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // A reference is a few bytes, so the list stays in one row instead of
+    // being split up as if each element still carried the whole string.
+    const modelRows = serializedContent
+      .split('\n')
+      .filter(row => row !== '')
+      // Skip the tagged rows, which includes the debug info emitted in DEV.
+      .filter(row => !/^[0-9a-f]+:[A-Z]/.test(row));
+    // In DEV each element is outlined anyway to give its debug info an ID.
+    expect(modelRows.length).toBeLessThan(__DEV__ ? 70 : 10);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result.props.children.length).toBe(60);
+  });
+
   function clientComponent(name, chunkFilename) {
     return clientExports(
       function Client() {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMEdge-test.js
@@ -1107,6 +1107,271 @@ describe('ReactFlightDOMEdge', () => {
     expect(items[5]).toEqual(items[10]);
   });
 
+  it('should encode repeated strings in a compact format by deduping', async () => {
+    const testString = 'a'.repeat(100);
+    const props = {texts: new Array(30).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // One inline copy, one outlined row and a reference per repetition.
+    expect(serializedContent.length).toBeLessThan(400);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should not dedupe strings below the length threshold', async () => {
+    const testString = 'a'.repeat(63);
+    const props = {texts: new Array(30).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Every copy is spelled out because outlining a string this short would
+    // cost more than the duplicate.
+    expect(serializedContent.length).toBeGreaterThan(30 * testString.length);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should not outline a string that is used only once', async () => {
+    const props = {text: 'a'.repeat(100)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Most strings never repeat, so the first copy stays inline rather than
+    // paying for a row and a reference to it.
+    expect(serializedContent).not.toContain('$');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should dedupe repeated large strings', async () => {
+    const testString = 'a'.repeat(2000);
+    const props = {texts: new Array(5).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    // Large strings are outlined on first use, so there's only ever one copy.
+    expect(serializedContent.length).toBeLessThan(2100);
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  it('should escape deduped strings that start with $', async () => {
+    const testString = '$' + 'a'.repeat(100);
+    const props = {texts: new Array(30).fill(testString)};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(props),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    expect(serializedContent).toContain('"$' + testString + '"');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    expect(result).toEqual(props);
+  });
+
+  function clientComponent(name, chunkFilename) {
+    return clientExports(
+      function Client() {
+        return <span>{name}</span>;
+      },
+      'chunk-' + name,
+      chunkFilename,
+      Promise.resolve(),
+    );
+  }
+
+  it('should dedupe strings inside client reference metadata', async () => {
+    // Bundlers repeat the same chunk in the metadata of every client reference
+    // that needs it.
+    const chunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const ClientA = clientComponent('A', chunk);
+    const ClientB = clientComponent('B', chunk);
+    const ClientC = clientComponent('C', chunk);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <div>
+          <ClientA />
+          <ClientB />
+          <ClientC />
+        </div>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    const outlinedRow = ':' + JSON.stringify(chunk) + '\n';
+    expect(serializedContent).toContain(outlinedRow);
+    // The client resolves a client reference while parsing its row, so the
+    // outlined row has to be flushed before every row referencing it.
+    expect(serializedContent.indexOf(outlinedRow)).toBeLessThan(
+      serializedContent.lastIndexOf(':I['),
+    );
+    // An export name is too short to be worth outlining.
+    expect(serializedContent).not.toContain(':"*"\n');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    expect(await readResult(ssrStream)).toBe(
+      '<div><span>A</span><span>B</span><span>C</span></div>',
+    );
+  });
+
+  it('should escape strings inside client reference metadata', async () => {
+    // A leading $ has to be escaped whether the string gets outlined or not.
+    const outlinedChunk = '$path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const inlineChunk = '$chunk.js';
+    const ClientA = clientComponent('A', outlinedChunk);
+    const ClientB = clientComponent('B', outlinedChunk);
+    const ClientC = clientComponent('C', inlineChunk);
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <div>
+          <ClientA />
+          <ClientB />
+          <ClientC />
+        </div>,
+        webpackMap,
+      ),
+    );
+    const [stream1, stream2] = passThrough(stream).tee();
+
+    const serializedContent = await readResult(stream1);
+    expect(serializedContent).toContain(':"$' + outlinedChunk + '"\n');
+    expect(serializedContent).toContain('"$' + inlineChunk + '"');
+
+    const result = await ReactServerDOMClient.createFromReadableStream(
+      stream2,
+      {
+        serverConsumerManifest: {
+          moduleMap: null,
+          moduleLoading: null,
+        },
+      },
+    );
+    const ssrStream = await serverAct(() =>
+      ReactDOMServer.renderToReadableStream(result),
+    );
+    expect(await readResult(ssrStream)).toBe(
+      '<div><span>A</span><span>B</span><span>C</span></div>',
+    );
+  });
+
+  // @gate __DEV__
+  it('should not dedupe import metadata on the debug channel', async () => {
+    // The debug channel is a separate transport, so a row it emits can't be
+    // referenced from the main stream and vice versa.
+    const chunk = 'path/to/some/hashed-chunk-0f1e2d3c4b5a6978.js';
+    const Client = clientComponent('Client', chunk);
+
+    function Server({a, b}) {
+      return ReactServer.createElement('div', null, a, b);
+    }
+
+    let debugContent = '';
+    const debugChannel = {
+      writable: new WritableStream({
+        write(value) {
+          debugContent += Buffer.from(value).toString('utf8');
+        },
+      }),
+    };
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        // We can't use JSX here because it'll use the Client React.
+        ReactServer.createElement(Server, {
+          a: ReactServer.createElement(Client),
+          b: ReactServer.createElement(Client),
+        }),
+        webpackMap,
+        {debugChannel},
+      ),
+    );
+    await readResult(stream);
+
+    expect(debugContent).toContain(':I[');
+    // Every import row on the debug channel spells the chunk out.
+    expect(debugContent.split(chunk).length).toBe(
+      debugContent.split(':I[').length,
+    );
+  });
+
   it('warns if passing a this argument to bind() of a server reference', async () => {
     const ServerModule = serverExports({
       greet: function () {},

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -615,6 +615,9 @@ export type Request = {
   writtenClientReferences: Map<ClientReferenceKey, number>,
   writtenServerReferences: Map<ServerReference<any>, number>,
   writtenObjects: WeakMap<Reference, string>,
+  // A null entry means the string has been seen once and is still inline.
+  writtenStrings: Map<string, null | string>,
+  writtenImportStrings: Map<string, null | string>,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
   identifierCount: number,
@@ -740,6 +743,8 @@ function RequestInstance(
   this.writtenClientReferences = new Map();
   this.writtenServerReferences = new Map();
   this.writtenObjects = new WeakMap();
+  this.writtenStrings = new Map();
+  this.writtenImportStrings = new Map();
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
   this.identifierCount = 1;
@@ -2155,6 +2160,16 @@ let canEmitDebugInfo: boolean = false;
 let serializedSize = 0;
 const MAX_ROW_SIZE = 3200;
 
+// Strings at least this long get outlined and deduplicated when they repeat.
+// Below it the reference and row header outweigh the duplicate, and the extra
+// rows compress worse than the duplication they replace.
+const MIN_DEDUPLICATED_STRING_LENGTH = 64;
+
+// Bundler metadata repeats the same chunk URLs across every client reference of
+// a route, so it pays off much sooner. It's still bounded away from zero because
+// outlining something as short as an export name costs more than copying it.
+const MIN_DEDUPLICATED_IMPORT_STRING_LENGTH = 16;
+
 function deferTask(request: Request, task: Task): ReactJSONValue {
   // Like outlineTask but instead the item is scheduled to be serialized
   // after its parent in the stream.
@@ -3468,6 +3483,65 @@ function escapeStringValue(value: string): string {
   }
 }
 
+function serializeDeduplicatedString(request: Request, value: string): string {
+  const writtenStrings = request.writtenStrings;
+  const existing = writtenStrings.get(value);
+  if (existing !== undefined && existing !== null) {
+    return existing;
+  }
+  // $FlowFixMe[invalid-compare]
+  const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
+  if (existing === undefined && !isLarge) {
+    // Leave the first occurrence inline. Most strings never repeat, and a row
+    // header plus a reference costs more than the duplicate would have.
+    writtenStrings.set(value, null);
+    return escapeStringValue(value);
+  }
+  let ref;
+  if (isLarge) {
+    // Large strings are encoded outside the JSON payload so that we don't have
+    // to double encode and double parse them.
+    ref = serializeLargeTextString(request, value);
+  } else {
+    request.pendingChunks++;
+    const outlinedId = request.nextChunkId++;
+    // $FlowFixMe[incompatible-type] stringify can return null
+    const json: string = stringify(escapeStringValue(value));
+    emitModelChunk(request, outlinedId, json);
+    ref = serializeByValueID(outlinedId);
+  }
+  writtenStrings.set(value, ref);
+  return ref;
+}
+
+function serializeImportString(request: Request, value: string): string {
+  if (value.length < MIN_DEDUPLICATED_IMPORT_STRING_LENGTH) {
+    return escapeStringValue(value);
+  }
+  const writtenStrings = request.writtenImportStrings;
+  const existing = writtenStrings.get(value);
+  if (existing !== undefined) {
+    if (existing !== null) {
+      return existing;
+    }
+    request.pendingChunks++;
+    const outlinedId = request.nextChunkId++;
+    // $FlowFixMe[incompatible-type] stringify can return null
+    const json: string = stringify(escapeStringValue(value));
+    // The client reads import metadata synchronously, so this row has to have
+    // been written by the time the referencing row arrives. Import chunks are
+    // flushed ahead of regular ones, which regular chunks can't guarantee.
+    request.completedImportChunks.push(
+      stringToChunk(outlinedId.toString(16) + ':' + json + '\n'),
+    );
+    const ref = serializeByValueID(outlinedId);
+    writtenStrings.set(value, ref);
+    return ref;
+  }
+  writtenStrings.set(value, null);
+  return escapeStringValue(value);
+}
+
 let modelRoot: null | ReactClientValue = false;
 
 function renderModel(
@@ -4070,12 +4144,8 @@ function renderModelDestructive(
         return serializeDateFromDateJSON(value);
       }
     }
-    // $FlowFixMe[invalid-compare]
-    if (value.length >= 1024 && byteLengthOfChunk !== null) {
-      // For large strings, we encode them outside the JSON payload so that we
-      // don't have to double encode and double parse the strings. This can also
-      // be more compact in case the string has a lot of escaped characters.
-      return serializeLargeTextString(request, value);
+    if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
+      return serializeDeduplicatedString(request, value);
     }
     return escapeStringValue(value);
   }
@@ -4455,7 +4525,15 @@ function emitImportChunk(
   debug: boolean,
 ): void {
   // $FlowFixMe[incompatible-type] stringify can return null
-  const json: string = stringify(clientReferenceMetadata);
+  const json: string =
+    __DEV__ && debug
+      ? // The debug channel can't reference rows in the main stream.
+        stringify(clientReferenceMetadata)
+      : stringify(clientReferenceMetadata, (key: string, value: mixed) =>
+          typeof value === 'string'
+            ? serializeImportString(request, value)
+            : value,
+        );
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -4525,22 +4525,49 @@ function emitErrorChunk(
   }
 }
 
+// Maps metadata strings through serializeImportString ahead of stringify,
+// which then runs without a replacer (a replacer costs a closure per row
+// and takes stringify off the fast path). Assumes metadata is plain JSON
+// data or unwraps to it via toJSON, which every host config satisfies.
+function transformImportMetadata(request: Request, value: mixed): mixed {
+  if (typeof value === 'string') {
+    return serializeImportString(request, value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    if (typeof (value as any).toJSON === 'function') {
+      // stringify would call toJSON before the replacer saw the value.
+      return transformImportMetadata(request, (value as any).toJSON());
+    }
+    if (isArray(value)) {
+      const copy: Array<mixed> = [];
+      for (let i = 0; i < value.length; i++) {
+        copy.push(transformImportMetadata(request, value[i]));
+      }
+      return copy;
+    }
+    const copy: {[string]: mixed} = {};
+    for (const name in value) {
+      if (hasOwnProperty.call(value, name)) {
+        copy[name] = transformImportMetadata(request, (value as any)[name]);
+      }
+    }
+    return copy;
+  }
+  return value;
+}
+
 function emitImportChunk(
   request: Request,
   id: number,
   clientReferenceMetadata: ClientReferenceMetadata,
   debug: boolean,
 ): void {
-  // $FlowFixMe[incompatible-type] stringify can return null
   const json: string =
     __DEV__ && debug
       ? // The debug channel can't reference rows in the main stream.
         stringify(clientReferenceMetadata)
-      : stringify(clientReferenceMetadata, (key: string, value: mixed) =>
-          typeof value === 'string'
-            ? serializeImportString(request, value)
-            : value,
-        );
+      : // $FlowFixMe[incompatible-type] stringify can return null
+        stringify(transformImportMetadata(request, clientReferenceMetadata));
   const row = serializeRowHeader('I', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -3487,8 +3487,13 @@ function serializeDeduplicatedString(request: Request, value: string): string {
   const writtenStrings = request.writtenStrings;
   const existing = writtenStrings.get(value);
   if (existing !== undefined && existing !== null) {
+    // The row it refers to was already emitted so only the reference is new here.
+    serializedSize += existing.length;
     return existing;
   }
+  // The string still has to arrive before this row can be used, whether it's
+  // written inline or into its own row, so either way it counts in full.
+  serializedSize += value.length;
   // $FlowFixMe[invalid-compare]
   const isLarge = value.length >= 1024 && byteLengthOfChunk !== null;
   if (existing === undefined && !isLarge) {
@@ -4134,19 +4139,21 @@ function renderModelDestructive(
         throwTaintViolation(tainted.message);
       }
     }
-    serializedSize += value.length;
     // TODO: Maybe too clever. If we support URL there's no similar trick.
     if (value[value.length - 1] === 'Z') {
       // Possibly a Date, whose toJSON automatically calls toISOString
       // $FlowFixMe[incompatible-use]
       const originalValue = parent[parentPropertyName];
       if (originalValue instanceof Date) {
+        serializedSize += value.length;
         return serializeDateFromDateJSON(value);
       }
     }
     if (value.length >= MIN_DEDUPLICATED_STRING_LENGTH) {
+      // This path does its own accounting since it might only write a reference.
       return serializeDeduplicatedString(request, value);
     }
+    serializedSize += value.length;
     return escapeStringValue(value);
   }
 


### PR DESCRIPTION
## Stacked on #37147

#37147 makes every deduplicated string arrive as a `$ref`, so reference resolution and import-row serialization become hot. Two allocations dominate:

- `getOutlinedModel` calls `reference.split(':')` for every reference, but most references have no path. `parseInt` already stops at `:`, so the id parses without slicing, and the no-path case reuses a shared empty array.
- `emitImportChunk` passes a replacer to `JSON.stringify`, which allocates a closure per import row and takes stringify off V8's fast path. Mapping the metadata strings ahead of stringify produces identical output (including `toJSON` unwrapping) from a plain fast-path stringify.

Paired A/B against #37147's head on a client-reference-heavy page (112 import rows), 16 VM boots, confirmed on an independent second run:

| cell | effect | 95% CI | p |
| --- | --- | --- | --- |
| serial | +3.4–3.9% req/s | ±0.9–1.1% | <0.0001 |
| under load | +4.8–5.6% req/s | ±1.8–2.2% | <0.001 |

Flight output is byte-identical to #37147 on real payloads. CPU profiles attribute the win to the two call sites: reference resolution −56% self-time, import-row serialization −60% (16/16 VMs agree). Payload-light routes show no detected difference.
