### PR TITLE
[compiler] Take reassigned variables' incoming value as a scope dependency

### DIFF
--- a/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
@@ -2294,8 +2294,16 @@ fn handle_function_deps(
         // Record phi operands
         for phi in &block.phis {
             for (_pred_id, operand) in &phi.operands {
-                if let Some(maybe_optional_chain) = ctx.temporaries.get(&operand.identifier) {
-                    ctx.visit_dependency(maybe_optional_chain.clone(), env);
+                let maybe_optional_chain = ctx.temporaries.get(&operand.identifier).cloned();
+                if let Some(maybe_optional_chain) = maybe_optional_chain {
+                    ctx.visit_dependency(maybe_optional_chain, env);
+                } else if operand.reactive {
+                    // A reactive phi operand defined before the current scope flows through the
+                    // scope, which may reassign the variable on some paths and leave the
+                    // incoming value untouched on others. Without a dependency on that incoming
+                    // value, skipping the scope restores a stale copy over what an earlier
+                    // scope computed.
+                    ctx.visit_operand(operand, env);
                 }
             }
         }

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -818,7 +818,13 @@ fn codegen_reactive_scope(
     let scope_decls = cx.env.scopes[scope_id.0 as usize].declarations.clone();
     let scope_reassignments = cx.env.scopes[scope_id.0 as usize].reassignments.clone();
 
+    let reassigned_declarations: FxHashSet<_> = scope_reassignments
+        .iter()
+        .map(|id| cx.env.identifiers[id.0 as usize].declaration_id)
+        .collect();
+
     let mut cache_store_stmts: Vec<Statement> = Vec::new();
+    let mut reassigned_dep_store_stmts: Vec<Statement> = Vec::new();
     let mut cache_load_stmts: Vec<Statement> = Vec::new();
     let mut cache_loads: Vec<(AstIdentifier, u32, Expression)> = Vec::new();
     let mut change_exprs: Vec<Expression> = Vec::new();
@@ -849,7 +855,15 @@ fn codegen_reactive_scope(
 
         // Store dependency value into cache
         let dep_value = codegen_dependency(cx, dep)?;
-        cache_store_stmts.push(Statement::ExpressionStatement(ExpressionStatement {
+        // The scope overwrites this dependency as it runs, so cache it beforehand
+        let stores = if reassigned_declarations
+            .contains(&cx.env.identifiers[dep.identifier.0 as usize].declaration_id)
+        {
+            &mut reassigned_dep_store_stmts
+        } else {
+            &mut cache_store_stmts
+        };
+        stores.push(Statement::ExpressionStatement(ExpressionStatement {
             base: BaseNode::typed("ExpressionStatement"),
             expression: Box::new(Expression::AssignmentExpression(
                 ast_expr::AssignmentExpression {
@@ -1000,6 +1014,9 @@ fn codegen_reactive_scope(
         }));
     }
 
+    computation_block
+        .body
+        .splice(0..0, reassigned_dep_store_stmts);
     computation_block.body.extend(cache_store_stmts);
 
     let memo_stmt = Statement::IfStatement(IfStatement {

--- a/compiler/crates/react_compiler_reactive_scopes/src/prune_non_reactive_dependencies.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/prune_non_reactive_dependencies.rs
@@ -217,12 +217,30 @@ impl<'a> ReactiveFunctionTransform for PruneVisitor<'a> {
         self.traverse_scope(scope, state)?;
 
         let scope_id = scope.scope;
+        // Dependencies on a variable that this scope reassigns describe the value flowing in
+        // from an earlier scope. That value only exists as a phi, which has been lowered away
+        // by now, so it never appears in `state`.
+        let reassigned_declarations: FxHashSet<_> = self.env.scopes[scope_id.0 as usize]
+            .reassignments
+            .iter()
+            .map(|id| self.env.identifiers[id.0 as usize].declaration_id)
+            .collect();
+        let retained: FxHashSet<IdentifierId> = self.env.scopes[scope_id.0 as usize]
+            .dependencies
+            .iter()
+            .filter(|dep| {
+                state.contains(&dep.identifier)
+                    || reassigned_declarations
+                        .contains(&self.env.identifiers[dep.identifier.0 as usize].declaration_id)
+            })
+            .map(|dep| dep.identifier)
+            .collect();
         let scope_data = &mut self.env.scopes[scope_id.0 as usize];
 
         // Remove non-reactive dependencies
         scope_data
             .dependencies
-            .retain(|dep| state.contains(&dep.identifier));
+            .retain(|dep| retained.contains(&dep.identifier));
 
         // If any deps remain, mark all declarations and reassignments as reactive
         if !scope_data.dependencies.is_empty() {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
@@ -801,6 +801,15 @@ function collectDependencies(
           const maybeOptionalChain = temporaries.get(operand[1].identifier.id);
           if (maybeOptionalChain) {
             context.visitDependency(maybeOptionalChain);
+          } else if (operand[1].reactive) {
+            /*
+             * A reactive phi operand defined before the current scope flows
+             * through the scope, which may reassign the variable on some paths
+             * and leave the incoming value untouched on others. Without a
+             * dependency on that incoming value, skipping the scope restores a
+             * stale copy over what an earlier scope computed.
+             */
+            context.visitOperand(operand[1]);
           }
         }
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -52,7 +52,7 @@ import {printIdentifier, printInstruction, printPlace} from '../HIR/PrintHIR';
 import {eachPatternOperand} from '../HIR/visitors';
 
 import {GuardKind} from '../Utils/RuntimeDiagnosticConstants';
-import {assertExhaustive} from '../Utils/utils';
+import {Iterable_some, assertExhaustive} from '../Utils/utils';
 import {buildReactiveFunction} from './BuildReactiveFunction';
 import {SINGLE_CHILD_FBT_TAGS} from './MemoizeFbtAndMacroOperandsInSameScope';
 import {ReactiveFunctionVisitor, visitReactiveFunction} from './visitors';
@@ -564,6 +564,7 @@ function codegenReactiveScope(
   block: ReactiveBlock,
 ): void {
   const cacheStoreStatements: Array<t.Statement> = [];
+  const reassignedDepStoreStatements: Array<t.Statement> = [];
   const cacheLoadStatements: Array<t.Statement> = [];
   const cacheLoads: Array<{
     name: t.Identifier;
@@ -584,23 +585,33 @@ function codegenReactiveScope(
       codegenDependency(cx, dep),
     );
     changeExpressions.push(comparison);
-    /*
-     * Adding directly to cacheStoreStatements rather than cacheLoads, because there
-     * is no corresponding cacheLoadStatement for dependencies
-     */
-    cacheStoreStatements.push(
-      t.expressionStatement(
-        t.assignmentExpression(
-          '=',
-          t.memberExpression(
-            t.identifier(cx.synthesizeName('$')),
-            t.numericLiteral(index),
-            true,
-          ),
-          codegenDependency(cx, dep),
+    const store = t.expressionStatement(
+      t.assignmentExpression(
+        '=',
+        t.memberExpression(
+          t.identifier(cx.synthesizeName('$')),
+          t.numericLiteral(index),
+          true,
         ),
+        codegenDependency(cx, dep),
       ),
     );
+    if (
+      Iterable_some(
+        scope.reassignments,
+        reassignment =>
+          reassignment.declarationId === dep.identifier.declarationId,
+      )
+    ) {
+      // The scope overwrites this dependency as it runs, so cache it beforehand
+      reassignedDepStoreStatements.push(store);
+    } else {
+      /*
+       * Adding directly to cacheStoreStatements rather than cacheLoads, because there
+       * is no corresponding cacheLoadStatement for dependencies
+       */
+      cacheStoreStatements.push(store);
+    }
   }
   let firstOutputIndex: number | null = null;
 
@@ -698,6 +709,7 @@ function codegenReactiveScope(
       ),
     );
   }
+  computationBlock.body.unshift(...reassignedDepStoreStatements);
   computationBlock.body.push(...cacheStoreStatements);
   memoStatement = t.ifStatement(
     testCondition,

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonReactiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/PruneNonReactiveDependencies.ts
@@ -13,6 +13,7 @@ import {
   isStableType,
 } from '../HIR';
 import {eachPatternOperand} from '../HIR/visitors';
+import {Iterable_some} from '../Utils/utils';
 import {collectReactiveIdentifiers} from './CollectReactiveIdentifiers';
 import {ReactiveFunctionVisitor, visitReactiveFunction} from './visitors';
 
@@ -96,7 +97,18 @@ class Visitor extends ReactiveFunctionVisitor<ReactiveIdentifiers> {
   ): void {
     this.traverseScope(scopeBlock, state);
     for (const dep of scopeBlock.scope.dependencies) {
-      const isReactive = state.has(dep.identifier.id);
+      /*
+       * Dependencies on a variable that this scope reassigns describe the value
+       * flowing in from an earlier scope. That value only exists as a phi, which
+       * has been lowered away by now, so it never appears in `state`.
+       */
+      const isReactive =
+        state.has(dep.identifier.id) ||
+        Iterable_some(
+          scopeBlock.scope.reassignments,
+          reassignment =>
+            reassignment.declarationId === dep.identifier.declarationId,
+        );
       if (!isReactive) {
         scopeBlock.scope.dependencies.delete(dep);
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/ssa-cascading-eliminated-phis.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/propagate-scope-deps-hir-fork/ssa-cascading-eliminated-phis.expect.md
@@ -47,6 +47,7 @@ function Component(props) {
     $[3] !== props.d ||
     $[4] !== x
   ) {
+    $[4] = x;
     values = [];
     const y = props.a || props.b;
     values.push(y);
@@ -64,7 +65,6 @@ function Component(props) {
     $[1] = props.b;
     $[2] = props.c;
     $[3] = props.d;
-    $[4] = x;
     $[5] = values;
     $[6] = x;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reassignment-across-scopes.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reassignment-across-scopes.expect.md
@@ -1,0 +1,102 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  let hasErrors = false;
+
+  const nameErrors = [];
+  if (props.name === 'taken') {
+    hasErrors = true;
+    nameErrors.push('That name is already taken');
+  }
+
+  const settingsErrors = [];
+  if (props.missingVariable) {
+    hasErrors = true;
+    settingsErrors.push('Pick an X variable');
+  }
+
+  return [hasErrors, nameErrors, settingsErrors];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{name: '', missingVariable: false}],
+  sequentialRenders: [
+    {name: '', missingVariable: false},
+    {name: 'taken', missingVariable: false},
+    {name: '', missingVariable: false},
+    {name: '', missingVariable: true},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+  const $ = _c(11);
+  let hasErrors = false;
+  let nameErrors;
+  if ($[0] !== props.name) {
+    nameErrors = [];
+    if (props.name === "taken") {
+      hasErrors = true;
+      nameErrors.push("That name is already taken");
+    }
+    $[0] = props.name;
+    $[1] = nameErrors;
+    $[2] = hasErrors;
+  } else {
+    nameErrors = $[1];
+    hasErrors = $[2];
+  }
+  let settingsErrors;
+  if ($[3] !== hasErrors || $[4] !== props.missingVariable) {
+    $[3] = hasErrors;
+    settingsErrors = [];
+    if (props.missingVariable) {
+      hasErrors = true;
+      settingsErrors.push("Pick an X variable");
+    }
+    $[4] = props.missingVariable;
+    $[5] = settingsErrors;
+    $[6] = hasErrors;
+  } else {
+    settingsErrors = $[5];
+    hasErrors = $[6];
+  }
+  let t0;
+  if ($[7] !== hasErrors || $[8] !== nameErrors || $[9] !== settingsErrors) {
+    t0 = [hasErrors, nameErrors, settingsErrors];
+    $[7] = hasErrors;
+    $[8] = nameErrors;
+    $[9] = settingsErrors;
+    $[10] = t0;
+  } else {
+    t0 = $[10];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ name: "", missingVariable: false }],
+  sequentialRenders: [
+    { name: "", missingVariable: false },
+    { name: "taken", missingVariable: false },
+    { name: "", missingVariable: false },
+    { name: "", missingVariable: true },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) [false,[],[]]
+[true,["That name is already taken"],[]]
+[false,[],[]]
+[true,[],["Pick an X variable"]]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reassignment-across-scopes.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/reassignment-across-scopes.js
@@ -1,0 +1,28 @@
+function Component(props) {
+  let hasErrors = false;
+
+  const nameErrors = [];
+  if (props.name === 'taken') {
+    hasErrors = true;
+    nameErrors.push('That name is already taken');
+  }
+
+  const settingsErrors = [];
+  if (props.missingVariable) {
+    hasErrors = true;
+    settingsErrors.push('Pick an X variable');
+  }
+
+  return [hasErrors, nameErrors, settingsErrors];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{name: '', missingVariable: false}],
+  sequentialRenders: [
+    {name: '', missingVariable: false},
+    {name: 'taken', missingVariable: false},
+    {name: '', missingVariable: false},
+    {name: '', missingVariable: true},
+  ],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/same-variable-as-dep-and-redeclare-maybe-frozen.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/same-variable-as-dep-and-redeclare-maybe-frozen.expect.md
@@ -74,13 +74,13 @@ function foo(props) {
   const header = t0;
   let y;
   if ($[5] !== props.b || $[6] !== props.c || $[7] !== x) {
+    $[7] = x;
     y = [x];
     x = [];
     y.push(props.b);
     x.push(props.c);
     $[5] = props.b;
     $[6] = props.c;
-    $[7] = x;
     $[8] = y;
     $[9] = x;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/same-variable-as-dep-and-redeclare.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/same-variable-as-dep-and-redeclare.expect.md
@@ -69,13 +69,13 @@ function foo(props) {
   const header = t0;
   let y;
   if ($[3] !== props.b || $[4] !== props.c || $[5] !== x) {
+    $[5] = x;
     y = [x];
     x = [];
     y.push(props.b);
     x.push(props.c);
     $[3] = props.b;
     $[4] = props.c;
-    $[5] = x;
     $[6] = y;
     $[7] = x;
   } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-cascading-eliminated-phis.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/ssa-cascading-eliminated-phis.expect.md
@@ -46,6 +46,7 @@ function Component(props) {
     $[3] !== props.d ||
     $[4] !== x
   ) {
+    $[4] = x;
     values = [];
     const y = props.a || props.b;
     values.push(y);
@@ -63,7 +64,6 @@ function Component(props) {
     $[1] = props.b;
     $[2] = props.c;
     $[3] = props.d;
-    $[4] = x;
     $[5] = values;
     $[6] = x;
   } else {


### PR DESCRIPTION
## Summary

Fixes #37224.

When a variable declared outside any reactive scope is reassigned inside two different scopes, each scope caches and restores its own copy of it. The second scope's `else` branch then overwrites the value with a copy from an earlier render, discarding what the first scope just computed. In the report, a `hasErrors` flag set by the first validation check gets reset to `false` when the second check's scope is skipped, so the error message renders but the Save button stays enabled.

A scope that reassigns a variable on some paths and leaves it alone on others is really consuming the incoming value, so it should be a dependency of the scope. That value shows up in the HIR only as a phi operand, and phi operands were only inspected for optional chains. Three things had to change:

* `PropagateScopeDependenciesHIR` now visits reactive phi operands, which makes the incoming value a dependency of the scope it flows into.
* `PruneNonReactiveDependencies` keeps dependencies on variables the scope reassigns. Their identifier only ever existed as a phi, which is lowered away before that pass runs, so it is never in the reactive identifier set and the dependency would otherwise be dropped again.
* `CodegenReactiveFunction` writes the cache slot for such a dependency at the top of the scope body instead of the bottom. The body reassigns the variable, so storing it afterwards recorded the outgoing value and compared it against the incoming one. This also fixes existing output: `ssa-cascading-eliminated-phis` and `same-variable-as-dep-and-redeclare` already had a dependency on a variable they reassign and were caching the wrong value for it.

The Rust port gets the same three changes.

## How did you test this change?

New fixture `reassignment-across-scopes` reproduces the report with `sequentialRenders`. Before the fix the second render evaluates to `[false, ["That name is already taken"], []]`; after it, `[true, ["That name is already taken"], []]`.

* `yarn snap`: 1811 passed, 0 failed
* `yarn snap --rust`: 1811 passed, 0 failed
* `yarn workspace babel-plugin-react-compiler jest`: 43 passed
* `yarn workspace babel-plugin-react-compiler lint`, `yarn prettier-check`, `cargo fmt --all -- --check`: clean
* `bash scripts/test-babel-ast.sh` and `bash scripts/test-rust-port.sh`: passed

Snapshot churn across the whole fixture suite is four files: the new fixture plus the three noted above.
