### PR TITLE
[Compiler] Preserve quoted computed property access in output (fix #37231)

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
@@ -238,9 +238,7 @@ function evaluateInstruction(
       if (
         property !== null &&
         property.kind === 'Primitive' &&
-        ((typeof property.value === 'string' &&
-          isValidIdentifier(property.value)) ||
-          typeof property.value === 'number')
+        typeof property.value === 'number'
       ) {
         const nextValue: InstructionValue = {
           kind: 'PropertyLoad',


### PR DESCRIPTION
Fixes #37231

## Summary
When optimizing property loads in React Compiler, `ConstantPropagation.ts` previously converted `ComputedLoad` nodes with string literals (e.g., `obj['property']`) to `PropertyLoad` nodes whenever the property string was a valid identifier. During code generation, `PropertyLoad` nodes output dot notation (`obj.property`).

While dot and bracket notation have identical standard runtime semantics, minifiers and tools like Closure Compiler treat quoted property accesses as non-renamable keys while dot properties are subject to symbol renaming. This caused compiled code accessing router/API payload properties via bracket notation to fail at runtime after property renaming.

This PR updates `ConstantPropagation.ts` to preserve `ComputedLoad` for developer-authored string literal bracket access (`obj['property']`).

## How was this tested?
- Tested compiler output preservation of quoted computed property access.
