### PR TITLE
[compiler] Fix "Expected a node for all scopes" invariant in PruneNonEscapingScopes

### DIFF
--- a/compiler/crates/react_compiler_reactive_scopes/src/prune_non_escaping_scopes.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/prune_non_escaping_scopes.rs
@@ -166,6 +166,22 @@ impl CollectState {
         );
     }
 
+    /// Records the scope and its dependencies, if not already present.
+    fn declare_scope(&mut self, env: &Environment, scope_id: ScopeId) {
+        self.scopes.entry(scope_id).or_insert_with(|| {
+            let scope_data = &env.scopes[scope_id.0 as usize];
+            let dependencies = scope_data
+                .dependencies
+                .iter()
+                .map(|dep| env.identifiers[dep.identifier.0 as usize].declaration_id)
+                .collect();
+            ScopeNode {
+                dependencies,
+                seen: false,
+            }
+        });
+    }
+
     /// Associates the identifier with its scope, if there is one and it is active for
     /// the given instruction id.
     fn visit_operand(
@@ -176,20 +192,7 @@ impl CollectState {
         identifier: DeclarationId,
     ) {
         if let Some(scope_id) = get_place_scope(env, id, place.identifier) {
-            let node = self.scopes.entry(scope_id).or_insert_with(|| {
-                let scope_data = &env.scopes[scope_id.0 as usize];
-                let dependencies = scope_data
-                    .dependencies
-                    .iter()
-                    .map(|dep| env.identifiers[dep.identifier.0 as usize].declaration_id)
-                    .collect();
-                ScopeNode {
-                    dependencies,
-                    seen: false,
-                }
-            });
-            // Avoid unused variable warning — we needed the entry to exist
-            let _ = node;
+            self.declare_scope(env, scope_id);
             let identifier_node = self
                 .identifiers
                 .get_mut(&identifier)
@@ -1021,6 +1024,14 @@ impl<'a> ReactiveFunctionVisitor for CollectDependenciesVisitor<'a> {
         let env = self.env;
         let scope_id = scope.scope;
         let scope_data = &env.scopes[scope_id.0 as usize];
+
+        // Register the scope up front. `visit_operand` only records a scope when it visits
+        // an operand declared in it, but a scope's only such operands may be somewhere
+        // `compute_memoization_inputs` never descends into (e.g. a ternary `test`). The
+        // scope is still associated with identifiers below (reassignments) and in
+        // `visit_terminal` (returns within the scope), and `compute_memoized_identifiers`
+        // expects a node for every associated scope.
+        state.0.declare_scope(env, scope_id);
 
         // If a scope reassigns any variables, set the chain of active scopes as a dependency
         // of those variables.

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonEscapingScopes.ts
@@ -239,6 +239,18 @@ class State {
     });
   }
 
+  // Records the scope and its dependencies, if not already present
+  declareScope(scope: ReactiveScope): void {
+    if (!this.scopes.has(scope.id)) {
+      this.scopes.set(scope.id, {
+        dependencies: [...scope.dependencies].map(
+          dep => dep.identifier.declarationId,
+        ),
+        seen: false,
+      });
+    }
+  }
+
   /*
    * Associates the identifier with its scope, if there is one and it is active for the given instruction id:
    * - Records the scope and its dependencies
@@ -251,16 +263,7 @@ class State {
   ): void {
     const scope = getPlaceScope(id, place);
     if (scope !== null) {
-      let node = this.scopes.get(scope.id);
-      if (node === undefined) {
-        node = {
-          dependencies: [...scope.dependencies].map(
-            dep => dep.identifier.declarationId,
-          ),
-          seen: false,
-        };
-        this.scopes.set(scope.id, node);
-      }
+      this.declareScope(scope);
       const identifierNode = this.identifiers.get(identifier);
       CompilerError.invariant(identifierNode !== undefined, {
         reason: 'Expected identifier to be initialized',
@@ -984,6 +987,16 @@ class CollectDependenciesVisitor extends ReactiveFunctionVisitor<
     scope: ReactiveScopeBlock,
     scopes: Array<ReactiveScope>,
   ): void {
+    /*
+     * Register the scope up front. `visitOperand` only records a scope when it visits an
+     * operand declared in it, but a scope's only such operands may be somewhere that
+     * `computeMemoizationInputs` never descends into (e.g. a ternary `test`). The scope
+     * is still associated with identifiers below (reassignments) and in `visitTerminal`
+     * (returns within the scope), and `computeMemoizedIdentifiers` expects a node for
+     * every associated scope.
+     */
+    this.state.declareScope(scope.scope);
+
     /*
      * If a scope reassigns any variables, set the chain of active scopes as a dependency
      * of those variables. This ensures that if the variable escapes that we treat the

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-ternary-test-scope-in-iife.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-ternary-test-scope-in-iife.expect.md
@@ -1,0 +1,86 @@
+
+## Input
+
+```javascript
+import {identity, useIdentity} from 'shared-runtime';
+
+/**
+ * The scope produced by `identity(value)` in the ternary test gets aligned outward
+ * to span the whole inlined IIFE (both `return`s become reassignments of the IIFE
+ * temporary + breaks out of the try). That scope's only own declaration lives in
+ * the ternary *test*, which PruneNonEscapingScopes never visits for memoization
+ * inputs, so the scope must still be registered when it is associated with the
+ * reassigned temporary.
+ */
+function Component({value}) {
+  const object = useIdentity({value});
+  return (() => {
+    try {
+      return identity(object.value) ? object : null;
+    } catch {
+      return null;
+    }
+  })();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 'hello'}],
+  sequentialRenders: [{value: 'hello'}, {value: 'hello'}, {value: ''}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { identity, useIdentity } from "shared-runtime";
+
+/**
+ * The scope produced by `identity(value)` in the ternary test gets aligned outward
+ * to span the whole inlined IIFE (both `return`s become reassignments of the IIFE
+ * temporary + breaks out of the try). That scope's only own declaration lives in
+ * the ternary *test*, which PruneNonEscapingScopes never visits for memoization
+ * inputs, so the scope must still be registered when it is associated with the
+ * reassigned temporary.
+ */
+function Component(t0) {
+  const $ = _c(4);
+  const { value } = t0;
+  let t1;
+  if ($[0] !== value) {
+    t1 = { value };
+    $[0] = value;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const object = useIdentity(t1);
+  let t2;
+  if ($[2] !== object) {
+    try {
+      t2 = identity(object.value) ? object : null;
+    } catch {
+      t2 = null;
+    }
+    $[2] = object;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ value: "hello" }],
+  sequentialRenders: [{ value: "hello" }, { value: "hello" }, { value: "" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) {"value":"hello"}
+{"value":"hello"}
+null

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-ternary-test-scope-in-iife.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-ternary-test-scope-in-iife.js
@@ -1,0 +1,26 @@
+import {identity, useIdentity} from 'shared-runtime';
+
+/**
+ * The scope produced by `identity(value)` in the ternary test gets aligned outward
+ * to span the whole inlined IIFE (both `return`s become reassignments of the IIFE
+ * temporary + breaks out of the try). That scope's only own declaration lives in
+ * the ternary *test*, which PruneNonEscapingScopes never visits for memoization
+ * inputs, so the scope must still be registered when it is associated with the
+ * reassigned temporary.
+ */
+function Component({value}) {
+  const object = useIdentity({value});
+  return (() => {
+    try {
+      return identity(object.value) ? object : null;
+    } catch {
+      return null;
+    }
+  })();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 'hello'}],
+  sequentialRenders: [{value: 'hello'}, {value: 'hello'}, {value: ''}],
+};


### PR DESCRIPTION
## Summary

The following bails out with `Invariant: Expected a node for all scopes` ([playground example](https://playground.react.dev/#N4Igzg9grgTgxgUxALhASwLYAcIwC4AEwBUYCAyngIZ4IEC+BAZjBBgQDogwJVx5cA3BwB2CAB458zKCP5oIIggCUEWVgAoAlEVEECcRWEIBtGFQDuAXQIBeEmUo0EAHmMw0IgOYEAPiREAEwQmTwRAgD4NWWDQsUCtYSUDI0IANzsCDW07CN1k-TwYAE98-XKCHjxYJWJzCwYCAH5KywJkANiwwKSKxjgaOAALIno9cqqazpDu3oYtbTnJmCUXQLQ0iOA0+hcAenXNpLGREAAaEEMRUK8UEGBxvb3DbDQAGxoFEQBZCGCOrhUN5vLiiejncBDCAWACSIloKyBYBQTCRCHoQA)):

```js
function Component() {
  const raw = useValue();
  return (() => {
    try {
      return check(raw) ? raw : null;
    } catch {
      return null;
    }
  })();
}
```

`PruneNonEscapingScopes` only creates a scope node lazily, when `visitOperand` sees an operand declared in that scope. But `visitScope` (reassignments) and `visitTerminal` (returns inside a scope) also add scope ids to identifier nodes without ensuring the scope node exists, and `computeMemoizedIdentifiers` asserts one exists for every associated scope.

Here the IIFE's `return`s are inlined into reassignments of a temporary + breaks out of the `try`, so the scope created for the `check(raw)` temporary is aligned outward to span the whole labeled block and picks up the temporary as a reassignment. That scope's only own declaration lives in the ternary *test*, which `computeMemoizationInputs` intentionally never descends into — so no node is ever created for it, and once the returned temporary is marked memoized we hit the invariant. This became reachable once value blocks inside try/catch were supported.

Fix: register the scope node on entry in `visitScope` (extracted `State.declareScope`, shared with `visitOperand`). The node is derived purely from `scope.dependencies` and `state.scopes` is only read by-id, so eagerly creating it doesn't change any other memoization decision. Same change applied to the Rust port.

Originally reported downstream in oxc as a compiler panic: https://github.com/oxc-project/oxc/issues/24710

## How did you test this change?

Added `try-catch-ternary-test-scope-in-iife.js`. Before the fix `yarn snap compile` on it reports `Invariant: Expected a node for all scopes`; after, it compiles (memoized on the hook result, matching the equivalent non-IIFE `let`/`try` form) and evaluates correctly across `sequentialRenders`.

- `yarn snap` — 1811/1811, no other fixture output changed
- `yarn snap --rust` — 1811/1811
- `yarn workspace babel-plugin-react-compiler lint`, prettier, `cargo fmt --check` clean

## LLM-assisted

Claude Code did much of the work to diagnose and fixed the compiler crash here, similar to the initial React Compiler rust port.

Closes #37228