### PR TITLE
Fix hydrated <dialog> missing onToggle and onBeforeToggle event listeners (fix #37261)

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -3132,6 +3132,8 @@ export function hydrateProperties(
   // TODO: Make sure that we check isMounted before firing any of these events.
   switch (tag) {
     case 'dialog':
+      listenToNonDelegatedEvent('beforetoggle', domElement);
+      listenToNonDelegatedEvent('toggle', domElement);
       listenToNonDelegatedEvent('cancel', domElement);
       listenToNonDelegatedEvent('close', domElement);
       break;


### PR DESCRIPTION
Fixes #37261

## Summary
`setInitialProperties` in `ReactDOMComponent.js` registers `beforetoggle`, `toggle`, `cancel`, and `close` non-delegated event listeners on `<dialog>` elements. However, `hydrateProperties` previously only registered `cancel` and `close`.

Because `beforetoggle` and `toggle` were missing from `hydrateProperties`, hydrated `<dialog>` components never received `onToggle` or `onBeforeToggle` callbacks.

This PR adds `listenToNonDelegatedEvent('beforetoggle', domElement)` and `listenToNonDelegatedEvent('toggle', domElement)` under `case 'dialog':` inside `hydrateProperties` to keep client-rendered and hydrated dialog property setup aligned.

## How was this tested?
- Tested non-delegated event registration alignment in `ReactDOMComponent.js`.
