### PR TITLE
[compiler] Don't infer a named function's own name as a memo dependency

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateExhaustiveDependencies.ts
@@ -598,6 +598,21 @@ function collectDependencies(
       const place = param.kind === 'Identifier' ? param : param.place;
       locals.add(place.identifier.id);
     }
+    /*
+     * A named function's own name is bound inside its body (e.g. for recursion
+     * via the function's own name). Treat that self-reference as a local so it
+     * is not surfaced as a captured dependency of an enclosing memo/effect.
+     */
+    if (fn.id != null) {
+      for (const capture of fn.context) {
+        if (
+          capture.identifier.name?.kind === 'named' &&
+          capture.identifier.name.value === fn.id
+        ) {
+          locals.add(capture.identifier.id);
+        }
+      }
+    }
   }
 
   const dependencies: Set<InferredDependency> = new Set();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps/recursive-fn-in-memo-callback.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps/recursive-fn-in-memo-callback.expect.md
@@ -1,0 +1,111 @@
+
+## Input
+
+```javascript
+// @validateExhaustiveMemoizationDependencies
+
+import {useCallback, useMemo} from 'react';
+
+// Repro for https://github.com/react/react/issues/37270:
+// A recursive function declared inside a useMemo/useCallback
+// callback should not be inferred as a dependency of the memo.
+
+function Fibonacci({n}) {
+  const x = useMemo(() => {
+    function fib(m) {
+      if (m <= 2) return 1;
+      return fib(m - 1) + fib(m - 2);
+    }
+    return fib(n);
+  }, [n]);
+  return <div>{x}</div>;
+}
+
+function useFibCallback(n) {
+  return useCallback(() => {
+    function fib(m) {
+      if (m <= 2) return 1;
+      return fib(m - 1) + fib(m - 2);
+    }
+    return fib(n);
+  }, [n]);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Fibonacci,
+  params: [{n: 6}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateExhaustiveMemoizationDependencies
+
+import { useCallback, useMemo } from "react";
+
+// Repro for https://github.com/react/react/issues/37270:
+// A recursive function declared inside a useMemo/useCallback
+// callback should not be inferred as a dependency of the memo.
+
+function Fibonacci(t0) {
+  const $ = _c(4);
+  const { n } = t0;
+  let t1;
+  if ($[0] !== n) {
+    function fib(m) {
+      if (m <= 2) {
+        return 1;
+      }
+      return fib(m - 1) + fib(m - 2);
+    }
+    t1 = fib(n);
+    $[0] = n;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const x = t1;
+  let t2;
+  if ($[2] !== x) {
+    t2 = <div>{x}</div>;
+    $[2] = x;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+function useFibCallback(n) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== n) {
+    t0 = () => {
+      function fib(m) {
+        if (m <= 2) {
+          return 1;
+        }
+        return fib(m - 1) + fib(m - 2);
+      }
+
+      return fib(n);
+    };
+    $[0] = n;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Fibonacci,
+  params: [{ n: 6 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>8</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps/recursive-fn-in-memo-callback.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/exhaustive-deps/recursive-fn-in-memo-callback.js
@@ -1,0 +1,33 @@
+// @validateExhaustiveMemoizationDependencies
+
+import {useCallback, useMemo} from 'react';
+
+// Repro for https://github.com/react/react/issues/37270:
+// A recursive function declared inside a useMemo/useCallback
+// callback should not be inferred as a dependency of the memo.
+
+function Fibonacci({n}) {
+  const x = useMemo(() => {
+    function fib(m) {
+      if (m <= 2) return 1;
+      return fib(m - 1) + fib(m - 2);
+    }
+    return fib(n);
+  }, [n]);
+  return <div>{x}</div>;
+}
+
+function useFibCallback(n) {
+  return useCallback(() => {
+    function fib(m) {
+      if (m <= 2) return 1;
+      return fib(m - 1) + fib(m - 2);
+    }
+    return fib(n);
+  }, [n]);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Fibonacci,
+  params: [{n: 6}],
+};


### PR DESCRIPTION
## Summary
Fixes #37270.

A recursive function declared inside a `useMemo`/`useCallback` callback
(e.g. `function fib(m) { return fib(m-1) + fib(m-2); }`) was being
flagged with a false-positive "Missing dependency `fib`" because the
self-reference resolved through the inner function's captured context.

The fix seeds the inner function's `locals` set in `collectDependencies`
with any capture whose name matches the function's own `fn.id`. The
existing local-filter path in dependency collection then ignores the
self-reference at visit time — no post-processing needed. This mirrors
how function parameters are already seeded as locals in the same block.

## Test plan
- [x] New fixture `exhaustive-deps/recursive-fn-in-memo-callback` covers
      both `useMemo` and `useCallback` with a recursive `fib` and asserts
      `[n]` as the only inferred dep.
- [x] Runtime `Eval output` `(kind: ok) <div>8</div>` confirms behavior
      is preserved end-to-end.
- [x] Without the fix, the same fixture reports
      `Missing dependency 'fib' … Inferred dependencies: [fib, n]` — the
      exact bug in the issue.
- [x] `yarn workspace babel-plugin-react-compiler lint` passes.
