### PR TITLE
[Fiber] Fix missing key warning for outlined Flight elements

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1159,6 +1159,22 @@ function createChildReconciler(
           break;
         case REACT_LAZY_TYPE: {
           const resolvedChild = resolveLazy(child as any);
+          if (
+            (child as any)._store &&
+            (child as any)._store.validated &&
+            resolvedChild !== null &&
+            typeof resolvedChild === 'object' &&
+            (resolvedChild as any).$$typeof === REACT_ELEMENT_TYPE &&
+            (resolvedChild as any)._store &&
+            !(resolvedChild as any)._store.validated
+          ) {
+            // The JSX runtime validated the lazy node as a static child before
+            // it was unwrapped, e.g. an outlined Flight element. Transfer that
+            // to the resolved element so it isn't reported as missing a key.
+            (resolvedChild as any)._store.validated = (
+              child as any
+            )._store.validated;
+          }
           warnOnInvalidKey(
             returnFiber,
             workInProgress,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -3137,4 +3137,43 @@ describe('ReactFlightDOMBrowser', () => {
 
     expect(container.innerHTML).toBe('<div></div>');
   });
+  it('should not have missing key warnings when a static child is outlined', async () => {
+    const ClientComponent = clientExports(function ClientComponent({
+      text,
+      element,
+    }) {
+      return (
+        <div>
+          <span>{text.length}</span>
+          {element}
+        </div>
+      );
+    });
+
+    // A large preceding prop pushes the element past the outlining threshold so
+    // it is emitted as its own row instead of inline.
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <ClientComponent text={'a'.repeat(4000)} element={<span>Hi</span>} />,
+        webpackMap,
+      ),
+    );
+
+    function ClientRoot({response}) {
+      return use(response);
+    }
+
+    const response = ReactServerDOMClient.createFromReadableStream(stream);
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(<ClientRoot response={response} />);
+    });
+
+    expect(container.innerHTML).toBe(
+      '<div><span>4000</span><span>Hi</span></div>',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #37240.

When Flight outlines a static child into its own row, the client wraps the reference in a lazy node (`createLazyChunkWrapper` in the `'L'` case of `parseModelString`). The JSX runtime marks that lazy node as a validated static child in `validateChildKeys`, but `warnOnInvalidKey` resolves the lazy and checks the inner element, which was created when the outlined row initialized and never received the mark. The result is a false `Each child in a list should have a unique "key" prop.` warning for a child that is not in an array — it appears or disappears depending on whether a preceding prop pushes the element past the outlining threshold.

#34350 fixed the same class of warning for blocked elements by transferring the `validated` flag from the lazy wrapper in `initializeElement`, but that path creates the lazy at the element's creation site, so the transfer cannot cover outlined rows, where the wrapper is created at the reference site and the element when the target chunk initializes.

This transfers the wrapper's `validated` flag to the resolved element when `warnOnInvalidKey` unwraps the lazy, mirroring what `validateChildKeys` already does for fulfilled lazy payloads.

## How did you test this change?

- Added a test mirroring the issue: a large preceding prop forces the static child to be outlined. It fails on `main` with the false key warning and passes with this change.
- `yarn test ReactFlightDOMBrowser` (50 tests) and `yarn test ReactFlightDOMBrowser --prod` (50 tests) — pass.
- `yarn test ReactFlight` — 358 pass; the one failure (`ReactFlightAsyncDebugInfo › can track async file reads`) also fails on a clean checkout of `main` in this environment, so it is unrelated.
- `yarn test ReactChildren ReactLazy ReactFragment ReactElement` (149 tests) and `yarn test ReactIncremental ReactCoroutine ReactMultiChild` (180 tests) — pass.
- `yarn prettier`, `yarn linc`, `yarn flow dom-node` — clean.