### PR TITLE
[compiler] Recognize `eslint-disable-line` suppressions

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
@@ -86,13 +86,19 @@ export function findProgramSuppressions(
   let enableComment: t.Comment | null = null;
   let source: SuppressionSource | null = null;
 
-  let disableNextLinePattern: RegExp | null = null;
+  let disableLinePattern: RegExp | null = null;
   let disablePattern: RegExp | null = null;
   let enablePattern: RegExp | null = null;
   if (ruleNames != null && ruleNames.length !== 0) {
     const rulePattern = `(${ruleNames.join('|')})`;
-    disableNextLinePattern = new RegExp(
-      `eslint-disable-next-line ${rulePattern}`,
+    /*
+     * `eslint-disable-line` and `eslint-disable-next-line` are both single-line
+     * suppressions, so the range they describe starts and ends at the comment
+     * itself. They differ only in which line ESLint applies them to, which does
+     * not affect whether the suppression falls within a given function.
+     */
+    disableLinePattern = new RegExp(
+      `eslint-disable-(next-)?line ${rulePattern}`,
     );
     disablePattern = new RegExp(`eslint-disable ${rulePattern}`);
     enablePattern = new RegExp(`eslint-enable ${rulePattern}`);
@@ -113,8 +119,8 @@ export function findProgramSuppressions(
        * CommentLine within the block.
        */
       disableComment == null &&
-      disableNextLinePattern != null &&
-      disableNextLinePattern.test(comment.value)
+      disableLinePattern != null &&
+      disableLinePattern.test(comment.value)
     ) {
       disableComment = comment;
       enableComment = comment;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/eslintSuppression-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/eslintSuppression-test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {runBabelPluginReactCompiler} from '../Babel/RunReactCompilerBabelPlugin';
+import type {PluginOptions} from '../Entrypoint';
+
+/*
+ * The ESLint suppression bailout is only consulted when the compiler is not
+ * already validating the equivalent rules itself.
+ */
+const OPTIONS: PluginOptions = {
+  environment: {validateExhaustiveMemoizationDependencies: false},
+};
+
+function wasCompiled(source: string): boolean {
+  const result = runBabelPluginReactCompiler(
+    source,
+    'Component.jsx',
+    'typescript',
+    OPTIONS,
+  );
+  return result.code!.includes('react/compiler-runtime');
+}
+
+it('compiles a component with no suppression', () => {
+  expect(
+    wasCompiled(`
+      function Component(props) {
+        const x = [props.value];
+        return <div>{x}</div>;
+      }
+    `),
+  ).toBe(true);
+});
+
+it('skips a component with an `eslint-disable-next-line` suppression', () => {
+  expect(
+    wasCompiled(`
+      function Component(props) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        const x = [props.value];
+        return <div>{x}</div>;
+      }
+    `),
+  ).toBe(false);
+});
+
+it('skips a component with an `eslint-disable-line` suppression', () => {
+  expect(
+    wasCompiled(`
+      function Component(props) {
+        const x = [props.value]; // eslint-disable-line react-hooks/exhaustive-deps
+        return <div>{x}</div>;
+      }
+    `),
+  ).toBe(false);
+});
+
+it('skips a component with a block `eslint-disable` suppression', () => {
+  expect(
+    wasCompiled(`
+      function Component(props) {
+        /* eslint-disable react-hooks/exhaustive-deps */
+        const x = [props.value];
+        /* eslint-enable react-hooks/exhaustive-deps */
+        return <div>{x}</div>;
+      }
+    `),
+  ).toBe(false);
+});
+
+it('does not skip a component suppressing an unrelated rule', () => {
+  expect(
+    wasCompiled(`
+      function Component(props) {
+        const x = [props.value]; // eslint-disable-line no-unused-vars
+        return <div>{x}</div>;
+      }
+    `),
+  ).toBe(true);
+});


### PR DESCRIPTION
React Compiler skips optimizing a component when it finds a suppression of one of the React ESLint rules, on the reasoning that the developer has acknowledged a violation of a rule the compiler depends on. `findProgramSuppressions` (`compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts`) recognizes such a suppression by testing comments against three patterns:

```js
disableNextLinePattern = new RegExp(`eslint-disable-next-line ${rulePattern}`);
disablePattern         = new RegExp(`eslint-disable ${rulePattern}`);
enablePattern          = new RegExp(`eslint-enable ${rulePattern}`);
```

ESLint's third directive form, `eslint-disable-line`, is matched by none of them. It cannot fall through to `disablePattern` either, because that pattern requires a space immediately after `eslint-disable`, whereas the directive continues with `-line`. Two spellings of the same suppression therefore get opposite treatment:

```js
// eslint-disable-next-line react-hooks/exhaustive-deps
const x = [];                                                    // found -> component skipped

const x = []; // eslint-disable-line react-hooks/exhaustive-deps // not found -> component compiled
```

The two forms are interchangeable in ESLint and mean the same thing here, so whether the compiler skips a component should not depend on which one the developer typed. `eslint-disable-line` is also the form most likely to appear on the offending line itself. I could not find a principled distinction that would explain the omission — it reads as an oversight rather than a deliberate choice.

Note that of the two, the gap fails in the less safe direction: a component whose violation was acknowledged with `eslint-disable-line` is compiled anyway, rather than skipped.

**What this PR changes** — one regex, so that `eslint-disable-line` is handled exactly like `eslint-disable-next-line`. Both are single-line suppressions whose range begins and ends at the comment itself; they differ only in which line ESLint applies them to, which does not affect whether the suppression falls within a given function. `disableNextLinePattern` is renamed to `disableLinePattern` to match its widened meaning.

Code that does not use `eslint-disable-line` is unaffected.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Added `compiler/packages/babel-plugin-react-compiler/src/__tests__/eslintSuppression-test.ts`, covering all three directive forms plus two controls. The test sets `validateExhaustiveMemoizationDependencies: false`, since the ESLint-suppression bailout is only consulted when the compiler is not already validating the equivalent rules itself.

First, with the regex change reverted, to confirm the test actually pins the behavior — and that it pins only the intended case:

```
$ yarn jest --selectProjects main eslintSuppression

  ✓ compiles a component with no suppression
  ✓ skips a component with an `eslint-disable-next-line` suppression
  ✕ skips a component with an `eslint-disable-line` suppression
  ✓ skips a component with a block `eslint-disable` suppression
  ✓ does not skip a component suppressing an unrelated rule

  Tests: 1 failed, 4 passed, 5 total
```

Then with the change applied:

```
$ yarn jest --selectProjects main eslintSuppression

  ✓ compiles a component with no suppression
  ✓ skips a component with an `eslint-disable-next-line` suppression
  ✓ skips a component with an `eslint-disable-line` suppression
  ✓ skips a component with a block `eslint-disable` suppression
  ✓ does not skip a component suppressing an unrelated rule

  Tests: 5 passed, 5 total
```

Full package suite, lint, and formatting:

```
$ yarn jest --selectProjects main
  Test Suites: 7 passed, 7 total
  Tests:       36 passed, 36 total
  Snapshots:   8 passed, 8 total

$ yarn workspace babel-plugin-react-compiler lint
  clean

$ prettier --check <changed files>
  All matched files use Prettier code style!
```

Two caveats, for transparency:

- I was not able to run the snap fixture suite locally. No existing fixture contains an `eslint-disable-line` comment, so I do not expect any fixture output to change, but this is worth a CI confirmation.
- The change is confined to the compiler package, so I ran that package's tests rather than the root React suite.
