### PR TITLE
Fix(devtools): preserve specifiers in formatConsoleArgumentsToSingleString when arguments run out

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -180,6 +180,21 @@ describe('utils', () => {
         formatConsoleArgumentsToSingleString('%o', Object.create(null)),
       ).toEqual('%o [object Object]');
     });
+
+    it('keeps specifiers literal when no argument is supplied', () => {
+      expect(
+        formatConsoleArgumentsToSingleString('%s %s', 'value'),
+      ).toEqual('value %s');
+      expect(
+        formatConsoleArgumentsToSingleString('%d %d', 1),
+      ).toEqual('1 %d');
+      expect(
+        formatConsoleArgumentsToSingleString('%i %i', 1),
+      ).toEqual('1 %i');
+      expect(
+        formatConsoleArgumentsToSingleString('%f %f', 1.5),
+      ).toEqual('1.5 %f');
+    });
   });
 
   describe('formatWithStyles', () => {

--- a/packages/react-devtools-shared/src/backend/utils/index.js
+++ b/packages/react-devtools-shared/src/backend/utils/index.js
@@ -197,6 +197,12 @@ export function formatConsoleArgumentsToSingleString(
 
       // $FlowFixMe[incompatible-type]
       formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+        if (escaped) {
+          return match;
+        }
+        if (args.length === 0) {
+          return match;
+        }
         let arg = args.shift();
         switch (flag) {
           case 's':
@@ -211,11 +217,7 @@ export function formatConsoleArgumentsToSingleString(
             arg = parseFloat(arg).toString();
             break;
         }
-        if (!escaped) {
-          return arg;
-        }
-        args.unshift(arg);
-        return match;
+        return arg;
       });
     }
   }


### PR DESCRIPTION
Fixes #37126

### Context
`formatConsoleArgumentsToSingleString` shifted `undefined` from an empty arguments array when substitution specifiers (`%s`, `%d`, `%i`, `%f`) exceeded the number of input arguments, producing `"undefined"` and `"NaN"`.

### Solution
Updated `formatConsoleArgumentsToSingleString` to return the original specifier match when `args.length === 0` or when `escaped` (`%%`), matching standard console formatter behavior and existing `formatConsoleArguments` tests.

### How was this tested?
Added unit tests in `packages/react-devtools-shared/src/__tests__/utils-test.js`.