### PR TITLE
docs: update company name from Facebook to Meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The main purpose of this repository is to continue evolving React core, making i
 
 ### [Code of Conduct](https://code.fb.com/codeofconduct)
 
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
+Meta has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
 
 ### [Contributing Guide](https://legacy.reactjs.org/docs/how-to-contribute.html)
 


### PR DESCRIPTION
## Description

This PR updates the company name from 'Facebook' to 'Meta' in the Code of Conduct section of README.md to reflect the current company branding.

## Changes
- Changed 'Facebook has adopted' to 'Meta has adopted' in Code of Conduct section
- Reflects the company's rebrand from Facebook to Meta

## Reasoning
- Meta is the current official company name since the 2021 rebrand
- Maintains consistency with current company branding
- Documentation should reflect current company identity

## Type
- [x] Documentation improvement
- [ ] Bug fix
- [ ] New feature