### PR TITLE
[Flight] Server References for arbitrary object types

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -47,6 +47,7 @@ import {
   enableComponentPerformanceTrack,
   enableAsyncDebugInfo,
   enableFlightWeakThenables,
+  enableFlightObjectReferences,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -69,6 +70,7 @@ import {
 import {
   createBoundServerReference,
   registerBoundServerReference,
+  createServerObjectReference,
 } from './ReactFlightReplyClient';
 
 import {readTemporaryReference} from './ReactFlightTemporaryReferences';
@@ -2130,6 +2132,20 @@ function loadServerReference<A: Iterable<any>, T>(
   return null as any;
 }
 
+function loadServerObjectReference(
+  response: Response,
+  metaData: {id: any},
+  parentObject: Object,
+  key: string,
+): mixed {
+  // A Server Reference to an object is always opaque on the client, even if
+  // we have a module mapping for Server References: unlike a function
+  // reference, the module that produced it is only meant to be evaluated in a
+  // true server environment. The reference can only be passed back to the
+  // server, where it resolves to the object.
+  return createServerObjectReference(metaData.id);
+}
+
 function resolveLazy(value: any): mixed {
   while (
     typeof value === 'object' &&
@@ -2599,6 +2615,20 @@ function parseModelString(
           key,
           loadServerReference,
         );
+      }
+      case 'H': {
+        if (enableFlightObjectReferences) {
+          // Server Reference to an object
+          const ref = value.slice(2);
+          return getOutlinedModel(
+            response,
+            ref,
+            parentObject,
+            key,
+            loadServerObjectReference,
+          );
+        }
+        return undefined;
       }
       case 'T': {
         // Temporary Reference

--- a/packages/react-client/src/ReactFlightReplyClient.js
+++ b/packages/react-client/src/ReactFlightReplyClient.js
@@ -37,6 +37,9 @@ import {writeTemporaryReference} from './ReactFlightTemporaryReferences';
 import isArray from 'shared/isArray';
 import getPrototypeOf from 'shared/getPrototypeOf';
 
+import {enableFlightObjectReferences} from 'shared/ReactFeatureFlags';
+import {createOpaqueServerObjectReference} from 'shared/ReactFlightOpaqueReferences';
+
 const ObjectPrototype = Object.prototype;
 
 import {
@@ -70,6 +73,12 @@ type ServerReferenceClosure = {
 };
 
 const knownServerReferences: WeakMap<Function, ServerReferenceClosure> =
+  new WeakMap();
+
+// Server References to objects are tracked separately from function
+// references. They have no bound arguments and are never callable, so a
+// reference of one kind must not be usable where the other is expected.
+const knownServerObjectReferences: WeakMap<Function, ServerReferenceId> =
   new WeakMap();
 
 // Serializable values
@@ -110,6 +119,10 @@ function serializePromiseID(id: number): string {
 
 function serializeServerReferenceID(id: number): string {
   return '$h' + id.toString(16);
+}
+
+function serializeServerObjectReferenceID(id: number): string {
+  return '$H' + id.toString(16);
 }
 
 function serializeTemporaryReferenceMarker(): string {
@@ -832,6 +845,38 @@ export function processReply(
         writtenObjects.set(value, serverReferenceId);
         return serverReferenceId;
       }
+      if (enableFlightObjectReferences) {
+        // Opaque object references are function-typed (they're Proxies over a
+        // function target, like Temporary References) but are tracked and
+        // encoded separately from function references. Like function
+        // references, they must be checked before the temporary reference
+        // fallback below — a Server Reference is never turned into a
+        // temporary reference.
+        const objectReferenceId = knownServerObjectReferences.get(value);
+        if (objectReferenceId !== undefined) {
+          const existingReference = writtenObjects.get(value);
+          if (existingReference !== undefined) {
+            return existingReference;
+          }
+          const referenceJSON = JSON.stringify(
+            {id: objectReferenceId},
+            resolveToJSON,
+          );
+          if (formData === null) {
+            // Upgrade to use FormData to allow us to stream this value.
+            formData = new FormData();
+          }
+          // The reference to this object came from the same client so we can
+          // pass it back to the server where it resolves to the object.
+          const refId = nextPartId++;
+          formData.set(formFieldPrefix + refId, referenceJSON);
+          const serverObjectReferenceId =
+            serializeServerObjectReferenceID(refId);
+          // Store the reference ID for deduplication.
+          writtenObjects.set(value, serverObjectReferenceId);
+          return serverObjectReferenceId;
+        }
+      }
       if (temporaryReferences !== undefined && key.indexOf(':') === -1) {
         // TODO: If the property name contains a colon, we don't dedupe. Escape instead.
         const parentReference = writtenObjects.get(parent);
@@ -1235,6 +1280,15 @@ export function registerServerReference<T: Function>(
   encodeFormAction?: EncodeFormActionCallback,
 ): ServerReference<T> {
   registerBoundServerReference(reference, id, null, encodeFormAction);
+  return reference;
+}
+
+export function createServerObjectReference(id: ServerReferenceId): mixed {
+  const reference = createOpaqueServerObjectReference();
+  // Register the reference so that passing it back to the server encodes it
+  // by id. Object references are tracked separately from function references
+  // so that one kind can never be encoded as the other.
+  knownServerObjectReferences.set(reference as any, id);
   return reference;
 }
 

--- a/packages/react-flight-server-fb/src/ReactFlightFBReferences.js
+++ b/packages/react-flight-server-fb/src/ReactFlightFBReferences.js
@@ -25,6 +25,7 @@ export type ClientReference<T> = {
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -32,6 +33,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function registerClientReference<T>(

--- a/packages/react-flight-server-fb/src/server/ReactFlightServerConfigFBBundler.js
+++ b/packages/react-flight-server-fb/src/server/ReactFlightServerConfigFBBundler.js
@@ -24,7 +24,11 @@ export type ClientReferenceMetadata = ClientReference<any>;
 
 export type ClientReferenceKey = string;
 
-export {isClientReference, isServerReference} from '../ReactFlightFBReferences';
+export {
+  isClientReference,
+  isServerReference,
+  isServerObjectReference,
+} from '../ReactFlightFBReferences';
 
 export function getClientReferenceKey(
   reference: ClientReference<any>,

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -57,6 +57,9 @@ const ReactNoopFlightServer = ReactFlightServer({
   isServerReference(reference: Object): boolean {
     return reference.$$typeof === Symbol.for('react.server.reference');
   },
+  isServerObjectReference(reference: Object): boolean {
+    return reference.$$typeof === Symbol.for('react.server.object.reference');
+  },
   getClientReferenceKey(reference: Object): Object {
     return reference;
   },

--- a/packages/react-server-dom-esm/src/ReactFlightESMReferences.js
+++ b/packages/react-server-dom-esm/src/ReactFlightESMReferences.js
@@ -24,6 +24,7 @@ export type ClientReference<T> = {
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -31,6 +32,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function registerClientReference<T>(

--- a/packages/react-server-dom-esm/src/server/ReactFlightServerConfigESMBundler.js
+++ b/packages/react-server-dom-esm/src/server/ReactFlightServerConfigESMBundler.js
@@ -30,6 +30,7 @@ export type ClientReferenceKey = string;
 export {
   isClientReference,
   isServerReference,
+  isServerObjectReference,
 } from '../ReactFlightESMReferences';
 
 export function getClientReferenceKey(

--- a/packages/react-server-dom-parcel/src/ReactFlightParcelReferences.js
+++ b/packages/react-server-dom-parcel/src/ReactFlightParcelReferences.js
@@ -27,6 +27,7 @@ export type ClientReference<T> = {
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -34,6 +35,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function createClientReference<T>(

--- a/packages/react-server-dom-parcel/src/server/ReactFlightServerConfigParcelBundler.js
+++ b/packages/react-server-dom-parcel/src/server/ReactFlightServerConfigParcelBundler.js
@@ -25,6 +25,7 @@ export type ClientReferenceKey = string;
 export {
   isClientReference,
   isServerReference,
+  isServerObjectReference,
 } from '../ReactFlightParcelReferences';
 
 export function getClientReferenceKey(

--- a/packages/react-server-dom-turbopack/npm/server.browser.js
+++ b/packages/react-server-dom-turbopack/npm/server.browser.js
@@ -12,6 +12,7 @@ exports.decodeReply = s.decodeReply;
 exports.decodeAction = s.decodeAction;
 exports.decodeFormState = s.decodeFormState;
 exports.registerServerReference = s.registerServerReference;
+exports.registerServerObjectReference = s.registerServerObjectReference;
 exports.registerClientReference = s.registerClientReference;
 exports.createClientModuleProxy = s.createClientModuleProxy;
 exports.createTemporaryReferenceSet = s.createTemporaryReferenceSet;

--- a/packages/react-server-dom-turbopack/npm/server.edge.js
+++ b/packages/react-server-dom-turbopack/npm/server.edge.js
@@ -13,6 +13,7 @@ exports.decodeReplyFromAsyncIterable = s.decodeReplyFromAsyncIterable;
 exports.decodeAction = s.decodeAction;
 exports.decodeFormState = s.decodeFormState;
 exports.registerServerReference = s.registerServerReference;
+exports.registerServerObjectReference = s.registerServerObjectReference;
 exports.registerClientReference = s.registerClientReference;
 exports.createClientModuleProxy = s.createClientModuleProxy;
 exports.createTemporaryReferenceSet = s.createTemporaryReferenceSet;

--- a/packages/react-server-dom-turbopack/npm/server.node.js
+++ b/packages/react-server-dom-turbopack/npm/server.node.js
@@ -15,6 +15,7 @@ exports.decodeReplyFromAsyncIterable = s.decodeReplyFromAsyncIterable;
 exports.decodeAction = s.decodeAction;
 exports.decodeFormState = s.decodeFormState;
 exports.registerServerReference = s.registerServerReference;
+exports.registerServerObjectReference = s.registerServerObjectReference;
 exports.registerClientReference = s.registerClientReference;
 exports.createClientModuleProxy = s.createClientModuleProxy;
 exports.createTemporaryReferenceSet = s.createTemporaryReferenceSet;

--- a/packages/react-server-dom-turbopack/server.browser.js
+++ b/packages/react-server-dom-turbopack/server.browser.js
@@ -13,6 +13,7 @@ export {
   decodeAction,
   decodeFormState,
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
   createTemporaryReferenceSet,

--- a/packages/react-server-dom-turbopack/server.edge.js
+++ b/packages/react-server-dom-turbopack/server.edge.js
@@ -14,6 +14,7 @@ export {
   decodeAction,
   decodeFormState,
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
   createTemporaryReferenceSet,

--- a/packages/react-server-dom-turbopack/server.node.js
+++ b/packages/react-server-dom-turbopack/server.node.js
@@ -16,6 +16,7 @@ export {
   decodeAction,
   decodeFormState,
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
   createTemporaryReferenceSet,

--- a/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
+++ b/packages/react-server-dom-turbopack/src/ReactFlightTurbopackReferences.js
@@ -25,6 +25,7 @@ export type ClientReference<T> = {
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -32,6 +33,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function registerClientReference<T>(
@@ -141,6 +146,34 @@ export function registerServerReference<T: Function>(
           toString: serverReferenceToString,
         }) as PropertyDescriptorMap,
   );
+}
+
+export type ServerObjectReference<T> = T & {
+  $$typeof: symbol,
+  $$id: string,
+};
+
+export function registerServerObjectReference<T>(
+  reference: T,
+  id: string,
+  exportName: null | string,
+): ServerObjectReference<T> {
+  if (__DEV__) {
+    if (typeof reference === 'function') {
+      console.error(
+        'registerServerObjectReference: The reference is a function. Use ' +
+          'registerServerReference to register a function as a Server ' +
+          'Reference.',
+      );
+    }
+  }
+  return Object.defineProperties(reference as any, {
+    $$typeof: {value: SERVER_OBJECT_REFERENCE_TAG},
+    $$id: {
+      value: exportName === null ? id : id + '#' + exportName,
+      configurable: true,
+    },
+  });
 }
 
 const PROMISE_PROTOTYPE = Promise.prototype;

--- a/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMObjectReferences-test.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/ReactFlightTurbopackDOMObjectReferences-test.js
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+import {patchMessageChannel} from '../../../../scripts/jest/patchMessageChannel';
+
+// Polyfills for test environment
+global.ReadableStream =
+  require('web-streams-polyfill/ponyfill/es6').ReadableStream;
+global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;
+
+let serverExports;
+let serverObjectExports;
+let turbopackMap;
+let turbopackServerMap;
+let ReactServerDOMServer;
+let ReactServerDOMClient;
+let ReactServerScheduler;
+let serverAct;
+
+describe('ReactFlightTurbopackDOMObjectReferences', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    ReactServerScheduler = require('scheduler');
+    patchMessageChannel(ReactServerScheduler);
+    serverAct = require('internal-test-utils').serverAct;
+
+    // Simulate the condition resolution
+    jest.mock('react', () => require('react/react.react-server'));
+    jest.mock('react-server-dom-turbopack/server', () =>
+      require('react-server-dom-turbopack/server.browser'),
+    );
+
+    const TurbopackMock = require('./utils/TurbopackMock');
+    serverExports = TurbopackMock.serverExports;
+    serverObjectExports = TurbopackMock.serverObjectExports;
+    turbopackMap = TurbopackMock.turbopackMap;
+    turbopackServerMap = TurbopackMock.turbopackServerMap;
+
+    ReactServerDOMServer = require('react-server-dom-turbopack/server.browser');
+
+    __unmockReact();
+    jest.resetModules();
+    ReactServerDOMClient = require('react-server-dom-turbopack/client');
+  });
+
+  // @gate enableFlightObjectReferences
+  it('passes an object reference to the client and back to the server where it resolves', async () => {
+    const settings = {theme: 'dark'};
+    const ServerModule = serverObjectExports({settings});
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        {ref: ServerModule.settings},
+        turbopackMap,
+      ),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream);
+    const token = result.ref;
+
+    // The client representation is opaque. The object never crossed the wire,
+    // and reading any property throws.
+    expect(() => token.theme).toThrow(
+      'Cannot access theme on the client. ' +
+        'You cannot read a Server Reference to an object on the client. ' +
+        'You can only pass it back to the server.',
+    );
+    // It is not callable either; it is not a Server Function.
+    expect(() => token()).toThrow(
+      'Attempted to call a Server Reference to an object from the client, ' +
+        'but it is not a function. You can only pass it back to the server.',
+    );
+
+    // Passing it back to the server resolves it to the object via the
+    // manifest. Object references are encoded with their own marker, distinct
+    // from function references.
+    const body = await ReactServerDOMClient.encodeReply({ref: token});
+    expect(body.get('0')).toContain('"$H');
+    const decoded = await ReactServerDOMServer.decodeReply(
+      body,
+      turbopackServerMap,
+    );
+    expect(decoded.ref).toBe(settings);
+  });
+
+  // @gate enableFlightObjectReferences
+  it('does not await an object reference that is a Promise', async () => {
+    const promise = Promise.resolve('server secret');
+    const ServerModule = serverObjectExports({promise});
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        {ref: ServerModule.promise},
+        turbopackMap,
+      ),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream);
+    const token = result.ref;
+
+    // The token must not appear thenable, or awaiting it would hang or leak.
+    // Awaiting it just yields the token itself.
+    expect(token.then).toBe(undefined);
+    expect(await token).toBe(token);
+    expect(() => token.value).toThrow('Cannot access value on the client.');
+
+    const body = await ReactServerDOMClient.encodeReply({ref: token});
+    const decoded = await ReactServerDOMServer.decodeReply(
+      body,
+      turbopackServerMap,
+    );
+    expect(decoded.ref).toBe(promise);
+    expect(await decoded.ref).toBe('server secret');
+  });
+
+  // @gate enableFlightObjectReferences
+  it('resolves to the current value of the module export, not a snapshot', async () => {
+    let current = {version: 1};
+    const ServerModule = serverObjectExports({
+      get value() {
+        return current;
+      },
+    });
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        {ref: ServerModule.value},
+        turbopackMap,
+      ),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream);
+    const token = result.ref;
+
+    const body1 = await ReactServerDOMClient.encodeReply({ref: token});
+    const decoded1 = await ReactServerDOMServer.decodeReply(
+      body1,
+      turbopackServerMap,
+    );
+    expect(decoded1.ref).toBe(current);
+    expect(decoded1.ref.version).toBe(1);
+
+    // Simulate a later request where the module export resolves to a fresh
+    // value. The same reference must resolve to the new value.
+    current = {version: 2};
+    const body2 = await ReactServerDOMClient.encodeReply({ref: token});
+    const decoded2 = await ReactServerDOMServer.decodeReply(
+      body2,
+      turbopackServerMap,
+    );
+    expect(decoded2.ref).toBe(current);
+    expect(decoded2.ref.version).toBe(2);
+  });
+
+  // @gate enableFlightObjectReferences
+  it('is not turned into a temporary reference when a TemporaryReferenceSet is passed', async () => {
+    const settings = {theme: 'dark'};
+    const ServerModule = serverObjectExports({settings});
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        {ref: ServerModule.settings},
+        turbopackMap,
+      ),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream);
+    const token = result.ref;
+
+    // A Server Reference is never turned into a temporary reference, even
+    // when a TemporaryReferenceSet is provided. It must encode as an object
+    // reference so the server resolves it through the manifest.
+    const temporaryReferences =
+      ReactServerDOMClient.createTemporaryReferenceSet();
+    const body = await ReactServerDOMClient.encodeReply(
+      {ref: token},
+      {temporaryReferences},
+    );
+    expect(body.get('0')).toContain('"$H');
+    const decoded = await ReactServerDOMServer.decodeReply(
+      body,
+      turbopackServerMap,
+    );
+    expect(decoded.ref).toBe(settings);
+  });
+
+  it('rejects a reference whose id is not in the server manifest', async () => {
+    const forged = ReactServerDOMClient.createServerReference(
+      'file:///forged#steal',
+      () => Promise.resolve(),
+    );
+    const body = await ReactServerDOMClient.encodeReply({ref: forged});
+    await expect(
+      ReactServerDOMServer.decodeReply(body, turbopackServerMap),
+    ).rejects.toThrow(
+      'Could not find the module "file:///forged#steal" in the React Server ' +
+        'Manifest.',
+    );
+  });
+
+  // @gate !enableFlightObjectReferences
+  it('serializes a registered Promise as a thenable when the flag is off', async () => {
+    const promise = Promise.resolve('resolved');
+    const ServerModule = serverObjectExports({promise});
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        {promise: ServerModule.promise},
+        turbopackMap,
+      ),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream);
+
+    // Without the flag, a registered Promise is awaited like any other
+    // thenable and its value crosses to the client.
+    expect(await result.promise).toBe('resolved');
+  });
+
+  it('still round-trips function server references', async () => {
+    function greet(name) {
+      return 'hi, ' + name;
+    }
+    const ServerModule = serverExports({greet});
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        {method: ServerModule.greet},
+        turbopackMap,
+      ),
+    );
+    const result = await ReactServerDOMClient.createFromReadableStream(stream);
+    expect(typeof result.method).toBe('function');
+
+    const body = await ReactServerDOMClient.encodeReply({
+      method: result.method,
+    });
+    const decoded = await ReactServerDOMServer.decodeReply(
+      body,
+      turbopackServerMap,
+    );
+    expect(decoded.method).toBe(greet);
+    expect(decoded.method('there')).toBe('hi, there');
+  });
+});

--- a/packages/react-server-dom-turbopack/src/__tests__/utils/TurbopackMock.js
+++ b/packages/react-server-dom-turbopack/src/__tests__/utils/TurbopackMock.js
@@ -25,6 +25,7 @@ global.__turbopack_require__ = function (id) {
 const Server = require('react-server-dom-turbopack/server');
 const registerClientReference = Server.registerClientReference;
 const registerServerReference = Server.registerServerReference;
+const registerServerObjectReference = Server.registerServerObjectReference;
 const createClientModuleProxy = Server.createClientModuleProxy;
 
 exports.turbopackMap = turbopackClientMap;
@@ -174,24 +175,48 @@ exports.serverExports = function serverExports(moduleExports) {
     };
   }
 
-  if (typeof exports === 'function') {
+  if (typeof moduleExports === 'function') {
     // The module exports a function directly,
     registerServerReference(
-      (exports: any),
-      idx,
+      (moduleExports: any),
+      path,
       // Represents the whole Module object instead of a particular import.
       null,
     );
   } else {
-    const keys = Object.keys(exports);
+    const keys = Object.keys(moduleExports);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      const value = exports[keys[i]];
+      const value = moduleExports[key];
       if (typeof value === 'function') {
-        registerServerReference((value: any), idx, key);
+        registerServerReference((value: any), path, key);
       }
     }
   }
 
+  return moduleExports;
+};
+
+// Simulates a "use server" module whose exports include objects, which are
+// registered as object Server References.
+exports.serverObjectExports = function serverObjectExports(moduleExports) {
+  const idx = '' + turbopackModuleIdx++;
+  turbopackServerModules[idx] = moduleExports;
+  const path = url.pathToFileURL(idx).href;
+  turbopackServerMap[path] = {
+    id: idx,
+    chunks: [],
+    name: '*',
+  };
+  const keys = Object.keys(moduleExports);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = moduleExports[key];
+    if (typeof value === 'function') {
+      registerServerReference((value: any), path, key);
+    } else {
+      registerServerObjectReference((value: any), path, key);
+    }
+  }
   return moduleExports;
 };

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerBrowser.js
@@ -40,6 +40,7 @@ import {
 
 export {
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
 } from '../ReactFlightTurbopackReferences';

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerEdge.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerEdge.js
@@ -46,6 +46,7 @@ import {
 
 export {
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
 } from '../ReactFlightTurbopackReferences';

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
@@ -56,6 +56,7 @@ import {
 
 export {
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
 } from '../ReactFlightTurbopackReferences';

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightServerConfigTurbopackBundler.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightServerConfigTurbopackBundler.js
@@ -34,6 +34,7 @@ export type ClientReferenceKey = string;
 export {
   isClientReference,
   isServerReference,
+  isServerObjectReference,
 } from '../ReactFlightTurbopackReferences';
 
 export function getClientReferenceKey(

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.browser.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.browser.js
@@ -14,6 +14,7 @@ export {
   decodeAction,
   decodeFormState,
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
   createTemporaryReferenceSet,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.edge.js
@@ -15,6 +15,7 @@ export {
   decodeAction,
   decodeFormState,
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
   createTemporaryReferenceSet,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.js
@@ -18,6 +18,7 @@ export {
   decodeAction,
   decodeFormState,
   registerServerReference,
+  registerServerObjectReference,
   registerClientReference,
   createClientModuleProxy,
   createTemporaryReferenceSet,

--- a/packages/react-server-dom-unbundled/src/ReactFlightUnbundledReferences.js
+++ b/packages/react-server-dom-unbundled/src/ReactFlightUnbundledReferences.js
@@ -25,6 +25,7 @@ export type ClientReference<T> = {
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -32,6 +33,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function registerClientReference<T>(

--- a/packages/react-server-dom-unbundled/src/server/ReactFlightServerConfigUnbundledBundler.js
+++ b/packages/react-server-dom-unbundled/src/server/ReactFlightServerConfigUnbundledBundler.js
@@ -34,6 +34,7 @@ export type ClientReferenceKey = string;
 export {
   isClientReference,
   isServerReference,
+  isServerObjectReference,
 } from '../ReactFlightUnbundledReferences';
 
 export function getClientReferenceKey(

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js
@@ -25,6 +25,7 @@ export type ClientReference<T> = {
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -32,6 +33,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function registerClientReference<T>(

--- a/packages/react-server-dom-webpack/src/server/ReactFlightServerConfigWebpackBundler.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightServerConfigWebpackBundler.js
@@ -34,6 +34,7 @@ export type ClientReferenceKey = string;
 export {
   isClientReference,
   isServerReference,
+  isServerObjectReference,
 } from '../ReactFlightWebpackReferences';
 
 export function getClientReferenceKey(

--- a/packages/react-server/src/ReactFlightReplyServer.js
+++ b/packages/react-server/src/ReactFlightReplyServer.js
@@ -42,6 +42,7 @@ import {
   registerTemporaryReference,
 } from './ReactFlightServerTemporaryReferences';
 import {ASYNC_ITERATOR} from 'shared/ReactSymbols';
+import {enableFlightObjectReferences} from 'shared/ReactFeatureFlags';
 
 import hasOwnProperty from 'shared/hasOwnProperty';
 import getPrototypeOf from 'shared/getPrototypeOf';
@@ -1624,6 +1625,24 @@ function parseModelString(
           null,
           loadServerReference,
         );
+      }
+      case 'H': {
+        if (enableFlightObjectReferences) {
+          // Server Reference to an object. Its metadata carries only an id —
+          // no bound arguments — and it resolves through the same manifest
+          // lookup as a function reference, which returns the module export
+          // without calling it.
+          const ref = value.slice(2);
+          return getOutlinedModel(
+            response,
+            ref,
+            obj,
+            key,
+            null,
+            loadServerReference,
+          );
+        }
+        return undefined;
       }
       case 'T': {
         // Temporary Reference

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -17,6 +17,7 @@ import {
   enableComponentPerformanceTrack,
   enableAsyncDebugInfo,
   enableFlightWeakThenables,
+  enableFlightObjectReferences,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -85,6 +86,7 @@ import {
   getClientReferenceKey,
   isClientReference,
   isServerReference,
+  isServerObjectReference,
   supportsRequestStorage,
   requestStorage,
   createHints,
@@ -615,6 +617,7 @@ export type Request = {
   writtenSymbols: Map<symbol, number>,
   writtenClientReferences: Map<ClientReferenceKey, number>,
   writtenServerReferences: Map<ServerReference<any>, number>,
+  writtenServerObjectReferences: Map<Object, number>,
   writtenObjects: WeakMap<Reference, string>,
   temporaryReferences: void | TemporaryReferenceSet,
   identifierPrefix: string,
@@ -740,6 +743,7 @@ function RequestInstance(
   this.writtenSymbols = new Map();
   this.writtenClientReferences = new Map();
   this.writtenServerReferences = new Map();
+  this.writtenServerObjectReferences = new Map();
   this.writtenObjects = new WeakMap();
   this.temporaryReferences = temporaryReferences;
   this.identifierPrefix = identifierPrefix || '';
@@ -3072,6 +3076,10 @@ function serializeServerReferenceID(id: number): string {
   return '$h' + id.toString(16);
 }
 
+function serializeServerObjectReferenceID(id: number): string {
+  return '$H' + id.toString(16);
+}
+
 function serializeSymbolReference(name: string): string {
   return '$S' + name;
 }
@@ -3338,6 +3346,27 @@ function serializeServerReference(
   const metadataId = outlineModel(request, serverReferenceMetadata);
   writtenServerReferences.set(serverReference, metadataId);
   return serializeServerReferenceID(metadataId);
+}
+
+function serializeServerObjectReference(
+  request: Request,
+  serverObjectReference: Object,
+): string {
+  const writtenServerObjectReferences = request.writtenServerObjectReferences;
+  const existingId = writtenServerObjectReferences.get(serverObjectReference);
+  if (existingId !== undefined) {
+    return serializeServerObjectReferenceID(existingId);
+  }
+
+  // Object references share the manifest id format with function references,
+  // but have no bound arguments and no debug metadata.
+  const id = getServerReferenceId(
+    request.bundlerConfig,
+    serverObjectReference as any,
+  );
+  const metadataId = outlineModel(request, {id});
+  writtenServerObjectReferences.set(serverObjectReference, metadataId);
+  return serializeServerObjectReferenceID(metadataId);
 }
 
 function serializeTemporaryReference(
@@ -3931,6 +3960,13 @@ function renderModelDestructive(
         parentPropertyName,
         value as any,
       );
+    }
+
+    if (enableFlightObjectReferences && isServerObjectReference(value)) {
+      // An object registered as a Server Reference. This must be checked
+      // before the thenable case below so that a reference that happens to
+      // be a Promise is serialized by reference instead of being awaited.
+      return serializeServerObjectReference(request, value as any);
     }
 
     if (request.temporaryReferences !== undefined) {

--- a/packages/react-server/src/ReactFlightServerConfigBundlerCustom.js
+++ b/packages/react-server/src/ReactFlightServerConfigBundlerCustom.js
@@ -17,6 +17,7 @@ export opaque type ServerReferenceId: any = mixed;
 export opaque type ClientReferenceKey: any = mixed;
 export const isClientReference = $$$config.isClientReference;
 export const isServerReference = $$$config.isServerReference;
+export const isServerObjectReference = $$$config.isServerObjectReference;
 export const getClientReferenceKey = $$$config.getClientReferenceKey;
 export const resolveClientReferenceMetadata =
   $$$config.resolveClientReferenceMetadata;

--- a/packages/react-server/src/ReactFlightServerTemporaryReferences.js
+++ b/packages/react-server/src/ReactFlightServerTemporaryReferences.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-const TEMPORARY_REFERENCE_TAG = Symbol.for('react.temporary.reference');
+import {
+  TEMPORARY_REFERENCE_TAG,
+  createOpaqueTemporaryReference,
+} from 'shared/ReactFlightOpaqueReferences';
 
 export opaque type TemporaryReferenceSet = WeakMap<
   TemporaryReference<any>,
@@ -32,82 +35,12 @@ export function resolveTemporaryReference<T>(
   return temporaryReferences.get(temporaryReference);
 }
 
-const proxyHandlers: Proxy$traps<mixed> = {
-  get: function (
-    target: Function,
-    name: string | symbol,
-    receiver: Proxy<Function>,
-  ) {
-    switch (name) {
-      // These names are read by the Flight runtime if you end up using the exports object.
-      case '$$typeof':
-        // These names are a little too common. We should probably have a way to
-        // have the Flight runtime extract the inner target instead.
-        return target.$$typeof;
-      case 'name':
-        return undefined;
-      case 'displayName':
-        return undefined;
-      // We need to special case this because createElement reads it if we pass this
-      // reference.
-      case 'defaultProps':
-        return undefined;
-      // React looks for debugInfo on thenables.
-      case '_debugInfo':
-        return undefined;
-      // Avoid this attempting to be serialized.
-      case 'toJSON':
-        return undefined;
-      case Symbol.toPrimitive:
-        // $FlowFixMe[prop-missing]
-        return Object.prototype[Symbol.toPrimitive];
-      case Symbol.toStringTag:
-        // $FlowFixMe[prop-missing]
-        return Object.prototype[Symbol.toStringTag];
-      case 'Provider':
-        // Context.Provider === Context in React, so return the same reference.
-        // This allows server components to render <ClientContext.Provider>
-        // which will be serialized and executed on the client.
-        return receiver;
-      case 'then':
-        // Allow returning a temporary reference from an async function
-        // Unlike regular Client References, a Promise would never have been serialized as
-        // an opaque Temporary Reference, but instead would have been serialized as a
-        // Promise on the server and so doesn't hit this path. So we can assume this wasn't
-        // a Promise on the client.
-        return undefined;
-    }
-    throw new Error(
-      // eslint-disable-next-line react-internal/safe-string-coercion
-      `Cannot access ${String(name)} on the server. ` +
-        'You cannot dot into a temporary client reference from a server component. ' +
-        'You can only pass the value through to the client.',
-    );
-  },
-  set: function () {
-    throw new Error(
-      'Cannot assign to a temporary client reference from a server module.',
-    );
-  },
-};
-
 export function createTemporaryReference<T>(
   temporaryReferences: TemporaryReferenceSet,
   id: string,
 ): TemporaryReference<T> {
-  const reference: TemporaryReference<any> = Object.defineProperties(
-    function () {
-      throw new Error(
-        `Attempted to call a temporary Client Reference from the server but it is on the client. ` +
-          `It's not possible to invoke a client function from the server, it can ` +
-          `only be rendered as a Component or passed to props of a Client Component.`,
-      );
-    } as any,
-    {
-      $$typeof: {value: TEMPORARY_REFERENCE_TAG},
-    },
-  );
-  const wrapper = new Proxy(reference, proxyHandlers);
+  const wrapper: TemporaryReference<T> =
+    createOpaqueTemporaryReference() as any;
   registerTemporaryReference(temporaryReferences, wrapper, id);
   return wrapper;
 }

--- a/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.markup.js
@@ -54,6 +54,7 @@ export opaque type ClientReferenceKey: any = string;
 
 const CLIENT_REFERENCE_TAG = Symbol.for('react.client.reference');
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference');
+const SERVER_OBJECT_REFERENCE_TAG = Symbol.for('react.server.object.reference');
 
 export function isClientReference(reference: Object): boolean {
   return reference.$$typeof === CLIENT_REFERENCE_TAG;
@@ -61,6 +62,10 @@ export function isClientReference(reference: Object): boolean {
 
 export function isServerReference(reference: Object): boolean {
   return reference.$$typeof === SERVER_REFERENCE_TAG;
+}
+
+export function isServerObjectReference(reference: Object): boolean {
+  return reference.$$typeof === SERVER_OBJECT_REFERENCE_TAG;
 }
 
 export function getClientReferenceKey(

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -85,6 +85,12 @@ export const enableAsyncIterableChildren = __EXPERIMENTAL__;
 // left unfulfilled.
 export const enableFlightWeakThenables = __EXPERIMENTAL__;
 
+// Support Server References that point to objects (including Promises), not
+// just functions. On the server the reference is the real object; on the
+// client it's an opaque handle that can only be passed back to the server,
+// where it resolves via the manifest.
+export const enableFlightObjectReferences = __EXPERIMENTAL__;
+
 export const enableTaint = __EXPERIMENTAL__;
 
 export const enableViewTransition: boolean = true;

--- a/packages/shared/ReactFlightOpaqueReferences.js
+++ b/packages/shared/ReactFlightOpaqueReferences.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// An opaque reference is a stand-in for a value that lives in a different
+// environment. It cannot be read where it is; it can only be passed back to
+// the environment that owns the value. Reading any property throws, except
+// for a small set of properties that React itself (or the JS runtime) probes
+// when a value passes through it.
+//
+// There are two kinds: a Temporary Reference is a client value that is opaque
+// on the server, and an object Server Reference is a server value that is
+// opaque on the client. The two proxy implementations below are deliberately
+// kept side by side instead of being merged: they special-case the same
+// property names but differ in environment and error messages. If you change
+// one, check whether the other needs the same change.
+
+export const TEMPORARY_REFERENCE_TAG: symbol = Symbol.for(
+  'react.temporary.reference',
+);
+
+const temporaryReferenceProxyHandlers: Proxy$traps<mixed> = {
+  get: function (
+    target: Function,
+    name: string | symbol,
+    receiver: Proxy<Function>,
+  ) {
+    switch (name) {
+      // These names are read by the Flight runtime if you end up using the exports object.
+      case '$$typeof':
+        // These names are a little too common. We should probably have a way to
+        // have the Flight runtime extract the inner target instead.
+        return target.$$typeof;
+      case 'name':
+        return undefined;
+      case 'displayName':
+        return undefined;
+      // We need to special case this because createElement reads it if we pass this
+      // reference.
+      case 'defaultProps':
+        return undefined;
+      // React looks for debugInfo on thenables.
+      case '_debugInfo':
+        return undefined;
+      // Avoid this attempting to be serialized.
+      case 'toJSON':
+        return undefined;
+      case Symbol.toPrimitive:
+        // $FlowFixMe[prop-missing]
+        return Object.prototype[Symbol.toPrimitive];
+      case Symbol.toStringTag:
+        // $FlowFixMe[prop-missing]
+        return Object.prototype[Symbol.toStringTag];
+      case 'Provider':
+        // Context.Provider === Context in React, so return the same reference.
+        // This allows server components to render <ClientContext.Provider>
+        // which will be serialized and executed on the client.
+        // TODO: This should only be forwarded if the referenced value is
+        // actually a React context. But no type information about the value
+        // crosses the wire, so refining here requires the client to encode a
+        // hint at serialization time. Until then, reading .Provider on a
+        // non-context reference silently returns the reference itself
+        // instead of throwing like every other property.
+        return receiver;
+      case 'then':
+        // Allow returning a temporary reference from an async function
+        // Unlike regular Client References, a Promise would never have been serialized as
+        // an opaque Temporary Reference, but instead would have been serialized as a
+        // Promise on the server and so doesn't hit this path. So we can assume this wasn't
+        // a Promise on the client.
+        return undefined;
+    }
+    throw new Error(
+      // eslint-disable-next-line react-internal/safe-string-coercion
+      `Cannot access ${String(name)} on the server. ` +
+        'You cannot dot into a temporary client reference from a server component. ' +
+        'You can only pass the value through to the client.',
+    );
+  },
+  set: function () {
+    throw new Error(
+      'Cannot assign to a temporary client reference from a server module.',
+    );
+  },
+};
+
+export function createOpaqueTemporaryReference(): mixed {
+  const reference = Object.defineProperties(
+    function () {
+      throw new Error(
+        `Attempted to call a temporary Client Reference from the server but it is on the client. ` +
+          `It's not possible to invoke a client function from the server, it can ` +
+          `only be rendered as a Component or passed to props of a Client Component.`,
+      );
+    } as any,
+    {
+      $$typeof: {value: TEMPORARY_REFERENCE_TAG},
+    },
+  );
+  return new Proxy(reference, temporaryReferenceProxyHandlers);
+}
+
+const serverObjectReferenceProxyHandlers: Proxy$traps<mixed> = {
+  get: function (target: Function, name: string | symbol) {
+    switch (name) {
+      // These names are read by the Flight runtime if you end up passing this
+      // reference along.
+      case '$$typeof':
+        return target.$$typeof;
+      case 'name':
+        return undefined;
+      case 'displayName':
+        return undefined;
+      // We need to special case this because createElement reads it if we pass this
+      // reference.
+      case 'defaultProps':
+        return undefined;
+      // React looks for debugInfo on thenables.
+      case '_debugInfo':
+        return undefined;
+      // Avoid this attempting to be serialized.
+      case 'toJSON':
+        return undefined;
+      case Symbol.toPrimitive:
+        // $FlowFixMe[prop-missing]
+        return Object.prototype[Symbol.toPrimitive];
+      case Symbol.toStringTag:
+        // $FlowFixMe[prop-missing]
+        return Object.prototype[Symbol.toStringTag];
+      case 'then':
+        // Even if the referenced object is a Promise, it must not appear
+        // thenable on the client or it would be awaited instead of passed
+        // along by reference.
+        return undefined;
+    }
+    throw new Error(
+      // eslint-disable-next-line react-internal/safe-string-coercion
+      `Cannot access ${String(name)} on the client. ` +
+        'You cannot read a Server Reference to an object on the client. ' +
+        'You can only pass it back to the server.',
+    );
+  },
+  set: function () {
+    throw new Error(
+      'Cannot assign to a Server Reference to an object on the client.',
+    );
+  },
+};
+
+export function createOpaqueServerObjectReference(): mixed {
+  const reference = function () {
+    throw new Error(
+      'Attempted to call a Server Reference to an object from the client, ' +
+        'but it is not a function. You can only pass it back to the server.',
+    );
+  };
+  return new Proxy(reference, serverObjectReferenceProxyHandlers);
+}

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -42,6 +42,7 @@ export const disableTextareaChildren: boolean = false;
 export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableFlightWeakThenables: boolean = false;
+export const enableFlightObjectReferences: boolean = false;
 export const enableCPUSuspense: boolean = true;
 export const enableCreateEventHandleAPI: boolean = false;
 export const enableBrowserAPI: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -27,6 +27,7 @@ export const disableTextareaChildren: boolean = false;
 export const enableAsyncDebugInfo: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableFlightWeakThenables: boolean = false;
+export const enableFlightObjectReferences: boolean = false;
 export const enableCPUSuspense: boolean = false;
 export const enableCreateEventHandleAPI: boolean = false;
 export const enableBrowserAPI: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -21,6 +21,7 @@ export const enableUpdaterTracking: boolean = false;
 export const enableLegacyCache: boolean = __EXPERIMENTAL__;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableFlightWeakThenables: boolean = false;
+export const enableFlightObjectReferences: boolean = false;
 export const enableTaint: boolean = true;
 export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -22,6 +22,7 @@ export const disableTextareaChildren = false;
 export const enableAsyncDebugInfo = true;
 export const enableAsyncIterableChildren = false;
 export const enableFlightWeakThenables = false;
+export const enableFlightObjectReferences = false;
 export const enableCPUSuspense = true;
 export const enableCreateEventHandleAPI = false;
 export const enableBrowserAPI = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -21,6 +21,7 @@ export const enableUpdaterTracking: boolean = false;
 export const enableLegacyCache: boolean = true;
 export const enableAsyncIterableChildren: boolean = false;
 export const enableFlightWeakThenables: boolean = false;
+export const enableFlightObjectReferences: boolean = false;
 export const enableTaint: boolean = true;
 export const disableCommentsAsDOMContainers: boolean = true;
 export const disableInputAttributeSyncing: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -73,6 +73,7 @@ export const enableLegacyCache: boolean = true;
 
 export const enableAsyncIterableChildren: boolean = false;
 export const enableFlightWeakThenables: boolean = false;
+export const enableFlightObjectReferences: boolean = false;
 
 export const enableTaint: boolean = false;
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -592,5 +592,8 @@
   "604": "The server render could not complete because client rendering was requested outside a Suspense boundary. See this error's cause for additional details.",
   "605": "Recoverable Exception: This is not a real error! It's an implementation detail of `use` to interrupt the current render so a downstream renderer can recover it. You must either rethrow it immediately, or move the `use` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.",
   "606": "Expected a suspended recoverable. This is a bug in React. Please file an issue.",
-  "607": "This library called use() to suspend in a previous render but did not call use() when it finished. This indicates an incorrect use of use(). Learn more: https://react.dev/warnings/conditional-use-of-use"
+  "607": "This library called use() to suspend in a previous render but did not call use() when it finished. This indicates an incorrect use of use(). Learn more: https://react.dev/warnings/conditional-use-of-use",
+  "608": "Cannot access %s on the client. You cannot read a Server Reference to an object on the client. You can only pass it back to the server.",
+  "609": "Cannot assign to a Server Reference to an object on the client.",
+  "610": "Attempted to call a Server Reference to an object from the client, but it is not a function. You can only pass it back to the server."
 }

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -158,6 +158,7 @@ jest.mock('react-server/flight', () => {
     jest.mock('react-server/src/ReactFlightServerConfigBundlerCustom', () => ({
       isClientReference: config.isClientReference,
       isServerReference: config.isServerReference,
+      isServerObjectReference: config.isServerObjectReference,
       getClientReferenceKey: config.getClientReferenceKey,
       resolveClientReferenceMetadata: config.resolveClientReferenceMetadata,
     }));


### PR DESCRIPTION
Added behind a new experimental flag, `enableFlightObjectReferences`.

Extends Server References so that a reference can point to an object, not just a function. An object is registered with a new API, `registerServerObjectReference`, which tags it with its module id the same way `registerServerReference` tags a Server Function.

The client receives an opaque handle: reading a property or calling it throws, similar to how Temporary References work inside Server Functions. The only thing the client can do with the handle is pass it back to the server via a Server Function, where it resolves through the server manifest.

The motivating use case is letting a framework pass request-scoped values by reference, so it can omit them from the request body. For example, a framework could model `searchParams` as a module export whose value resolves from the current request. This avoids encoding the search params twice (they already appear in the request URL) but it also makes the responses more cacheable: if the search params don't appear elsewhere in the body, then a response cache can omit them from its cache key.

This initial PR only exposes the new API in the Turbopack bindings. We will port it to the other bundler configs if the experiment advances.
