### PR TITLE
docs: replace legacy contributing links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [React](https://react.dev/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/react/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react) [![(Runtime) Build and Test](https://github.com/facebook/react/actions/workflows/runtime_build_and_test.yml/badge.svg)](https://github.com/facebook/react/actions/workflows/runtime_build_and_test.yml) [![(Compiler) TypeScript](https://github.com/facebook/react/actions/workflows/compiler_typescript.yml/badge.svg?branch=main)](https://github.com/facebook/react/actions/workflows/compiler_typescript.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://legacy.reactjs.org/docs/how-to-contribute.html#your-first-pull-request)
+# [React](https://react.dev/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/react/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react) [![(Runtime) Build and Test](https://github.com/facebook/react/actions/workflows/runtime_build_and_test.yml/badge.svg)](https://github.com/facebook/react/actions/workflows/runtime_build_and_test.yml) [![(Compiler) TypeScript](https://github.com/facebook/react/actions/workflows/compiler_typescript.yml/badge.svg?branch=main)](https://github.com/facebook/react/actions/workflows/compiler_typescript.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 
 React is a JavaScript library for building user interfaces.
 
@@ -34,7 +34,7 @@ The documentation is divided into several sections:
 * [Advanced Guides](https://react.dev/learn/escape-hatches)
 * [API Reference](https://react.dev/reference/react)
 * [Where to Get Support](https://react.dev/community)
-* [Contributing Guide](https://legacy.reactjs.org/docs/how-to-contribute.html)
+* [Contributing Guide](./CONTRIBUTING.md)
 
 You can improve it by sending pull requests to [this repository](https://github.com/reactjs/react.dev).
 
@@ -65,9 +65,9 @@ The main purpose of this repository is to continue evolving React core, making i
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
 
-### [Contributing Guide](https://legacy.reactjs.org/docs/how-to-contribute.html)
+### [Contributing Guide](./CONTRIBUTING.md)
 
-Read our [contributing guide](https://legacy.reactjs.org/docs/how-to-contribute.html) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
+Read our [contributing guide](./CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
 
 ### [Good First Issues](https://github.com/facebook/react/labels/good%20first%20issue)
 


### PR DESCRIPTION
## Summary
- Replace legacy README contributing links with the repository-local `CONTRIBUTING.md`
- Update the PRs Welcome badge target to the same canonical contributing guide

## Why
The README currently points contributors to legacy docs for contribution instructions. Linking to the maintained repository guide keeps onboarding current and self-contained.

## How did you test this change?
- Manual review of rendered README links in the diff
- Verified all updated links point to `./CONTRIBUTING.md`

## Scope
Docs-only changes. No runtime behavior impact.