### PR TITLE
[compiler] Preserve named exports for gated hoisted functions

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -22,6 +22,7 @@ use react_compiler_ast::common::BaseNode;
 use react_compiler_ast::declarations::Declaration;
 use react_compiler_ast::declarations::ExportDefaultDecl;
 use react_compiler_ast::declarations::ExportDefaultDeclaration;
+use react_compiler_ast::declarations::ExportNamedDeclaration;
 use react_compiler_ast::declarations::ImportSpecifier;
 use react_compiler_ast::declarations::ModuleExportName;
 use react_compiler_ast::expressions::*;
@@ -2077,6 +2078,18 @@ struct CompiledFnForReplacement {
     gating: Option<GatingConfig>,
 }
 
+/// Get the function declaration of a top level statement, unwrapping `export function f() {}`.
+fn as_function_declaration(stmt: &Statement) -> Option<&FunctionDeclaration> {
+    match stmt {
+        Statement::FunctionDeclaration(f) => Some(f),
+        Statement::ExportNamedDeclaration(export) => match export.declaration.as_deref() {
+            Some(Declaration::FunctionDeclaration(f)) => Some(f),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Check if a compiled function is referenced before its declaration at the top level.
 /// This is needed for the gating rewrite: hoisted function declarations that are
 /// referenced before their declaration site need a special gating pattern.
@@ -2106,7 +2119,7 @@ fn get_functions_referenced_before_declaration(
     // any of the function names before the function's declaration.
     for stmt in &program.body {
         // Check if this statement IS one of the function declarations
-        if let Statement::FunctionDeclaration(f) = stmt {
+        if let Some(f) = as_function_declaration(stmt) {
             if let Some(ref id) = f.id {
                 fn_names.remove(&id.name);
             }
@@ -3001,12 +3014,14 @@ fn apply_gated_function_hoisted(
     // Find the original function declaration and determine its params
     let mut original_params: Vec<PatternLike> = Vec::new();
     let mut fn_stmt_idx: Option<usize> = None;
+    let mut is_named_export = false;
 
     for (idx, stmt) in program.body.iter().enumerate() {
-        if let Statement::FunctionDeclaration(f) = stmt {
+        if let Some(f) = as_function_declaration(stmt) {
             if f.base.node_id == Some(node_id) {
                 original_params = f.params.clone();
                 fn_stmt_idx = Some(idx);
+                is_named_export = matches!(stmt, Statement::ExportNamedDeclaration(_));
                 break;
             }
         }
@@ -3016,6 +3031,13 @@ fn apply_gated_function_hoisted(
         Some(idx) => idx,
         None => return,
     };
+
+    // The dispatcher keeps the public name, so the export moves onto it instead
+    if is_named_export {
+        if let Some(f) = as_function_declaration(&program.body[fn_idx]).cloned() {
+            program.body[fn_idx] = Statement::FunctionDeclaration(f);
+        }
+    }
 
     // Rename the original function to `_unoptimized`
     if let Statement::FunctionDeclaration(f) = &mut program.body[fn_idx] {
@@ -3153,7 +3175,7 @@ fn apply_gated_function_hoisted(
     //   if (gating_result) return Foo_optimized(arg0, ...);
     //   else return Foo_unoptimized(arg0, ...);
     // }
-    let dispatcher_fn = Statement::FunctionDeclaration(FunctionDeclaration {
+    let dispatcher_fn_decl = FunctionDeclaration {
         base: BaseNode::typed("FunctionDeclaration"),
         id: Some(Identifier {
             base: BaseNode::typed("Identifier"),
@@ -3219,7 +3241,22 @@ fn apply_gated_function_hoisted(
         predicate: None,
         component_declaration: false,
         hook_declaration: false,
-    });
+    };
+    let dispatcher_fn = if is_named_export {
+        Statement::ExportNamedDeclaration(ExportNamedDeclaration {
+            base: BaseNode::typed("ExportNamedDeclaration"),
+            declaration: Some(Box::new(Declaration::FunctionDeclaration(
+                dispatcher_fn_decl,
+            ))),
+            specifiers: vec![],
+            source: None,
+            export_kind: None,
+            assertions: None,
+            attributes: None,
+        })
+    } else {
+        Statement::FunctionDeclaration(dispatcher_fn_decl)
+    };
 
     // Insert nodes. The TS code uses insertBefore for the gating result and optimized fn,
     // and insertAfter for the dispatcher. The order in the output should be:

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
@@ -90,29 +90,33 @@ function insertAdditionalFunctionDeclaration(
       genNewArgs.push(() => t.identifier(argName));
     }
   }
-  // insertAfter called in reverse order of how nodes should appear in program
-  fnPath.insertAfter(
-    t.functionDeclaration(
-      originalFnName,
-      newParams,
-      t.blockStatement([
-        t.ifStatement(
-          gatingCondition,
-          t.returnStatement(
-            t.callExpression(
-              compiled.id,
-              genNewArgs.map(fn => fn()),
-            ),
-          ),
-          t.returnStatement(
-            t.callExpression(
-              unoptimizedFnName,
-              genNewArgs.map(fn => fn()),
-            ),
+  const gatedFn = t.functionDeclaration(
+    originalFnName,
+    newParams,
+    t.blockStatement([
+      t.ifStatement(
+        gatingCondition,
+        t.returnStatement(
+          t.callExpression(
+            compiled.id,
+            genNewArgs.map(fn => fn()),
           ),
         ),
-      ]),
-    ),
+        t.returnStatement(
+          t.callExpression(
+            unoptimizedFnName,
+            genNewArgs.map(fn => fn()),
+          ),
+        ),
+      ),
+    ]),
+  );
+  const exportPath = fnPath.parentPath.isExportNamedDeclaration()
+    ? fnPath.parentPath
+    : null;
+  // insertAfter called in reverse order of how nodes should appear in program
+  fnPath.insertAfter(
+    exportPath != null ? t.exportNamedDeclaration(gatedFn) : gatedFn,
   );
   fnPath.insertBefore(
     t.variableDeclaration('const', [
@@ -123,6 +127,9 @@ function insertAdditionalFunctionDeclaration(
     ]),
   );
   fnPath.insertBefore(compiled);
+  if (exportPath != null) {
+    exportPath.replaceWith(fnPath.node);
+  }
 }
 export function insertGatedFunctionDeclaration(
   fnPath: NodePath<

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-export.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-export.expect.md
@@ -1,0 +1,64 @@
+
+## Input
+
+```javascript
+// @gating
+import {memo} from 'react';
+import {Stringify} from 'shared-runtime';
+
+export const Memoized = memo(Foo);
+export function Foo({prop1, prop2}) {
+  'use memo';
+  return <Stringify prop1={prop1} prop2={prop2} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('Foo'),
+  params: [{prop1: 1, prop2: 2}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating
+import { memo } from "react";
+import { Stringify } from "shared-runtime";
+
+export const Memoized = memo(Foo);
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
+function Foo_optimized(t0) {
+  "use memo";
+  const $ = _c(3);
+  const { prop1, prop2 } = t0;
+  let t1;
+  if ($[0] !== prop1 || $[1] !== prop2) {
+    t1 = <Stringify prop1={prop1} prop2={prop2} />;
+    $[0] = prop1;
+    $[1] = prop2;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  return t1;
+}
+function Foo_unoptimized({ prop1, prop2 }) {
+  "use memo";
+  return <Stringify prop1={prop1} prop2={prop2} />;
+}
+export function Foo(arg0) {
+  if (isForgetEnabled_Fixtures_result) return Foo_optimized(arg0);
+  else return Foo_unoptimized(arg0);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval("Foo"),
+  params: [{ prop1: 1, prop2: 2 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"prop1":1,"prop2":2}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-export.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-export.js
@@ -1,0 +1,14 @@
+// @gating
+import {memo} from 'react';
+import {Stringify} from 'shared-runtime';
+
+export const Memoized = memo(Foo);
+export function Foo({prop1, prop2}) {
+  'use memo';
+  return <Stringify prop1={prop1} prop2={prop2} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('Foo'),
+  params: [{prop1: 1, prop2: 2}],
+};


### PR DESCRIPTION
## Summary

With gating enabled, a function declaration that is referenced before its declaration site gets renamed to `Foo_unoptimized`, and a fresh `Foo` wrapper is inserted after it to pick between the two implementations. When the declaration was written as `export function Foo`, the rename carried the export along with it, so the module exported `Foo_unoptimized` and no longer exported `Foo` at all. Importers of the public name then failed module linking before the runtime gate ever ran. The export now moves onto the wrapper. TypeScript overload signatures hit the same path, since they count as a reference ahead of the implementation.

The Rust port needed the same treatment, plus one extra fix: it only looked for a bare `FunctionDeclaration` at the top level, so it never found one wrapped in an export and silently skipped gating for it.

Fixes #37265

## How did you test this change?

Added a gating fixture for the case, which reproduces the dropped export on `main`. `yarn snap`, `yarn snap --rust`, `yarn workspace babel-plugin-react-compiler jest`, `scripts/test-babel-ast.sh` and `scripts/test-rust-port.sh` all pass locally.