### PR TITLE
[DevTools] Stop collapse weight deltas at a collapsed ancestor

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1548,6 +1548,66 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 19.0
+    it('should not change the element count when collapsing inside a collapsed subtree', async () => {
+      function Leaf() {
+        return <span>leaf</span>;
+      }
+      function Middle() {
+        return (
+          <div>
+            <Leaf />
+            <Leaf />
+          </div>
+        );
+      }
+      function Outer() {
+        return <Middle />;
+      }
+      function App() {
+        return <Outer />;
+      }
+
+      await actAsync(() => render(<App />));
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+          ▾ <App>
+            ▾ <Outer>
+              ▾ <Middle>
+                  <Leaf>
+                  <Leaf>
+      `);
+
+      const outer = store.getElementAtIndex(1);
+      const middle = store.getElementAtIndex(2);
+
+      await act(() => store.toggleIsCollapsed(outer.id, true));
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+          ▾ <App>
+            ▸ <Outer>
+      `);
+
+      await act(() => store.toggleIsCollapsed(middle.id, true));
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+          ▾ <App>
+            ▸ <Outer>
+      `);
+      expect(store.numElements).toBe(2);
+
+      await act(() => store.toggleIsCollapsed(middle.id, false));
+      await act(() => store.toggleIsCollapsed(outer.id, false));
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+          ▾ <App>
+            ▾ <Outer>
+              ▾ <Middle>
+                  <Leaf>
+                  <Leaf>
+      `);
+    });
+
     // @reactVersion >= 18.0
     it('should support reordering of children', async () => {
       const Root = ({children}) => children;

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1328,9 +1328,12 @@ export default class Store extends EventEmitter<{
 
           let parentElement = this._idToElement.get(element.parentID);
           while (parentElement !== undefined) {
-            // We don't need to break on a collapsed parent in the same way as the expand case below.
-            // That's because collapsing a node doesn't "bubble" and affect its parents.
             parentElement.weight += weightDelta;
+            if (parentElement.isCollapsed) {
+              // A collapsed parent already contributes a weight of 1 to its own
+              // parent, so the delta must not bubble past it.
+              break;
+            }
             parentElement = this._idToElement.get(parentElement.parentID);
           }
         }
@@ -2388,6 +2391,9 @@ export default class Store extends EventEmitter<{
         let parentElement = this._idToElement.get(element.parentID);
         while (parentElement !== undefined) {
           parentElement.weight += weightDelta;
+          if (parentElement.isCollapsed) {
+            break;
+          }
           parentElement = this._idToElement.get(parentElement.parentID);
         }
         return true;


### PR DESCRIPTION
**Setup**

Depends on #37282.

Stack: #37281 → #37282 → this PR.

- Default component filters: host elements hidden.
- `numElements` is the sum of each root's `weight`. A collapsed node still has a full subtree weight, but it **contributes 1** to its parent.

```jsx
function App() {
  return (
    <Outer>
      <Middle>
        <Leaf />
        <Leaf />
      </Middle>
    </Outer>
  );
}
```

```
[root]
└── <App>                          weight 5, contributes 5
    └── <Outer>                    weight 4, contributes 4
        └── <Middle>               weight 3, contributes 3
            ├── <Leaf>             weight 1
            └── <Leaf>             weight 1
```

---

## Commit 1 — collapse `<Outer>`

`weightDelta = 1 - 4 = -3`. The delta bubbles to `<App>` and the root.

```
[root]
└── <App>                          weight 2
    └── ▸ <Outer>                  weight 4, contributes 1
```

`numElements === 2`. Identical before and after the fix.

---

## Commit 2 — collapse `<Middle>` while `<Outer>` is already collapsed

`Middle` is not on screen. Collapsing it still changes *its* contribution to `Outer`:

```
weightDelta = 1 - 3 = -2
Outer.weight  4 + (-2) = 2        ← correct, Middle now contributes 1
```

A collapsed parent already contributes **1** to *its* parent, regardless of what happens inside. The delta must stop at `Outer`.

The collapse path did not stop. The deleted comment said it did not need to — "collapsing a node doesn't bubble and affect its parents":

```
Outer.weight += -2
App.weight   += -2                ← wrong, Outer still contributes 1
    └── numElements becomes 0
```

Store — **before the fix**:

```
[root]                             weight 0, no rows
                                   <App> and <Outer> are still in the map
```

`toggleIsCollapsed` then calls `_recalculateWeightAcrossRoots`, so `numElements` follows the corrupted root weight. The nodes are still there; the panel thinks the tree is empty.

The same loop lives in `_collapseActivitiesRecursively`, which runs when a slice focus auto-collapses the other Activities. Same math, same hole.

Store — **after the fix**:

```
[root]
└── <App>                          weight 2
    └── ▸ <Outer>                  weight 2, contributes 1
```

`numElements` stays 2.

---

## Commit 3 — expand `<Middle>`, then `<Outer>`

The expand path already broke on a collapsed parent (expanding "bubbles" and opens ancestors; without the break those ancestors were incremented twice). After this PR both directions agree.

```
[root]
└── <App>
    └── <Outer>
        └── <Middle>
            ├── <Leaf>
            └── <Leaf>
```

`numElements` is 5 again.

---

## Why the comment was wrong

Collapsing a **visible** node does bubble — that is how `numElements` shrinks. Collapsing a node **inside an already-collapsed ancestor** must not: that ancestor's contribution to the rest of the tree is already pinned at 1.

The old comment read a fact about the first case as a proof of the second:

| what the code knew                              | what it concluded                         |
| ----------------------------------------------- | ----------------------------------------- |
| collapse of a visible node updates its parents  | an inner collapse may update them too     |

`_adjustParentTreeWeight` (add / remove while a parent is collapsed) already stopped at the collapsed ancestor. `toggleIsCollapsed(true)` and `_collapseActivitiesRecursively` now do the same thing.