### PR TITLE
[DevTools] Don't assert on child order changes below a filtered bailout

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -572,6 +572,78 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 19.0
+  it('stays in sync when a filtered boundary suspends during a sibling restructure', async () => {
+    const neverResolves = new Promise(() => {});
+
+    function Reader() {
+      React.use(neverResolves);
+      return <div>read</div>;
+    }
+
+    function A({collapsed}) {
+      if (collapsed) {
+        return (
+          <React.Suspense fallback={<div>a-fb</div>}>
+            <Reader />
+          </React.Suspense>
+        );
+      }
+      return (
+        <React.Suspense fallback={<div>a-outer-fb</div>}>
+          <React.Suspense fallback={<div>a-inner-fb</div>}>
+            <Reader />
+          </React.Suspense>
+          <React.Suspense fallback={<div>a-sib-fb</div>}>
+            <div>a-sibling</div>
+          </React.Suspense>
+        </React.Suspense>
+      );
+    }
+
+    function App({collapsed, extra}) {
+      return (
+        <div>
+          {extra ? <em key="s">side</em> : null}
+          <A key="a" collapsed={collapsed} />
+        </div>
+      );
+    }
+
+    store.componentFilters = [
+      utils.createElementTypeFilter(Types.ElementTypeSuspense),
+    ];
+
+    await actAsync(() => render(<App collapsed={false} extra={false} />));
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <div>
+            ▾ <A key="a">
+                <div>
+                <div>
+    `);
+
+    await actAsync(() => render(<App collapsed={true} extra={true} />));
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <div>
+              <em key="s">
+            ▾ <A key="a">
+                <div>
+    `);
+
+    await actAsync(() => render(<App collapsed={true} extra={false} />));
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <div>
+            ▾ <A key="a">
+                <div>
+    `);
+  });
+
   describe('inline errors and warnings', () => {
     const {render: legacyRender} = getLegacyRenderImplementation();
 

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -4755,19 +4755,13 @@ export function attach(
               }
             }
           } else {
-            const childrenUpdateFlags = updateChildrenRecursively(
+            // If this fiber is filtered there might be changes to this set elsewhere so we have
+            // to visit each child to place it back in the set. We let the child bail out instead.
+            updateFlags |= updateChildrenRecursively(
               nextFiber.child,
               prevFiber.child,
               false,
             );
-            // If this fiber is filtered there might be changes to this set elsewhere so we have
-            // to visit each child to place it back in the set. We let the child bail out instead.
-            if ((childrenUpdateFlags & ShouldResetChildren) !== NoUpdate) {
-              throw new Error(
-                'The children should not have changed if we pass in the same set.',
-              );
-            }
-            updateFlags |= childrenUpdateFlags;
           }
         }
       }


### PR DESCRIPTION
**Setup**

- Component filter: `<Suspense>` hidden, host elements visible.
- `Reader` calls `use()` on a promise that never resolves, so any boundary
  containing it shows its fallback.

```jsx
<div>
  {extra ? <em key="s">side</em> : null}
  <A key="a" collapsed={collapsed} />
</div>
```

```jsx
// A collapsed={false}                    // A collapsed={true}
<Suspense fallback="a-outer-fb">          <Suspense fallback="a-fb">
  <Suspense fallback="a-inner-fb">          <Reader />
    <Reader />                            </Suspense>
  </Suspense>
  <Suspense fallback="a-sib-fb">
    <div>a-sibling</div>
  </Suspense>
</Suspense>
```

---

## Commit 1 — `collapsed={false} extra={false}`

React. A `<Suspense>` renders its content into an `Offscreen`; when it suspends,
the fallback is added as a **sibling** of that `Offscreen` and the content is
hidden rather than unmounted.

```
<div>
└── <A key="a">
    └── Suspense·outer                          not suspended
        └── Offscreen                           visible
            ├── Suspense·inner                  SUSPENDED
            │   ├── Offscreen                   hidden
            │   │   └── <Reader>                still mounted
            │   └── <div>a-inner-fb</div>       fallback
            └── Suspense·sib                    not suspended
                └── Offscreen                   visible
                    └── <div>a-sibling</div>
```

Store. `Suspense` and `Offscreen` are filtered, so surviving descendants hoist to
the nearest visible ancestor, `<A>`.

```
[root]
└── <App>
    └── <div>
        └── <A key="a">
            ├── <div>          a-inner-fb
            └── <div>          a-sibling
```

Identical before and after the fix.

---

## Commit 2 — `collapsed={true} extra={true}`

Two changes land in one commit: `<em>` mounts, and `A` restructures so that
`Suspense·outer` now directly contains `<Reader>` and therefore suspends.

React, after the commit:

```
<div>
├── <em key="s">                               NEW, id 7
└── <A key="a">
    └── Suspense·outer                         now SUSPENDED
        ├── Offscreen                          hidden
        │   └── <Reader>
        └── <div>a-fb</div>                    fallback
```

While reconciling, DevTools reaches the `Offscreen` of the outgoing
`Suspense·sib`. React handed that node back with its child pointer untouched, so
DevTools takes its "children unchanged" shortcut — but the walk beneath reports
that the panel's rows changed, because the subtree around it was restructured:

```
Offscreen (of Suspense·sib)     ← filtered, so it has no Store row of its own
    sameChildPtr = true         ← locally nothing changed
    flagSet      = true         ← the panel's rows did change
        └── throw "The children should not have changed if we pass in the same set."
```

React catches whatever DevTools throws and logs it at most once, so the app is
unaffected and nothing surfaces. But `flushPendingEvents` never runs, and the
`add <em id=7>` recorded earlier in this same commit is left unsent in
`pendingOperations`.

Store — **before the fix** (unchanged from commit 1, now stale):

```
[root]
└── <App>
    └── <div>
        └── <A key="a">
            ├── <div>          stale, no longer exists
            └── <div>          stale, no longer exists
                               <em> never arrived
```

Store — **after the fix**:

```
[root]
└── <App>
    └── <div>
        ├── <em key="s">
        └── <A key="a">
            └── <div>          a-fb
```

---

## Commit 3 — `collapsed={true} extra={false}`

`<em>` unmounts. This commit walks cleanly and does flush — but the batch still
carries commit 2's leftovers, and `flushPendingEvents` writes **all removals to
the front**, ahead of everything else:

```
[ remove <div> ][ remove <div> ][ remove <em id=7> ]   ← hoisted to the front
[ add <em id=7> ][ add <div>a-fb ]                     ← never reached
```

The Store applies the two removals, then hits a removal for id 7 — a node it was
never told about — throws, and abandons the rest of the array.

Store — **before the fix**:

```
[root]
└── <App>
    └── <div>
        └── <A key="a">        children removed, nothing added back
```

```
Cannot remove node "7" because no matching node was found in the Store.
```

From here the Store never applies another operation.

Store — **after the fix**:

```
[root]
└── <App>
    └── <div>
        └── <A key="a">
            └── <div>          a-fb
```

---

## Why the check was wrong

Suspending **hides** content instead of unmounting it, so state survives a
reveal. That means React can reuse every fiber while the set of rows the panel
should display changes completely. `nextFiber.child === prevFiber.child` is a
fact about one link; it says nothing about the subtree below it.

The deleted assertion read that local fact as proof of a global one:

| what the code knew            | what it concluded              |
| ----------------------------- | ------------------------------ |
| React reused the same objects | the panel shows the same rows  |

Those come apart precisely when a `Suspense` or `Activity` boundary changes
visibility — which is the one case this branch had to handle.

The fix lets the "rows changed" signal propagate to the closest unfiltered
ancestor, which re-sends its child list. That is the path the surrounding code
already uses; twenty lines below the assertion there is a branch whose only
purpose is to forward this flag from a filtered fiber.
