### PR TITLE
docs(react-is): fix undefined Component in README

### DIFF
--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -29,7 +29,7 @@ class ClassComponent extends React.Component {
 const FunctionComponent = () => React.createElement("div");
 
 const ForwardRefComponent = React.forwardRef((props, ref) =>
-  React.createElement(Component, { forwardedRef: ref, ...props })
+  React.createElement(ClassComponent, { forwardedRef: ref, ...props })
 );
 
 const Context = React.createContext(false);


### PR DESCRIPTION
The `ForwardRefComponent` example in the `react-is` README references an undefined `Component` left behind by an incomplete rename. This updates the reference to the already declared `ClassComponent`.