### PR TITLE
docs: update contribution guide link to react.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Want to contribute to React? There are a few things you need to know.  
 
-We wrote a **[contribution guide](https://reactjs.org/docs/how-to-contribute.html)** to help you get started.
+We wrote a **[contribution guide](https://react.dev/community/how-to-contribute)** to help you get started.


### PR DESCRIPTION
### Description%0AThis PR updates an outdated link in the CONTRIBUTING.md file.%0A%0A### Changes%0AUpdated the contribution guide link from the old eactjs.org domain to the new eact.dev domain.%0A%0A### Why%0AReact's official documentation has moved to react.dev. This link should point to the current domain for consistency and to avoid redirects.%0A%0A### Type of Change%0A- [x] Documentation update%0A- [x] Link correction