### PR TITLE
DevTools: Remove stale comments referencing removed timeline package

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -35,8 +35,7 @@ import {isDevToolsPresent} from './ReactFiberDevToolsHook';
 import {clz32} from './clz32';
 import {LegacyRoot} from './ReactRootTags';
 
-// Lane values below should be kept in sync with getLabelForLane(), used by react-devtools-timeline.
-// If those values are changed that package should be rebuilt and redeployed.
+// Lane values below should be kept in sync with getLabelForLane().
 
 export const TotalLanes = 31;
 
@@ -122,7 +121,6 @@ export const HydrationLanes =
   SelectiveHydrationLane |
   IdleHydrationLane;
 
-// This function is used for the experimental timeline (react-devtools-timeline)
 // It should be kept in sync with the Lanes values above.
 export function getLabelForLane(lane: Lane): string | void {
   if (enableSchedulingProfiler) {

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -529,7 +529,7 @@ function wrapWithTopLevelDefinitions(
         source = source.replace(USE_STRICT_HEADER_REGEX, '');
 
         // Certain DEV and Profiling bundles should self-register their own module boundaries with DevTools.
-        // This allows the Timeline to de-emphasize (dim) internal stack frames.
+        // This allows DevTools to de-emphasize (dim) internal stack frames.
         source = wrapWithRegisterInternalModule(source);
         break;
     }


### PR DESCRIPTION
 In PR #37187 ("Remove the dead Timeline profiler code"), `packages/react-devtools-timeline` was deleted along
  with its backend profiling hooks. The commit notes explicitly highlighted three follow-up comments left behind:

> *"Three stale comments still name the removed package: `scripts/rollup/wrappers.js:532` and `ReactFiberLane.
  js:38,125`. Left alone to keep this stack purely DevTools-side."*

This PR removes these stale comments from ReactFiberLane.js and updates the reference in wrappers.js to maintain accurate documentation.

## How did you test this change?

 - Ran `yarn linc` to confirm no linting errors on modified files.
 - Confirmed zero functional or runtime logic changes to lane constants or rollup wrappers.