### PR TITLE
[DOM] Register dialog toggle events during hydration

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -3162,6 +3162,8 @@ export function hydrateProperties(
   // TODO: Make sure that we check isMounted before firing any of these events.
   switch (tag) {
     case 'dialog':
+      listenToNonDelegatedEvent('beforetoggle', domElement);
+      listenToNonDelegatedEvent('toggle', domElement);
       listenToNonDelegatedEvent('cancel', domElement);
       listenToNonDelegatedEvent('close', domElement);
       break;

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -703,6 +703,43 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
+  it('should dispatch dialog events on a hydrated dialog', async () => {
+    const container = document.createElement('div');
+    const ref = React.createRef();
+    const onBeforeToggle = jest.fn();
+    const onToggle = jest.fn();
+    const onCancel = jest.fn();
+    const onClose = jest.fn();
+    const tree = (
+      <dialog
+        ref={ref}
+        onBeforeToggle={onBeforeToggle}
+        onToggle={onToggle}
+        onCancel={onCancel}
+        onClose={onClose}
+      />
+    );
+    document.body.appendChild(container);
+    try {
+      container.innerHTML = ReactDOMServer.renderToString(tree);
+      await act(() => {
+        ReactDOMClient.hydrateRoot(container, tree);
+      });
+      await act(() => {
+        ref.current.dispatchEvent(new Event('beforetoggle', {bubbles: false}));
+        ref.current.dispatchEvent(new Event('toggle', {bubbles: false}));
+        ref.current.dispatchEvent(new Event('cancel', {bubbles: false}));
+        ref.current.dispatchEvent(new Event('close', {bubbles: false}));
+      });
+      expect(onBeforeToggle).toHaveBeenCalledTimes(1);
+      expect(onToggle).toHaveBeenCalledTimes(1);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
   it('should bubble non-native bubbling toggle events', async () => {
     const container = document.createElement('div');
     const ref = React.createRef();


### PR DESCRIPTION
## Summary

Fixes #37261.

`toggle` and `beforetoggle` are in `nonDelegatedEvents`, so React only receives them through the per-element `listenToNonDelegatedEvent` call. #32479 added those calls for `dialog` to `setInitialProperties` but not to `hydrateProperties`, so a hydrated `<dialog>` never fires `onToggle` or `onBeforeToggle` while a client-rendered one does. `onCancel` and `onClose` work in both modes, and `details` and the `popover` attribute register the same events in both paths.

This adds the two missing registrations to the hydration path.

## How did you test this change?

- Added a test that hydrates a `<dialog>` with all four handlers and dispatches the four events. It fails on `main` (`onBeforeToggle` and `onToggle` receive 0 calls) and passes with this change.
- `yarn test ReactDOMEventListener ReactDOMEventPropagation` (115 tests) — pass.
- `yarn test ReactDOMEventListener --prod` (24 tests) — pass.
- `yarn test ReactDOMServerIntegration` (1602 tests) — pass.
- `yarn test ReactDOMFizzServer` (223 tests) — pass.
- `yarn prettier`, `yarn linc`, `yarn flow dom-node` — clean.