### PR TITLE
docs: use standard wording for bug fixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You'll notice that we used an HTML-like syntax; [we call it JSX](https://react.d
 
 ## Contributing
 
-The main purpose of this repository is to continue evolving React core, making it faster and easier to use. Development of React happens in the open on GitHub, and we are grateful to the community for contributing bugfixes and improvements. Read below to learn how you can take part in improving React.
+The main purpose of this repository is to continue evolving React core, making it faster and easier to use. Development of React happens in the open on GitHub, and we are grateful to the community for contributing bug fixes and improvements. Read below to learn how you can take part in improving React.
 
 ### [Code of Conduct](https://code.fb.com/codeofconduct)
 
@@ -67,7 +67,7 @@ Facebook has adopted a Code of Conduct that we expect project participants to ad
 
 ### [Contributing Guide](https://legacy.reactjs.org/docs/how-to-contribute.html)
 
-Read our [contributing guide](https://legacy.reactjs.org/docs/how-to-contribute.html) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
+Read our [contributing guide](https://legacy.reactjs.org/docs/how-to-contribute.html) to learn about our development process, how to propose bug fixes and improvements, and how to build and test your changes to React.
 
 ### [Good First Issues](https://github.com/facebook/react/labels/good%20first%20issue)
 


### PR DESCRIPTION
## Summary
This PR changes one wording instance in the root README from "bugfixes" to "bug fixes" for documentation consistency.

## How did you test this change?
- Manual review of the updated sentence.
- Confirmed this is a docs-only change with no runtime impact.