### PR TITLE
Guard DevTools Store tree operation remove against unmapped node errors (fix #37264)

### DIFF
--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1617,13 +1617,13 @@ export default class Store extends EventEmitter<{
             const element = this._idToElement.get(id);
 
             if (element === undefined) {
-              this._throwAndEmitError(
-                Error(
+              if (__DEV__) {
+                console.warn(
                   `Cannot remove node "${id}" because no matching node was found in the Store.`,
-                ),
-              );
-
-              break;
+                );
+              }
+              i += 1;
+              continue;
             }
 
             i += 1;


### PR DESCRIPTION
Fixes #37264

## Summary
When rapid unmount events or fast re-renders generate tree removal operation streams, `Store.js` previously called `this._throwAndEmitError` and `break`ed out of operation parsing whenever an element ID was absent from `_idToElement`.

Throwing an error and breaking out of the loop aborted parsing for remaining valid tree operations in the payload, corrupting DevTools Store state.

This PR updates `TREE_OPERATION_REMOVE` handling in `store.js` to log a warning in `__DEV__`, advance the operations payload pointer `i += 1`, and `continue` processing the remainder of the operations payload.

## How was this tested?
- Verified `TREE_OPERATION_REMOVE` handling when receiving remove operations for unmapped element IDs.
