### PR TITLE
[DevTools] Don't focus an Activity slice the frontend cannot see

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -1076,4 +1076,112 @@ describe('Store component filters', () => {
           <Suspense name="Page" uniqueSuspenders={true} rects={[{x:1,y:2,width:9,height:1}]}>
     `);
   });
+
+  // @reactVersion >= 19.0
+  it('stays in sync when a slice is focused as its boundary suspends', async () => {
+    const Activity = React.Activity || React.unstable_Activity;
+    const neverResolves = new Promise(() => {});
+
+    function Reader() {
+      React.use(neverResolves);
+      return <div>read</div>;
+    }
+
+    function App({suspend}) {
+      return (
+        <div>
+          <React.Suspense fallback={<div>fallback</div>}>
+            {suspend ? <Reader /> : null}
+            <Activity name="target" mode="visible">
+              <span>inside</span>
+            </Activity>
+          </React.Suspense>
+        </div>
+      );
+    }
+
+    store.componentFilters = [
+      utils.createElementTypeFilter(Types.ElementTypeHostComponent),
+    ];
+
+    await actAsync(() => render(<App suspend={false} />));
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <Suspense>
+              <Activity name="target" mode="visible">
+      [suspense-root]  rects={[{x:1,y:2,width:6,height:1}]}
+        <Suspense name="App" uniqueSuspenders={false} rects={[{x:1,y:2,width:6,height:1}]}>
+    `);
+
+    // Indices 0, 1, 2 are App, Suspense, Activity.
+    const activity = store.getElementAtIndex(2);
+
+    // Focusing the Activity is what the Suspense tab does with the id it read
+    // out of the tree; here the app suspends the boundary in the same commit.
+    await actAsync(() => {
+      render(<App suspend={true} />);
+      store.componentFilters = [utils.createActivitySliceFilter(activity.id)];
+    });
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <App>
+          ▾ <div>
+            ▾ <Suspense>
+                <div>
+      [suspense-root]  rects={[{x:1,y:2,width:8,height:1}]}
+        <Suspense name="App" uniqueSuspenders={true} rects={[{x:1,y:2,width:8,height:1}]}>
+    `);
+  });
+
+  // @reactVersion >= 19.0
+  it('stays in sync when the slice is focused before the boundary suspends', async () => {
+    const Activity = React.Activity || React.unstable_Activity;
+    const neverResolves = new Promise(() => {});
+
+    function Reader() {
+      React.use(neverResolves);
+      return <div>read</div>;
+    }
+
+    function App({suspend}) {
+      return (
+        <div>
+          <React.Suspense fallback={<div>fallback</div>}>
+            {suspend ? <Reader /> : null}
+            <Activity name="target" mode="visible">
+              <span>inside</span>
+            </Activity>
+          </React.Suspense>
+        </div>
+      );
+    }
+
+    store.componentFilters = [
+      utils.createElementTypeFilter(Types.ElementTypeHostComponent),
+    ];
+
+    await actAsync(() => render(<App suspend={false} />));
+    const activity = store.getElementAtIndex(2);
+
+    await actAsync(() => {
+      store.componentFilters = [utils.createActivitySliceFilter(activity.id)];
+    });
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <Activity name="target" mode="visible">
+            <span>
+      [suspense-root]  rects={[{x:1,y:2,width:6,height:1}]}
+        <Suspense name="Unknown" uniqueSuspenders={false} rects={[{x:1,y:2,width:6,height:1}]}>
+    `);
+
+    await actAsync(() => render(<App suspend={true} />));
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <Activity name="target" mode="visible">
+            <span>
+      [suspense-root]  rects={[{x:1,y:2,width:8,height:1}]}
+        <Suspense name="Unknown" uniqueSuspenders={true} rects={[{x:1,y:2,width:8,height:1}]}>
+    `);
+  });
 });

--- a/packages/react-devtools-shared/src/backend/fiber/renderer.js
+++ b/packages/react-devtools-shared/src/backend/fiber/renderer.js
@@ -906,7 +906,11 @@ export function attach(
       if (filter.type === ComponentFilterActivitySlice && filter.isEnabled) {
         focusedActivityFilter = filter;
         const instance = idToDevToolsInstanceMap.get(filter.activityID);
-        if (instance !== undefined && instance.kind === FIBER_INSTANCE) {
+        if (
+          instance !== undefined &&
+          instance.kind === FIBER_INSTANCE &&
+          instance.connected
+        ) {
           nextFocusedActivity = instance.data;
         }
       }


### PR DESCRIPTION
**Setup**

Depends on #37281.

Stack: #37281 → this PR → #37283.

- Starts with host elements filtered. Applying the Activity-slice filter replaces that list, so hosts show up again if the slice is not applied.
- `Reader` calls `use()` on a promise that never resolves.
- Focusing an Activity is what the Suspense tab does with the id it just read out of the tree.

```jsx
<div>
  <Suspense fallback={<div>fallback</div>}>
    {suspend ? <Reader /> : null}
    <Activity name="target" mode="visible">
      <span>inside</span>
    </Activity>
  </Suspense>
</div>
```

`App`, `Suspense`, `Activity` sit at indices 0, 1, 2.

---

## Commit 1 — render `suspend={false}`

Nothing is suspended. The Activity is in the tree and has been sent to the frontend (`connected`). Hosts are still filtered.

```
[root]
└── <App>
    └── <Suspense>
        └── <Activity name="target">
```

---

## Commit 2 — suspend and focus the slice in the **same** commit

```js
render(<App suspend={true} />);
store.componentFilters = [createActivitySliceFilter(activity.id)];
```

In tests the React commit runs first. The parent `Suspense` hides its Offscreen, `recordDisconnect` runs, and `connected` is already false when filters apply.

Applying a filter remounts every root. The lookup used to take any `FIBER_INSTANCE` for that id. That fiber still exists on the backend, but it will remount **inside the hidden Offscreen** and never get `TREE_OPERATION_ADD`.

The mount path then did this anyway:

```
isFocusedActivityEntry = true
    push TREE_OPERATION_APPLIED_ACTIVITY_SLICE_CHANGE
    push newInstance.id          ← frontend has no row for this id
```

Store — **before the fix**:

```
Next Activity slice not found in Store.
```

Store — **after the fix**:

Do not apply the slice unless the instance is already `connected`. Remount is a normal tree. The `0` sent before remount already means the slice is off.

```
[root]
└── <App>
    └── <div>
        └── <Suspense>
            └── <div>          fallback
```

---

## The other order — focus first, then suspend

The Activity is connected when the filter is applied, so the slice focuses for real. If the parent later suspends, that is a later disconnect, not this lookup.

---

## Why sending the id was wrong

"We have a backend instance for the focused fiber" is not "the frontend has a row for this id".

If the Activity is not connected, skip the slice. Do not advertise an id the frontend never received.