### PR TITLE
React: Add DEV guard validation for useMemoCache size argument

### DIFF
--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -210,6 +210,14 @@ export function use<T>(usable: Usable<T>): T {
 }
 
 export function useMemoCache(size: number): Array<mixed> {
+  if (__DEV__) {
+    if (typeof size !== 'number' || size < 0 || !Number.isInteger(size)) {
+      console.error(
+        'useMemoCache expected a non-negative integer for size, but received %s.',
+        size,
+      );
+    }
+  }
   const dispatcher = resolveDispatcher();
   // $FlowFixMe[not-a-function] This is unstable, thus optional
   return dispatcher.useMemoCache(size);


### PR DESCRIPTION
`useMemoCache(size)` allocates a fixed array buffer for compiled memoization slots. When called with an invalid `size` argument (e.g. negative numbers or non-integers), V8 throws an unhandled `RangeError: Invalid array length` deep inside reconciler execution.

Following React's developer experience principles, this PR adds a `__DEV__` guard in  `packages/react/src/ReactHooks.js` to log an informative `console.error` warning when `size` is not a non-negative integer, making invalid invocations easy to diagnose during development.

## How did you test this change?

- Ran `yarn test packages/react-reconciler/src/__tests__/useMemoCache-test.js`.
- Verified that passing negative sizes or invalid types in development triggers the `console.error` warning.
- Verified that the check is completely eliminated by Rollup in production builds (`yarn build`).