### PR TITLE
[DevTools] Only report instances the frontend knows about in a reorder

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -644,6 +644,81 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 19.0
+  it('stays in sync when filtered boundaries suspend inside a hidden Activity', async () => {
+    const Activity = React.Activity || React.unstable_Activity;
+    const neverResolves = new Promise(() => {});
+
+    function Gate({blocked}) {
+      if (blocked) {
+        React.use(neverResolves);
+      }
+      return <span>content</span>;
+    }
+
+    function Fallback({label}) {
+      return <span>{label}</span>;
+    }
+
+    function App({hidden, first, second}) {
+      return (
+        <Activity mode={hidden ? 'hidden' : 'visible'}>
+          <React.Suspense fallback={<Fallback label="first" />}>
+            <Gate blocked={first} />
+          </React.Suspense>
+          <React.Suspense fallback={<Fallback label="second" />}>
+            <Gate blocked={second} />
+          </React.Suspense>
+        </Activity>
+      );
+    }
+
+    store.componentFilters = [
+      utils.createElementTypeFilter(Types.ElementTypeSuspense),
+    ];
+
+    await actAsync(() =>
+      render(<App hidden={false} first={false} second={false} />),
+    );
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <Activity mode="visible">
+            ▾ <Gate>
+                <span>
+            ▾ <Gate>
+                <span>
+    `);
+
+    await actAsync(() =>
+      render(<App hidden={true} first={true} second={true} />),
+    );
+    const activity = store.getElementAtIndex(1);
+    await actAsync(() => store.toggleIsCollapsed(activity.id, false));
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <Activity mode="hidden">
+            ▾ <Fallback>
+                <span>
+            ▾ <Fallback>
+                <span>
+    `);
+
+    await actAsync(() =>
+      render(<App hidden={true} first={true} second={false} />),
+    );
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <Activity mode="hidden">
+            ▾ <Fallback>
+                <span>
+            ▾ <Gate>
+                <span>
+    `);
+  });
+
   describe('inline errors and warnings', () => {
     const {render: legacyRender} = getLegacyRenderImplementation();
 

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -205,6 +205,7 @@ function createFiberInstance(fiber: Fiber): FiberInstance {
     treeBaseDuration: 0,
     suspendedBy: null,
     suspenseNode: null,
+    connected: false,
     data: fiber,
   };
 }
@@ -222,6 +223,7 @@ function createFilteredFiberInstance(fiber: Fiber): FilteredFiberInstance {
     treeBaseDuration: 0,
     suspendedBy: null,
     suspenseNode: null,
+    connected: false,
     data: fiber,
   } as any;
 }
@@ -240,6 +242,7 @@ function createVirtualInstance(
     treeBaseDuration: 0,
     suspendedBy: null,
     suspenseNode: null,
+    connected: false,
     data: debugEntry,
   };
 }
@@ -1736,6 +1739,7 @@ export function attach(
       // We're disconnected. We'll reconnect a hidden mount after the parent reappears.
       return;
     }
+    fiberInstance.connected = true;
     const id = fiberInstance.id;
     const fiber = fiberInstance.data;
 
@@ -1917,6 +1921,7 @@ export function attach(
       // We're disconnected. We'll reconnect a hidden mount after the parent reappears.
       return;
     }
+    instance.connected = true;
     const componentInfo = instance.data;
 
     const key =
@@ -2086,6 +2091,7 @@ export function attach(
       setTrackedPath(null);
     }
 
+    fiberInstance.connected = false;
     const id = fiberInstance.id;
     pendingRealUnmountedIDs.push(id);
   }
@@ -2815,6 +2821,7 @@ export function attach(
       setTrackedPath(null);
     }
 
+    instance.connected = false;
     const id = instance.id;
     pendingRealUnmountedIDs.push(id);
   }
@@ -3820,7 +3827,7 @@ export function attach(
         } else {
           addUnfilteredChildrenIDs(child, nextChildren);
         }
-      } else {
+      } else if (child.connected) {
         nextChildren.push(child.id);
       }
       child = child.nextSibling;

--- a/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberTypes.js
+++ b/packages/react-devtools-shared/src/backend/fiber/shared/DevToolsFiberTypes.js
@@ -34,6 +34,7 @@ export type FiberInstance = {
   treeBaseDuration: number, // the profiled time of the last render of this subtree
   suspendedBy: null | Array<ReactAsyncInfo>, // things that suspended in the children position of this component
   suspenseNode: null | SuspenseNode,
+  connected: boolean, // whether the frontend has been told about this instance
   data: Fiber, // one of a Fiber pair
 };
 
@@ -50,6 +51,7 @@ export type FilteredFiberInstance = {
   treeBaseDuration: number, // the profiled time of the last render of this subtree
   suspendedBy: null | Array<ReactAsyncInfo>, // only used at the root
   suspenseNode: null | SuspenseNode,
+  connected: boolean, // always false here.
   data: Fiber, // one of a Fiber pair
 };
 
@@ -69,6 +71,7 @@ export type VirtualInstance = {
   treeBaseDuration: number, // the profiled time of the last render of this subtree
   suspendedBy: null | Array<ReactAsyncInfo>, // things that blocked the server component's child from rendering
   suspenseNode: null,
+  connected: boolean, // whether the frontend has been told about this instance
   // The latest info for this instance. This can be updated over time and the
   // same info can appear in more than once ServerComponentInstance.
   data: ReactComponentInfo,


### PR DESCRIPTION
**Setup**

Targets `main`. The previous stack base (#37280) was superseded by #37475.

Stack: this PR → #37282 → #37283.

- Component filter: `<Suspense>` hidden, host elements visible.
- `Gate` calls `use()` when `blocked`, so that boundary shows its fallback.
- Hidden `<Activity>` still appears in the tree; its children stay linked on the backend.

```jsx
<Activity mode={hidden ? 'hidden' : 'visible'}>
  <Suspense fallback={<Fallback label="first" />}>
    <Gate blocked={first} />
  </Suspense>
  <Suspense fallback={<Fallback label="second" />}>
    <Gate blocked={second} />
  </Suspense>
</Activity>
```

---

## Commit 1 — `hidden={false} first={false} second={false}`

Both boundaries resolve. `Suspense` / `Offscreen` are filtered, so the Gates hoist to `<Activity>`.

```
[root]
└── <App>
    └── <Activity mode="visible">
        ├── <Gate>
        │   └── <span>
        └── <Gate>
            └── <span>
```

Identical before and after the fix.

---

## Commit 2 — `hidden={true} first={true} second={true}`

Activity hides and both boundaries suspend in one commit. Each Suspense keeps its `Gate` on a **hidden Offscreen** (disconnected: linked on the backend, not sent to the frontend) and mounts a `Fallback` beside it.

React, after the commit:

```
Activity                                          hidden, still in the tree
├── Suspense·first                                SUSPENDED
│   ├── Offscreen                                 hidden, disconnected
│   │   └── <Gate>                                still mounted
│   └── <Fallback>first</Fallback>
└── Suspense·second                               SUSPENDED
    ├── Offscreen                                 hidden, disconnected
    │   └── <Gate>
    └── <Fallback>second</Fallback>
```

`recordResetChildren` then walks Activity's descendants to rebuild the visible child list. Hidden Offscreen is skipped, but anything that mounted or stayed linked **while `isInDisconnectedSubtree`** can still sit in that walk as a real `FiberInstance` — with an id the frontend never received.

```
addUnfilteredChildrenIDs
    Fallback first          connected, sent     ← ok
    Fallback second         connected, sent     ← ok
    Gate (disconnected)     never sent          ← included anyway
        └── TREE_OPERATION_REORDER_CHILDREN names an unknown id
```

`flushPendingEvents` puts removals first. The Store applies those, then hits a reorder (or a leftover remove) for an id it was never told about, throws, and stops applying operations.

Store — **before the fix**:

```
Cannot reorder children for node "…" because no matching node was found in the Store.
```

or a remove of an id that never arrived. From here the Store never applies another operation.

Store — **after the fix** (hidden Activity is collapsed by default; expanded here):

```
[root]
└── <App>
    └── <Activity mode="hidden">
        ├── <Fallback>     first
        │   └── <span>
        └── <Fallback>     second
            └── <span>
```

---

## Commit 3 — `hidden={true} first={true} second={false}`

The second boundary reveals. That `Gate` reconnects and should replace the second fallback. The first `Gate` is still disconnected under the hidden Offscreen.

Without `connected`, the reset child list can name the first `Gate` again — an id the frontend does not have. With it, only the rows that were actually sent are reordered.

Store — **after the fix**:

```
[root]
└── <App>
    └── <Activity mode="hidden">
        ├── <Fallback>     first
        │   └── <span>
        └── <Gate>
            └── <span>
```

---

## Why the walk was wrong

"In the backend sibling list" is not "the frontend has a row for this id".

`recordReconnect` is what pushes `TREE_OPERATION_ADD`. When `isInDisconnectedSubtree` is set — a suspending Suspense's hidden Offscreen — that function returns before the add, and the instance stays linked so it can be reconnected later. Hidden Activity still walks those descendants (plain Offscreen does not).

The old walk treated every non-filtered instance as a Store row:

| what the code knew                    | what it concluded                 |
| ------------------------------------- | --------------------------------- |
| this instance is in the sibling list  | the panel has a row with this id  |

Those come apart for the one case this walk had to handle: a child that is mounted, filtered-through, and **not yet connected**.

The fix records that fact on the instance (`connected = true` only after we tell the frontend, `false` after we disconnect) and omits the others from the reorder. Removals already go out through `pendingRealUnmountedIDs`; the two lists now agree.