### PR TITLE
Do not trim CSS custom property values

### DIFF
--- a/packages/react-dom-bindings/src/client/CSSPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/CSSPropertyOperations.js
@@ -38,7 +38,7 @@ export function createDangerousStringForStyles(styles) {
           if (__DEV__) {
             checkCSSPropertyStringCoercion(value, styleName);
           }
-          serialized += delimiter + styleName + ':' + ('' + value).trim();
+          serialized += delimiter + styleName + ':' + ('' + value);
         } else {
           if (
             typeof value === 'number' &&

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1315,9 +1315,7 @@ function pushStyleAttribute(
       if (__DEV__) {
         checkCSSPropertyStringCoercion(styleValue, styleName);
       }
-      valueChunk = stringToChunk(
-        escapeTextForBrowser(('' + styleValue).trim()),
-      );
+      valueChunk = stringToChunk(escapeTextForBrowser('' + styleValue));
     } else {
       if (__DEV__) {
         warnValidStyle(styleName, styleValue);

--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -69,6 +69,24 @@ describe('CSSPropertyOperations', () => {
     expect(html).toContain('"--someColor:#000000"');
   });
 
+  it('should not trim CSS custom property values', () => {
+    const styles = {
+      '--foo': ' a b ',
+    };
+    const div = <div style={styles} />;
+    const html = ReactDOMServer.renderToString(div);
+    expect(html).toContain('"--foo: a b "');
+  });
+
+  it('should not trim a CSS custom property value that is only whitespace (gh-20497)', () => {
+    const styles = {
+      '--foo': ' ',
+    };
+    const div = <div style={styles} />;
+    const html = ReactDOMServer.renderToString(div);
+    expect(html).toContain('"--foo: "');
+  });
+
   it('should set style attribute when styles exist', async () => {
     const styles = {
       backgroundColor: '#000',

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -459,6 +459,20 @@ describe('ReactDOMServerHydration', () => {
       `);
     });
 
+    // Guards that the Fizz and hydration-diff serializers stay in sync;
+    // this passes pre-fix too since both used to trim consistently.
+    // @gate __DEV__
+    it('does not warn when a CSS custom property value is only whitespace (gh-20497)', () => {
+      function Mismatch() {
+        return (
+          <div className="parent">
+            <main className="child" style={{'--foo': ' '}} />
+          </div>
+        );
+      }
+      expect(testMismatch(Mismatch)).toEqual([]);
+    });
+
     // @gate __DEV__
     it('picks the DFS-first Fiber as the error Owner', () => {
       function LeftMismatch({isClient}) {


### PR DESCRIPTION
## Summary

Partially addresses #20497 ("Bug: CSS variables can't be a space character").

React trims style values before serializing them. That is harmless for standard CSS
properties, but custom properties hold an arbitrary token stream where leading and
trailing whitespace is meaningful, so `style={{'--foo': ' '}}` was emitted as `--foo:`
(the variable effectively disappears) and `style={{'--foo': ' a b '}}` as `--foo:a b`.

The client runtime already sets custom properties untrimmed via
`style.setProperty(name, value)`, so the trimming lived only on the two serialization
paths, both changed here:

- `pushStyleAttribute` in `ReactFizzConfigDOM.js` — the SSR `style` attribute
- `createDangerousStringForStyles` in `CSSPropertyOperations.js` — the DEV-only string
  hydration diffing compares against `getAttribute('style')`

They have to move together. Fixing either one alone makes the hydration comparison
disagree with the server output, and every custom property containing whitespace
produces a spurious hydration mismatch warning. Non-custom properties keep trimming
and are unchanged.

### Scope

This fixes only the trimming asymmetry. The other case in the same issue — a custom
property set to the empty string, `style={{'--foo': ''}}` — is **not** addressed. `''`
is skipped by an earlier `continue` in both serializers alongside `null`, `undefined`
and booleans, which is separate behavior with its own back-compat question (there is
already a `// TODO: We used to set empty string as a style with an empty value. Does
that ever make sense?` next to it in `ReactFizzConfigDOM.js`). Hence "partially
addresses" rather than "fixes".

### On process

I'm opening this because @eps1lon's guidance in the issue thread was to propose the
change as a PR and let core members weigh in. That's an invitation to open the
discussion, not a sign-off on this particular approach — happy to revise or close.

## How did you test this change?

Two tests added.

**1. `CSSPropertyOperations-test.js` — SSR emission.**
`should not trim CSS custom property values` (`'--foo': ' a b '`) and
`should not trim a CSS custom property value that is only whitespace (gh-20497)`
(`'--foo': ' '`, the issue's literal repro). Both fail on `main` and pass with this
change. The existing `should trim values` test still passes, covering that normal
properties are still trimmed.

**2. `ReactDOMHydrationDiff-test.js` — client/server agreement.**
`does not warn when a CSS custom property value is only whitespace (gh-20497)` hydrates
`<main style={{'--foo': ' '}} />` and asserts no console errors. To be precise about
what this test is: it passes both before and after the fix, because before the fix both
sides trimmed consistently. It is a coupling guard, not a repro — verified it fails if
either serializer is changed without the other, in both directions. That is the
regression this PR could otherwise introduce.

Commands and results:

```
$ node ./scripts/jest/jest-cli.js CSSPropertyOperations-test ReactDOMHydrationDiff-test
Test Suites: 2 passed, 2 total
Tests:       57 passed, 57 total

$ node ./scripts/jest/jest-cli.js --release-channel=stable \
    CSSPropertyOperations-test ReactDOMHydrationDiff-test
Test Suites: 2 passed, 2 total
Tests:       57 passed, 57 total

$ yarn lint
$ yarn prettier-check
```

Lint and prettier are clean. Also confirmed the tests are not vacuous by reverting the
source change: with both serializers reverted the two `CSSPropertyOperations` tests fail;
with exactly one reverted the hydration test fails.
