### PR TITLE
[Fiber] Memoize the lazy context propagation walk (behind a flag)

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -389,22 +389,10 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
   workInProgress.memoizedState = current.memoizedState;
   workInProgress.updateQueue = current.updateQueue;
 
-  // Clone the dependencies object. This is mutated during the render phase, so
-  // it cannot be shared with the current fiber.
-  const currentDependencies = current.dependencies;
-  workInProgress.dependencies =
-    currentDependencies === null
-      ? null
-      : __DEV__
-        ? {
-            lanes: currentDependencies.lanes,
-            firstContext: currentDependencies.firstContext,
-            _debugThenableState: currentDependencies._debugThenableState,
-          }
-        : {
-            lanes: currentDependencies.lanes,
-            firstContext: currentDependencies.firstContext,
-          };
+  // The dependencies object is never mutated during the render phase (a fiber
+  // that re-renders gets a fresh object in prepareToReadContext/readContext),
+  // so it can be shared with the current fiber.
+  workInProgress.dependencies = current.dependencies;
 
   // These will be overridden during the parent's reconciliation
   workInProgress.sibling = current.sibling;
@@ -498,22 +486,9 @@ export function resetWorkInProgress(
       workInProgress.key = current.key;
     }
 
-    // Clone the dependencies object. This is mutated during the render phase, so
-    // it cannot be shared with the current fiber.
-    const currentDependencies = current.dependencies;
-    workInProgress.dependencies =
-      currentDependencies === null
-        ? null
-        : __DEV__
-          ? {
-              lanes: currentDependencies.lanes,
-              firstContext: currentDependencies.firstContext,
-              _debugThenableState: currentDependencies._debugThenableState,
-            }
-          : {
-              lanes: currentDependencies.lanes,
-              firstContext: currentDependencies.firstContext,
-            };
+    // The dependencies object is never mutated during the render phase, so it
+    // can be shared with the current fiber. See createWorkInProgress.
+    workInProgress.dependencies = current.dependencies;
 
     if (enableProfilerTimer) {
       // Note: We don't reset the actualTime counts. It's useful to accumulate

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3846,9 +3846,10 @@ function bailoutOnAlreadyFinishedWork(
     // TODO: Once we add back resuming, we should check if the children are
     // a work-in-progress set. If so, we need to transfer their effects.
 
-    if (current !== null) {
+    if (current !== null && workInProgress.child !== null) {
       // Before bailing out, check if there are any context changes in
-      // the children.
+      // the children. If there are no children there's nothing to propagate
+      // to, so we can skip the walk up the return path entirely.
       lazilyPropagateParentContextChanges(current, workInProgress, renderLanes);
       if (!includesSomeLane(renderLanes, workInProgress.childLanes)) {
         return null;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -641,16 +641,26 @@ function finishRenderingHooks<Props, SecondArg>(
   if (__DEV__) {
     workInProgress._debugHookTypes = hookTypesDev;
     // Stash the thenable state for use by DevTools.
-    if (workInProgress.dependencies === null) {
+    const dependencies = workInProgress.dependencies;
+    if (dependencies === null) {
       if (thenableState !== null) {
         workInProgress.dependencies = {
-          lanes: NoLanes,
           firstContext: null,
           _debugThenableState: thenableState,
         };
       }
+    } else if (current !== null && dependencies === current.dependencies) {
+      // The dependencies object is still shared with the current fiber (this
+      // fiber rendered hooks without going through prepareToReadContext, e.g.
+      // a stateful host component). Don't mutate the current tree.
+      if (dependencies._debugThenableState !== thenableState) {
+        workInProgress.dependencies = {
+          firstContext: dependencies.firstContext,
+          _debugThenableState: thenableState,
+        };
+      }
     } else {
-      workInProgress.dependencies._debugThenableState = thenableState;
+      dependencies._debugThenableState = thenableState;
     }
     checkIfUseWasUsedBefore(workInProgress, thenableState);
   }

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -97,11 +97,19 @@ const MAX_DEPTH = 0x3fffffff;
 const visitedFibers: Array<Fiber | null> = [];
 const visitedContexts: Array<ReactContext<mixed> | null> = [];
 
+// DEV only. Set once the memoized walk has been reported as disagreeing with
+// the full walk in the current render attempt, so we warn at most once per
+// attempt.
+let didWarnAboutContextPropagationMemoMismatch: boolean = false;
+
 export function resetContextPropagationMemo(): void {
   propagationMemoOutside = null;
   propagationMemoInside = null;
   lastReturnFiber = null;
   lastReturnFiberContexts = null;
+  if (__DEV__) {
+    didWarnAboutContextPropagationMemoMismatch = false;
+  }
 }
 
 export function resetContextDependencies(): void {
@@ -515,8 +523,8 @@ function getChangedContext(
 
 // Collects the parent providers whose value changed, walking from
 // `workInProgress` towards the root. This is the unmemoized walk used when
-// enableMemoizedContextPropagation is off. The result is in walk order:
-// nearest provider first.
+// enableMemoizedContextPropagation is off (and, in DEV, to check the memoized
+// walk against). The result is in walk order: nearest provider first.
 function collectChangedParentContexts(
   workInProgress: Fiber,
 ): ChangedContexts | null {
@@ -628,6 +636,7 @@ function collectChangedParentContextsMemoized(
   // while already inside a NeedsPropagation subtree. Providers below this index
   // are memoized in the "outside" map, the rest in the "inside" map.
   let firstInsideDepth = isInsidePropagationBailout ? 0 : MAX_DEPTH;
+  let didHitMemo = false;
   let parent: null | Fiber = returnFiber;
   if (
     parent === lastReturnFiber &&
@@ -636,6 +645,7 @@ function collectChangedParentContextsMemoized(
   ) {
     suffix = lastReturnFiberContexts;
     parent = null;
+    didHitMemo = true;
   }
   while (parent !== null) {
     if (isPossiblyProvider(parent, hostTransitionProvider)) {
@@ -646,6 +656,7 @@ function collectChangedParentContextsMemoized(
         const memoized = memo.get(parent);
         if (memoized !== undefined) {
           suffix = memoized;
+          didHitMemo = true;
           break;
         }
       }
@@ -713,7 +724,69 @@ function collectChangedParentContextsMemoized(
     contexts = {context: ownContext, next: contexts};
   }
 
+  if (__DEV__) {
+    if (didHitMemo) {
+      // Whenever a memoized result was reused, check it against the full walk
+      // and fall back to the full walk's result if they disagree, so that a
+      // memoization bug surfaces as a warning rather than a missed update.
+      const unmemoized = collectChangedParentContexts(workInProgress);
+      if (!areChangedContextsEqual(contexts, unmemoized)) {
+        if (!didWarnAboutContextPropagationMemoMismatch) {
+          didWarnAboutContextPropagationMemoMismatch = true;
+          console.error(
+            'React: memoized context propagation result did not match the ' +
+              'full walk (%s the NeedsPropagation subtree, %s). ' +
+              'This is a bug in React.',
+            returnFiberIsInside ? 'inside' : 'outside',
+            areChangedContextsEqualUnordered(contexts, unmemoized)
+              ? 'same contexts in a different order'
+              : 'different contexts',
+          );
+        }
+        contexts = unmemoized;
+      }
+    }
+  }
   return contexts;
+}
+
+// DEV only.
+function areChangedContextsEqual(
+  a: ChangedContexts | null,
+  b: ChangedContexts | null,
+): boolean {
+  while (a !== null && b !== null) {
+    if (a.context !== b.context) {
+      return false;
+    }
+    a = a.next;
+    b = b.next;
+  }
+  return a === null && b === null;
+}
+
+function areChangedContextsEqualUnordered(
+  a: ChangedContexts | null,
+  b: ChangedContexts | null,
+): boolean {
+  const setA: Set<ReactContext<mixed>> = new Set();
+  const setB: Set<ReactContext<mixed>> = new Set();
+  for (let node = a; node !== null; node = node.next) {
+    setA.add(node.context);
+  }
+  for (let node = b; node !== null; node = node.next) {
+    setB.add(node.context);
+  }
+  if (setA.size !== setB.size) {
+    return false;
+  }
+  let equal = true;
+  setA.forEach(context => {
+    if (!setB.has(context)) {
+      equal = false;
+    }
+  });
+  return equal;
 }
 
 function propagateParentContextChanges(

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -33,6 +33,7 @@ import {
 } from './ReactFiberFlags';
 
 import is from 'shared/objectIs';
+import {enableMemoizedContextPropagation} from 'shared/ReactFeatureFlags';
 import {getHostTransitionProvider} from './ReactFiberHostContext';
 
 const valueCursor: StackCursor<mixed> = createCursor(null);
@@ -108,7 +109,9 @@ export function resetContextDependencies(): void {
   // cannot be called outside the render phase.
   currentlyRenderingFiber = null;
   lastContextDependency = null;
-  resetContextPropagationMemo();
+  if (enableMemoizedContextPropagation) {
+    resetContextPropagationMemo();
+  }
   if (__DEV__) {
     isDisallowedContextReadInDEV = false;
   }
@@ -510,15 +513,86 @@ function getChangedContext(
   return null;
 }
 
-function propagateParentContextChanges(
-  current: Fiber,
+// Collects the parent providers whose value changed, walking from
+// `workInProgress` towards the root. This is the unmemoized walk used when
+// enableMemoizedContextPropagation is off. The result is in walk order:
+// nearest provider first.
+function collectChangedParentContexts(
   workInProgress: Fiber,
-  renderLanes: Lanes,
-  forcePropagateEntireTree: boolean,
-): boolean {
-  // Collect all the parent providers that changed, walking from this fiber
-  // towards the root.
-  //
+): ChangedContexts | null {
+  // Collect all the parent providers that changed. Since this is usually small
+  // number, we use a linked list in walk order.
+  let contexts: ChangedContexts | null = null;
+  let lastContexts: ChangedContexts | null = null;
+  let parent: null | Fiber = workInProgress;
+  let isInsidePropagationBailout = false;
+  while (parent !== null) {
+    if (!isInsidePropagationBailout) {
+      if ((parent.flags & NeedsPropagation) !== NoFlags) {
+        isInsidePropagationBailout = true;
+      } else if ((parent.flags & DidPropagateContext) !== NoFlags) {
+        break;
+      }
+    }
+
+    let context: ReactContext<mixed> | null = null;
+    if (parent.tag === ContextProvider) {
+      const currentParent = parent.alternate;
+
+      if (currentParent === null) {
+        throw new Error('Should have a current fiber. This is a bug in React.');
+      }
+
+      const oldProps = currentParent.memoizedProps;
+      if (oldProps !== null) {
+        const newProps = parent.pendingProps;
+        const newValue = newProps.value;
+
+        const oldValue = oldProps.value;
+
+        if (!is(newValue, oldValue)) {
+          context = parent.type;
+        }
+      }
+    } else if (parent === getHostTransitionProvider()) {
+      // During a host transition, a host component can act like a context
+      // provider. E.g. in React DOM, this would be a <form />.
+      const currentParent = parent.alternate;
+      if (currentParent === null) {
+        throw new Error('Should have a current fiber. This is a bug in React.');
+      }
+
+      const oldStateHook: Hook = currentParent.memoizedState;
+      const oldState: TransitionStatus = oldStateHook.memoizedState;
+
+      const newStateHook: Hook = parent.memoizedState;
+      const newState: TransitionStatus = newStateHook.memoizedState;
+
+      // This uses regular equality instead of Object.is because we assume that
+      // host transition state doesn't include NaN as a valid type.
+      if (oldState !== newState) {
+        context = HostTransitionContext as any;
+      }
+    }
+    if (context !== null) {
+      const node: ChangedContexts = {context, next: null};
+      if (lastContexts !== null) {
+        lastContexts.next = node;
+      } else {
+        contexts = node;
+      }
+      lastContexts = node;
+    }
+    parent = parent.return;
+  }
+  return contexts;
+}
+
+// Same as `collectChangedParentContexts` but memoized per render attempt.
+// Only used when enableMemoizedContextPropagation is on.
+function collectChangedParentContextsMemoized(
+  workInProgress: Fiber,
+): ChangedContexts | null {
   // For any strict ancestor the portion of the result contributed by it and
   // everything above it is fixed for the rest of this begin pass (see
   // `propagationMemoOutside`), so the first walk that visits a provider
@@ -528,9 +602,10 @@ function propagateParentContextChanges(
   // the suffix is known.
   //
   // `workInProgress` itself is always evaluated against its live flags and is
-  // never memoized here: it receives DidPropagateContext at the end of this
-  // function, which changes the answer for its descendants. Walks started by
-  // its descendants will see the post-propagation flags.
+  // never memoized here: it receives DidPropagateContext at the end of
+  // `propagateParentContextChanges`, which changes the answer for its
+  // descendants. Walks started by its descendants will see the
+  // post-propagation flags.
   let isInsidePropagationBailout =
     (workInProgress.flags & NeedsPropagation) !== NoFlags;
   if (
@@ -538,7 +613,7 @@ function propagateParentContextChanges(
     (workInProgress.flags & DidPropagateContext) !== NoFlags
   ) {
     // We already propagated from this fiber earlier in its begin phase.
-    return false;
+    return null;
   }
   const hostTransitionProvider = getHostTransitionProvider();
   const ownContext = isPossiblyProvider(workInProgress, hostTransitionProvider)
@@ -637,6 +712,20 @@ function propagateParentContextChanges(
   if (ownContext !== null) {
     contexts = {context: ownContext, next: contexts};
   }
+
+  return contexts;
+}
+
+function propagateParentContextChanges(
+  current: Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+  forcePropagateEntireTree: boolean,
+): boolean {
+  // Collect all the parent providers that changed.
+  const contexts = enableMemoizedContextPropagation
+    ? collectChangedParentContextsMemoized(workInProgress)
+    : collectChangedParentContexts(workInProgress);
 
   if (contexts !== null) {
     // If there were any changed providers, search through the children and

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -57,11 +57,58 @@ let lastContextDependency: ContextDependency<mixed> | null = null;
 
 let isDisallowedContextReadInDEV: boolean = false;
 
+// A set of contexts whose provider value changed, as an immutable linked list
+// so that results for nested fibers can share structure.
+type ChangedContexts = {
+  context: ReactContext<mixed>,
+  next: ChangedContexts | null,
+};
+
+// Memoized results of `propagateParentContextChanges` walking the return path.
+// An entry for fiber F is the list of changed providers found by walking from
+// F (inclusive) towards the root, following the same NeedsPropagation /
+// DidPropagateContext rules as the walk itself, or `null` if there are none.
+// Because those rules depend on whether the walk had already passed a
+// NeedsPropagation fiber by the time it reached F, there is one map for each
+// of the two states. Only (possible) provider fibers get entries: they are
+// what makes return paths long in practice, and skipping everything else
+// keeps the maps small and means trees without providers never touch them.
+//
+// Entries are only ever created for strict ancestors of the fiber currently
+// being begun. Within a single uninterrupted begin sequence such a fiber's
+// pendingProps, its alternate's memoizedProps and its NeedsPropagation /
+// DidPropagateContext flags no longer change, so neither does the entry. The
+// memo is dropped whenever that stops being true: when the work loop yields,
+// finishes, or unwinds (resetContextDependencies), and when it re-enters the
+// begin phase for a fiber that was already begun (resetContextPropagationMemo
+// from the work loop). Missing entries only cost a longer walk.
+let propagationMemoOutside: Map<Fiber, ChangedContexts | null> | null = null;
+let propagationMemoInside: Map<Fiber, ChangedContexts | null> | null = null;
+// The result for the return fiber of the last walk (whatever its tag), kept
+// inline because consecutive walks overwhelmingly start from siblings.
+let lastReturnFiber: Fiber | null = null;
+let lastReturnFiberIsInside: boolean = false;
+let lastReturnFiberContexts: ChangedContexts | null = null;
+
+// Scratch buffers for the provider fibers visited by a single walk before it
+// reaches a memoized ancestor, the root, or a DidPropagateContext boundary.
+const MAX_DEPTH = 0x3fffffff;
+const visitedFibers: Array<Fiber | null> = [];
+const visitedContexts: Array<ReactContext<mixed> | null> = [];
+
+export function resetContextPropagationMemo(): void {
+  propagationMemoOutside = null;
+  propagationMemoInside = null;
+  lastReturnFiber = null;
+  lastReturnFiberContexts = null;
+}
+
 export function resetContextDependencies(): void {
   // This is called right before React yields execution, to ensure `readContext`
   // cannot be called outside the render phase.
   currentlyRenderingFiber = null;
   lastContextDependency = null;
+  resetContextPropagationMemo();
   if (__DEV__) {
     isDisallowedContextReadInDEV = false;
   }
@@ -203,17 +250,21 @@ export function propagateContextChange<T>(
   // lazilyPropagateParentContextChanges to look for Cache components so they
   // can take advantage of lazy propagation.
   const forcePropagateEntireTree = true;
+  const contexts: ChangedContexts = {
+    context: context as any as ReactContext<mixed>,
+    next: null,
+  };
   propagateContextChanges(
     workInProgress,
-    [context],
+    contexts,
     renderLanes,
     forcePropagateEntireTree,
   );
 }
 
-function propagateContextChanges<T>(
+function propagateContextChanges(
   workInProgress: Fiber,
-  contexts: Array<any>,
+  contexts: ChangedContexts,
   renderLanes: Lanes,
   forcePropagateEntireTree: boolean,
 ): void {
@@ -235,10 +286,11 @@ function propagateContextChanges<T>(
         // Assigning these to constants to help Flow
         const dependency = dep;
         const consumer = fiber;
-        findContext: for (let i = 0; i < contexts.length; i++) {
-          const context: ReactContext<T> = contexts[i];
+        let changed: ChangedContexts | null = contexts;
+        findContext: while (changed !== null) {
+          const context = changed.context;
+          changed = changed.next;
           // Check if the context matches.
-          // $FlowFixMe[invalid-compare]
           if (dependency.context === context) {
             // Match! Schedule an update on this fiber.
 
@@ -408,74 +460,182 @@ export function propagateParentContextChangesToDeferredTree(
   );
 }
 
+function isPossiblyProvider(
+  fiber: Fiber,
+  hostTransitionProvider: Fiber | null,
+): boolean {
+  return fiber.tag === ContextProvider || fiber === hostTransitionProvider;
+}
+
+// Returns the context provided by `fiber` if `fiber` is a provider whose value
+// differs from the committed one, or null otherwise.
+function getChangedContext(
+  fiber: Fiber,
+  hostTransitionProvider: Fiber | null,
+): ReactContext<mixed> | null {
+  if (fiber.tag === ContextProvider) {
+    const current = fiber.alternate;
+    if (current === null) {
+      throw new Error('Should have a current fiber. This is a bug in React.');
+    }
+    const oldProps = current.memoizedProps;
+    if (oldProps !== null) {
+      const newProps = fiber.pendingProps;
+      if (!is(newProps.value, oldProps.value)) {
+        return fiber.type;
+      }
+    }
+  } else if (fiber === hostTransitionProvider) {
+    // During a host transition, a host component can act like a context
+    // provider. E.g. in React DOM, this would be a <form />.
+    //
+    // NOTE: Like pushHostContext, this assumes host transition providers do
+    // not nest, so the nearest one on the stack is the only one on the return
+    // path and the memoized result below does not depend on which descendant
+    // computed it.
+    const current = fiber.alternate;
+    if (current === null) {
+      throw new Error('Should have a current fiber. This is a bug in React.');
+    }
+    const oldStateHook: Hook = current.memoizedState;
+    const oldState: TransitionStatus = oldStateHook.memoizedState;
+    const newStateHook: Hook = fiber.memoizedState;
+    const newState: TransitionStatus = newStateHook.memoizedState;
+    // This uses regular equality instead of Object.is because we assume that
+    // host transition state doesn't include NaN as a valid type.
+    if (oldState !== newState) {
+      return HostTransitionContext as any;
+    }
+  }
+  return null;
+}
+
 function propagateParentContextChanges(
   current: Fiber,
   workInProgress: Fiber,
   renderLanes: Lanes,
   forcePropagateEntireTree: boolean,
 ): boolean {
-  // Collect all the parent providers that changed. Since this is usually small
-  // number, we use an Array instead of Set.
-  let contexts = null;
-  let parent: null | Fiber = workInProgress;
-  let isInsidePropagationBailout = false;
+  // Collect all the parent providers that changed, walking from this fiber
+  // towards the root.
+  //
+  // For any strict ancestor the portion of the result contributed by it and
+  // everything above it is fixed for the rest of this begin pass (see
+  // `propagationMemoOutside`), so the first walk that visits a provider
+  // records that portion and later walks stop as soon as they reach a
+  // provider that has already been visited. The providers visited before the
+  // hit are buffered in `visitedFibers`/`visitedContexts` and memoized once
+  // the suffix is known.
+  //
+  // `workInProgress` itself is always evaluated against its live flags and is
+  // never memoized here: it receives DidPropagateContext at the end of this
+  // function, which changes the answer for its descendants. Walks started by
+  // its descendants will see the post-propagation flags.
+  let isInsidePropagationBailout =
+    (workInProgress.flags & NeedsPropagation) !== NoFlags;
+  if (
+    !isInsidePropagationBailout &&
+    (workInProgress.flags & DidPropagateContext) !== NoFlags
+  ) {
+    // We already propagated from this fiber earlier in its begin phase.
+    return false;
+  }
+  const hostTransitionProvider = getHostTransitionProvider();
+  const ownContext = isPossiblyProvider(workInProgress, hostTransitionProvider)
+    ? getChangedContext(workInProgress, hostTransitionProvider)
+    : null;
+
+  const returnFiber = workInProgress.return;
+  const returnFiberIsInside = isInsidePropagationBailout;
+  let suffix: ChangedContexts | null = null;
+  let depth = 0;
+  // Index into the visited buffer of the first provider that was reached
+  // while already inside a NeedsPropagation subtree. Providers below this index
+  // are memoized in the "outside" map, the rest in the "inside" map.
+  let firstInsideDepth = isInsidePropagationBailout ? 0 : MAX_DEPTH;
+  let parent: null | Fiber = returnFiber;
+  if (
+    parent === lastReturnFiber &&
+    returnFiberIsInside === lastReturnFiberIsInside &&
+    parent !== null
+  ) {
+    suffix = lastReturnFiberContexts;
+    parent = null;
+  }
   while (parent !== null) {
-    if (!isInsidePropagationBailout) {
+    if (isPossiblyProvider(parent, hostTransitionProvider)) {
+      const memo = isInsidePropagationBailout
+        ? propagationMemoInside
+        : propagationMemoOutside;
+      if (memo !== null) {
+        const memoized = memo.get(parent);
+        if (memoized !== undefined) {
+          suffix = memoized;
+          break;
+        }
+      }
+      visitedFibers[depth] = parent;
+      if (!isInsidePropagationBailout) {
+        if ((parent.flags & NeedsPropagation) !== NoFlags) {
+          isInsidePropagationBailout = true;
+          firstInsideDepth = depth + 1;
+        } else if ((parent.flags & DidPropagateContext) !== NoFlags) {
+          // Everything at or above this fiber was already propagated into its
+          // subtree, which includes us.
+          visitedContexts[depth] = null;
+          depth++;
+          break;
+        }
+      }
+      visitedContexts[depth] = getChangedContext(
+        parent,
+        hostTransitionProvider,
+      );
+      depth++;
+    } else if (!isInsidePropagationBailout) {
       if ((parent.flags & NeedsPropagation) !== NoFlags) {
         isInsidePropagationBailout = true;
+        firstInsideDepth = depth;
       } else if ((parent.flags & DidPropagateContext) !== NoFlags) {
         break;
       }
     }
+    parent = parent.return;
+  }
 
-    if (parent.tag === ContextProvider) {
-      const currentParent = parent.alternate;
-
-      if (currentParent === null) {
-        throw new Error('Should have a current fiber. This is a bug in React.');
+  // Memoize the result for every provider we visited, sharing structure with
+  // the suffix we stopped at.
+  let contexts: ChangedContexts | null = suffix;
+  if (depth > 0) {
+    let outside = propagationMemoOutside;
+    let inside = propagationMemoInside;
+    for (let i = depth - 1; i >= 0; i--) {
+      const fiber: Fiber = visitedFibers[i] as any;
+      const context = visitedContexts[i];
+      visitedFibers[i] = null;
+      if (context !== null) {
+        contexts = {context, next: contexts};
       }
-
-      const oldProps = currentParent.memoizedProps;
-      if (oldProps !== null) {
-        const context: ReactContext<any> = parent.type;
-        const newProps = parent.pendingProps;
-        const newValue = newProps.value;
-
-        const oldValue = oldProps.value;
-
-        if (!is(newValue, oldValue)) {
-          if (contexts !== null) {
-            contexts.push(context);
-          } else {
-            contexts = [context];
-          }
+      if (i >= firstInsideDepth) {
+        if (inside === null) {
+          inside = propagationMemoInside = new Map();
         }
-      }
-    } else if (parent === getHostTransitionProvider()) {
-      // During a host transition, a host component can act like a context
-      // provider. E.g. in React DOM, this would be a <form />.
-      const currentParent = parent.alternate;
-      if (currentParent === null) {
-        throw new Error('Should have a current fiber. This is a bug in React.');
-      }
-
-      const oldStateHook: Hook = currentParent.memoizedState;
-      const oldState: TransitionStatus = oldStateHook.memoizedState;
-
-      const newStateHook: Hook = parent.memoizedState;
-      const newState: TransitionStatus = newStateHook.memoizedState;
-
-      // This uses regular equality instead of Object.is because we assume that
-      // host transition state doesn't include NaN as a valid type.
-      if (oldState !== newState) {
-        if (contexts !== null) {
-          contexts.push(HostTransitionContext);
-        } else {
-          contexts = [HostTransitionContext];
+        inside.set(fiber, contexts);
+      } else {
+        if (outside === null) {
+          outside = propagationMemoOutside = new Map();
         }
+        outside.set(fiber, contexts);
       }
     }
-    parent = parent.return;
+  }
+  // At this point `contexts` is the entry for the return fiber.
+  lastReturnFiber = returnFiber;
+  lastReturnFiberIsInside = returnFiberIsInside;
+  lastReturnFiberContexts = contexts;
+
+  if (ownContext !== null) {
+    contexts = {context: ownContext, next: contexts};
   }
 
   if (contexts !== null) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -25,7 +25,7 @@ import {
   DehydratedFragment,
   SuspenseComponent,
 } from './ReactWorkTags';
-import {NoLanes, isSubsetOfLanes, mergeLanes} from './ReactFiberLane';
+import {isSubsetOfLanes, mergeLanes} from './ReactFiberLane';
 import {
   NoFlags,
   DidPropagateContext,
@@ -543,11 +543,10 @@ export function prepareToReadContext(
   currentlyRenderingFiber = workInProgress;
   lastContextDependency = null;
 
-  const dependencies = workInProgress.dependencies;
-  if (dependencies !== null) {
-    // Reset the work-in-progress list
-    dependencies.firstContext = null;
-  }
+  // Reset the work-in-progress list. The dependencies object may be shared
+  // with the current fiber, so we drop the reference rather than mutate it. A
+  // new object is created on the first `readContext` call.
+  workInProgress.dependencies = null;
 }
 
 export function readContext<T>(context: ReactContext<T>): T {
@@ -608,13 +607,11 @@ function readContextForConsumer<T>(
     consumer.dependencies = __DEV__
       ? // $FlowFixMe[incompatible-type]
         {
-          lanes: NoLanes,
           firstContext: contextItem,
           _debugThenableState: null,
         }
       : // $FlowFixMe[incompatible-type]
         {
-          lanes: NoLanes,
           firstContext: contextItem,
         };
     consumer.flags |= NeedsPropagation;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -267,7 +267,10 @@ import {
   startGestureAnimations,
 } from './ReactFiberApplyGesture';
 import {enqueueUpdate} from './ReactFiberClassUpdateQueue';
-import {resetContextDependencies} from './ReactFiberNewContext';
+import {
+  resetContextDependencies,
+  resetContextPropagationMemo,
+} from './ReactFiberNewContext';
 import {
   resetHooksAfterThrow,
   resetHooksOnUnwind,
@@ -2252,6 +2255,7 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   pendingEffectsLanes = NoLanes;
 
   resetWorkInProgressStack();
+  resetContextPropagationMemo();
   workInProgressRoot = root;
   const rootWorkInProgress = createWorkInProgress(root.current, null);
   workInProgress = rootWorkInProgress;
@@ -3407,6 +3411,11 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
     }
     if (next !== null) {
       // Completing this fiber spawned new work. Work on that next.
+      //
+      // This re-enters the begin phase for fibers that were already begun
+      // (e.g. the second pass of a SuspenseList), so any memoized parent
+      // context propagation results below this point are no longer valid.
+      resetContextPropagationMemo();
       workInProgress = next;
       return;
     }
@@ -3452,6 +3461,10 @@ function unwindUnitOfWork(unitOfWork: Fiber, skipSiblings: boolean): void {
       // Since we're restarting, remove anything that is not a host effect
       // from the effect tag.
       next.flags &= HostEffectMask;
+      // The boundary and its subtree are about to be begun again with
+      // different flags and children, so any memoized parent context
+      // propagation results for them are no longer valid.
+      resetContextPropagationMemo();
       workInProgress = next;
       return;
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -60,6 +60,7 @@ import {
   enableGestureTransition,
   enableDefaultTransitionIndicator,
   enableParallelTransitions,
+  enableMemoizedContextPropagation,
 } from 'shared/ReactFeatureFlags';
 import {resetOwnerStackLimit} from 'shared/ReactOwnerStackReset';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -2255,7 +2256,9 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   pendingEffectsLanes = NoLanes;
 
   resetWorkInProgressStack();
-  resetContextPropagationMemo();
+  if (enableMemoizedContextPropagation) {
+    resetContextPropagationMemo();
+  }
   workInProgressRoot = root;
   const rootWorkInProgress = createWorkInProgress(root.current, null);
   workInProgress = rootWorkInProgress;
@@ -3415,7 +3418,9 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
       // This re-enters the begin phase for fibers that were already begun
       // (e.g. the second pass of a SuspenseList), so any memoized parent
       // context propagation results below this point are no longer valid.
-      resetContextPropagationMemo();
+      if (enableMemoizedContextPropagation) {
+        resetContextPropagationMemo();
+      }
       workInProgress = next;
       return;
     }
@@ -3464,7 +3469,9 @@ function unwindUnitOfWork(unitOfWork: Fiber, skipSiblings: boolean): void {
       // The boundary and its subtree are about to be begun again with
       // different flags and children, so any memoized parent context
       // propagation results for them are no longer valid.
-      resetContextPropagationMemo();
+      if (enableMemoizedContextPropagation) {
+        resetContextPropagationMemo();
+      }
       workInProgress = next;
       return;
     }

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -73,7 +73,6 @@ export type ContextDependency<T> = {
 };
 
 export type Dependencies = {
-  lanes: Lanes,
   firstContext: ContextDependency<mixed> | null,
   _debugThenableState?: null | ThenableState, // DEV-only
   ...

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -1114,6 +1114,10 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('ContentB');
   });
 
+  // These exercise the shapes the memoized parent walk
+  // (enableMemoizedContextPropagation) has to get right, but they only assert
+  // which consumers re-render, which must be the same with the flag on or off.
+  // They are deliberately not gated so both code paths are covered.
   describe('memoized parent walk', () => {
     // These tests target the memoization of the return-path walk performed by
     // lazilyPropagateParentContextChanges. They use a shape where an update

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -1113,4 +1113,1319 @@ describe('ReactLazyContextPropagation', () => {
     assertLog(['Content']);
     expect(root).toMatchRenderedOutput('ContentB');
   });
+
+  describe('memoized parent walk', () => {
+    // These tests target the memoization of the return-path walk performed by
+    // lazilyPropagateParentContextChanges. They use a shape where an update
+    // enters below a bailed-out memo boundary and fans out into many sibling
+    // subtrees that bail out, so that later siblings (and their descendants)
+    // reuse the results recorded by earlier ones.
+
+    let Activity;
+    let useMemo;
+    let memo;
+    let startTransition;
+    let waitFor;
+    let waitForAll;
+    let StableA;
+    let StableB;
+
+    beforeEach(() => {
+      Activity = React.Activity;
+      useMemo = React.useMemo;
+      memo = React.memo;
+      startTransition = React.startTransition;
+      const InternalTestUtils = require('internal-test-utils');
+      waitFor = InternalTestUtils.waitFor;
+      waitForAll = InternalTestUtils.waitForAll;
+      StableA = React.createContext('a');
+      StableB = React.createContext('b');
+    });
+
+    // Some providers and plain wrappers whose values never change, to put
+    // distance between the interesting provider and the consumers.
+    function Padding({depth, children}) {
+      if (depth === 0) {
+        return children;
+      }
+      const inner = <Padding depth={depth - 1}>{children}</Padding>;
+      switch (depth % 3) {
+        case 0:
+          return <StableA.Provider value="a">{inner}</StableA.Provider>;
+        case 1:
+          return <PassThrough>{inner}</PassThrough>;
+        default:
+          return <StableB.Provider value="b">{inner}</StableB.Provider>;
+      }
+    }
+    function PassThrough({children}) {
+      return children;
+    }
+
+    it('propagates a distant provider change into many bailed-out sibling subtrees', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={12}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <Padding depth={6}>
+            <List />
+          </Padding>
+        );
+      });
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        setTick = _setTick;
+        // Reading a context here means that when List re-renders it is
+        // flagged NeedsPropagation, so its children's walks continue past the
+        // memo boundary above.
+        useContext(StableA);
+        const rows = useMemo(
+          () => [0, 1, 2, 3, 4, 5, 6, 7].map(i => <Row key={i} id={i} />),
+          [],
+        );
+        return (
+          <>
+            <Text text={'List ' + tick} />
+            {rows}
+          </>
+        );
+      }
+
+      const Row = memo(function Row({id}) {
+        return (
+          <div>
+            <Padding depth={4}>
+              <Consumer id={id + 'a'} />
+              <Consumer id={id + 'b'} />
+            </Padding>
+          </div>
+        );
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        useContext(StableB);
+        return <Text text={id + ':' + value} />;
+      }
+
+      const ids = [0, 1, 2, 3, 4, 5, 6, 7];
+      const consumers = v => ids.flatMap(i => [i + 'a:' + v, i + 'b:' + v]);
+      const output = (tick, v) => (
+        <>
+          {'List ' + tick}
+          <div>{'0a:' + v + '0b:' + v}</div>
+          <div>{'1a:' + v + '1b:' + v}</div>
+          <div>{'2a:' + v + '2b:' + v}</div>
+          <div>{'3a:' + v + '3b:' + v}</div>
+          <div>{'4a:' + v + '4b:' + v}</div>
+          <div>{'5a:' + v + '5b:' + v}</div>
+          <div>{'6a:' + v + '6b:' + v}</div>
+          <div>{'7a:' + v + '7b:' + v}</div>
+        </>
+      );
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog(['List 0', ...consumers('A')]);
+
+      // Only the list re-renders. Every row bails out and nothing changed
+      // above, so no consumer should render.
+      await act(() => {
+        setTick(1);
+      });
+      assertLog(['List 1']);
+
+      // The distant provider changes and the list re-renders in the same
+      // pass. Every consumer must see the new value.
+      await act(() => {
+        setValue('B');
+        setTick(2);
+      });
+      assertLog(['List 2', ...consumers('B')]);
+      expect(root).toMatchRenderedOutput(output(2, 'B'));
+
+      // The distant provider changes but the list itself bails out.
+      await act(() => {
+        setValue('C');
+      });
+      assertLog(consumers('C'));
+      expect(root).toMatchRenderedOutput(output(2, 'C'));
+    });
+
+    it('propagates a change from the direct parent provider into bailed-out siblings', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        return (
+          <Padding depth={6}>
+            <List />
+          </Padding>
+        );
+      }
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        const [value, _setValue] = useState('A');
+        setTick = _setTick;
+        setValue = _setValue;
+        const rows = useMemo(
+          () => [0, 1, 2, 3].map(i => <Row key={i} id={i} />),
+          [],
+        );
+        return (
+          <Context.Provider value={value}>
+            <Text text={'List ' + tick} />
+            {rows}
+          </Context.Provider>
+        );
+      }
+
+      const Row = memo(function Row({id}) {
+        return (
+          <Padding depth={3}>
+            <Consumer id={id} />
+          </Padding>
+        );
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog(['List 0', '0:A', '1:A', '2:A', '3:A']);
+
+      await act(() => {
+        setTick(1);
+      });
+      assertLog(['List 1']);
+
+      await act(() => {
+        setValue('B');
+      });
+      assertLog(['List 1', '0:B', '1:B', '2:B', '3:B']);
+      expect(root).toMatchRenderedOutput('List 10:B1:B2:B3:B');
+    });
+
+    it('nested providers of the same context: only the outer one changes', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('-');
+
+      let setOuter;
+      let setInner;
+      function App() {
+        const [outer, _setOuter] = useState('A');
+        setOuter = _setOuter;
+        return (
+          <Context.Provider value={outer}>
+            <Padding depth={4}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <div>
+            <Rows prefix="outer" />
+            <InnerHost />
+          </div>
+        );
+      });
+
+      function InnerHost() {
+        const [inner, _setInner] = useState('a');
+        setInner = _setInner;
+        return (
+          <Context.Provider value={inner}>
+            <Rows prefix="inner" />
+          </Context.Provider>
+        );
+      }
+
+      const Rows = memo(function Rows({prefix}) {
+        return (
+          <Padding depth={2}>
+            <Row id={prefix + '0'} />
+            <Row id={prefix + '1'} />
+            <Row id={prefix + '2'} />
+          </Padding>
+        );
+      });
+
+      const Row = memo(function Row({id}) {
+        return (
+          <span>
+            <Consumer id={id} />
+          </span>
+        );
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog([
+        'outer0:A',
+        'outer1:A',
+        'outer2:A',
+        'inner0:a',
+        'inner1:a',
+        'inner2:a',
+      ]);
+
+      // Only the outer provider changes. Consumers under the inner provider
+      // are shadowed, so they must keep showing the inner value. (They are
+      // marked, because propagation matches on the context type, but they
+      // bail out after reading the unchanged value.)
+      await act(() => {
+        setOuter('B');
+      });
+      assertLog(['outer0:B', 'outer1:B', 'outer2:B']);
+      expect(root).toMatchRenderedOutput(
+        <div>
+          <span>outer0:B</span>
+          <span>outer1:B</span>
+          <span>outer2:B</span>
+          <span>inner0:a</span>
+          <span>inner1:a</span>
+          <span>inner2:a</span>
+        </div>,
+      );
+
+      // Only the inner provider changes. Consumers that aren't under it must
+      // not re-render.
+      await act(() => {
+        setInner('b');
+      });
+      assertLog(['inner0:b', 'inner1:b', 'inner2:b']);
+      expect(root).toMatchRenderedOutput(
+        <div>
+          <span>outer0:B</span>
+          <span>outer1:B</span>
+          <span>outer2:B</span>
+          <span>inner0:b</span>
+          <span>inner1:b</span>
+          <span>inner2:b</span>
+        </div>,
+      );
+
+      // Both change in the same pass.
+      await act(() => {
+        setOuter('C');
+        setInner('c');
+      });
+      assertLog([
+        'outer0:C',
+        'outer1:C',
+        'outer2:C',
+        'inner0:c',
+        'inner1:c',
+        'inner2:c',
+      ]);
+    });
+
+    it('a component that bailed out and propagated acts as a boundary for its descendants', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={3}>
+              <List />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        setTick = _setTick;
+        return (
+          <>
+            <Text text={'List ' + tick} />
+            <Section id="x" />
+            <Section id="y" />
+          </>
+        );
+      }
+
+      // Section bails out (memo) while List re-renders. When the provider
+      // above changed it propagates into its own subtree and is flagged, so
+      // the walks started by its bailing descendants stop at it.
+      const Section = memo(function Section({id}) {
+        Scheduler.log('Section ' + id);
+        return (
+          <Padding depth={2}>
+            <Group id={id + '0'} />
+            <Group id={id + '1'} />
+          </Padding>
+        );
+      });
+
+      const Group = memo(function Group({id}) {
+        Scheduler.log('Group ' + id);
+        return (
+          <div>
+            <Consumer id={id + 'a'} />
+            <Leaf id={id} />
+            <Consumer id={id + 'b'} />
+          </div>
+        );
+      });
+
+      const Leaf = memo(function Leaf({id}) {
+        Scheduler.log('Leaf ' + id);
+        return <span>{id}</span>;
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog([
+        'List 0',
+        'Section x',
+        'Group x0',
+        'x0a:A',
+        'Leaf x0',
+        'x0b:A',
+        'Group x1',
+        'x1a:A',
+        'Leaf x1',
+        'x1b:A',
+        'Section y',
+        'Group y0',
+        'y0a:A',
+        'Leaf y0',
+        'y0b:A',
+        'Group y1',
+        'y1a:A',
+        'Leaf y1',
+        'y1b:A',
+      ]);
+
+      await act(() => {
+        setValue('B');
+        setTick(1);
+      });
+      // Only the list and the consumers re-render.
+      assertLog([
+        'List 1',
+        'x0a:B',
+        'x0b:B',
+        'x1a:B',
+        'x1b:B',
+        'y0a:B',
+        'y0b:B',
+        'y1a:B',
+        'y1b:B',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          List 1
+          <div>
+            x0a:B<span>x0</span>x0b:B
+          </div>
+          <div>
+            x1a:B<span>x1</span>x1b:B
+          </div>
+          <div>
+            y0a:B<span>y0</span>y0b:B
+          </div>
+          <div>
+            y1a:B<span>y1</span>y1b:B
+          </div>
+        </>,
+      );
+    });
+
+    it('a re-rendered consumer still propagates to memoized descendants after a sibling bailed out', async () => {
+      // The memo boundary propagates the change and stops at the first
+      // matching consumer in each branch, so consumers nested below a
+      // matched consumer rely on the walk started under that consumer
+      // continuing past the memo boundary. An earlier sibling that bailed out
+      // records a result for the shared parent that stops at the boundary;
+      // that result must not be reused for the walk under the consumer.
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={3}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      // The stable provider below the memo boundary matters: providers are
+      // where walk results get recorded.
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <StableB.Provider value="b">
+            <PassThrough>
+              <Static id="before" />
+              <DirectConsumer />
+              <Static id="after" />
+            </PassThrough>
+          </StableB.Provider>
+        );
+      });
+
+      const Static = memo(function Static({id}) {
+        return (
+          <PassThrough>
+            <Text text={id} />
+          </PassThrough>
+        );
+      });
+
+      function DirectConsumer() {
+        const value = useContext(Context);
+        Scheduler.log('Direct:' + value);
+        return <Nested />;
+      }
+
+      const Nested = memo(function Nested() {
+        return (
+          <Padding depth={2}>
+            <NestedConsumer />
+          </Padding>
+        );
+      });
+
+      function NestedConsumer() {
+        const value = useContext(Context);
+        return <Text text={'Nested:' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog(['before', 'Direct:A', 'Nested:A', 'after']);
+
+      await act(() => {
+        setValue('B');
+      });
+      assertLog(['Direct:B', 'Nested:B']);
+      expect(root).toMatchRenderedOutput('beforeNested:Bafter');
+    });
+
+    it('does not attribute a provider inside a re-rendered sibling to a bailed-out sibling', async () => {
+      const root = ReactNoop.createRoot();
+      const Outer = React.createContext('A');
+      const Local = React.createContext(0);
+
+      let setValue;
+      let setTick;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Outer.Provider value={value}>
+            <Local.Provider value={0}>
+              <Padding depth={3}>
+                <StaticMiddle />
+              </Padding>
+            </Local.Provider>
+          </Outer.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <div>
+            <List />
+          </div>
+        );
+      });
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        setTick = _setTick;
+        return (
+          <>
+            <Text text={'List ' + tick} />
+            <SiblingA tick={tick} />
+            <SiblingB />
+            <SiblingA tick={tick} />
+            <SiblingB />
+          </>
+        );
+      }
+
+      // Re-renders with the list and provides a new Local value each time.
+      function SiblingA({tick}) {
+        return (
+          <Local.Provider value={tick}>
+            <Consumers prefix="a" />
+          </Local.Provider>
+        );
+      }
+
+      // Bails out. Its Local consumers read the provider above List, which
+      // never changes.
+      const SiblingB = memo(function SiblingB() {
+        return <Consumers prefix="b" />;
+      });
+
+      const Consumers = memo(function Consumers({prefix}) {
+        return (
+          <Padding depth={2}>
+            <LocalConsumer id={prefix} />
+            <OuterConsumer id={prefix} />
+          </Padding>
+        );
+      });
+
+      function LocalConsumer({id}) {
+        const value = useContext(Local);
+        return <Text text={id + ' local:' + value} />;
+      }
+
+      function OuterConsumer({id}) {
+        const value = useContext(Outer);
+        return <Text text={id + ' outer:' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog([
+        'List 0',
+        'a local:0',
+        'a outer:A',
+        'b local:0',
+        'b outer:A',
+        'a local:0',
+        'a outer:A',
+        'b local:0',
+        'b outer:A',
+      ]);
+
+      // Only the providers inside the SiblingAs change.
+      await act(() => {
+        setTick(1);
+      });
+      assertLog(['List 1', 'a local:1', 'a local:1']);
+      expect(root).toMatchRenderedOutput(
+        <div>
+          List 1a local:1a outer:Ab local:0b outer:Aa local:1a outer:Ab local:0b
+          outer:A
+        </div>,
+      );
+
+      // The providers inside the SiblingAs and the distant Outer provider
+      // change in the same pass.
+      await act(() => {
+        setTick(2);
+        setValue('B');
+      });
+      assertLog([
+        'List 2',
+        'a local:2',
+        'a outer:B',
+        'b outer:B',
+        'a local:2',
+        'a outer:B',
+        'b outer:B',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <div>
+          List 2a local:2a outer:Bb local:0b outer:Ba local:2a outer:Bb local:0b
+          outer:B
+        </div>,
+      );
+    });
+
+    // @gate enableLegacyCache
+    it('propagates through Suspense boundaries in sibling subtrees (content and fallback)', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={4}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <Padding depth={2}>
+            <List />
+          </Padding>
+        );
+      });
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        setTick = _setTick;
+        const rows = useMemo(
+          () => ['x', 'y', 'z'].map(id => <Row key={id} id={id} />),
+          [],
+        );
+        return (
+          <>
+            <Text text={'List ' + tick} />
+            {rows}
+          </>
+        );
+      }
+
+      const Row = memo(function Row({id}) {
+        return (
+          <div>
+            <Suspense fallback={<Consumer id={id + ' fallback'} />}>
+              <Padding depth={2}>
+                <Async id={id} />
+                <Consumer id={id + ' content'} />
+              </Padding>
+            </Suspense>
+          </div>
+        );
+      });
+
+      function Async({id}) {
+        readText(id);
+        return null;
+      }
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      // Mount with 'y' still suspended.
+      await act(async () => {
+        seedNextTextCache('x');
+        seedNextTextCache('z');
+        root.render(<App />);
+      });
+      assertLog([
+        'List 0',
+        'x content:A',
+        'Suspend! [y]',
+        'y fallback:A',
+        'z content:A',
+        // pre-warming
+        'Suspend! [y]',
+        'y content:A',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          List 0<div>x content:A</div>
+          <div>y fallback:A</div>
+          <div>z content:A</div>
+        </>,
+      );
+
+      // Change the provider while the list also re-renders. The resolved
+      // boundaries update their content, the suspended one its fallback.
+      await act(() => {
+        setValue('B');
+        setTick(1);
+      });
+      assertLog([
+        'List 1',
+        'x content:B',
+        // The suspended boundary retries its content first
+        'Suspend! [y]',
+        'y fallback:B',
+        'z content:B',
+        // pre-warming
+        'Suspend! [y]',
+        'y content:B',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          List 1<div>x content:B</div>
+          <div>y fallback:B</div>
+          <div>z content:B</div>
+        </>,
+      );
+
+      // Same, but this time the list bails out too.
+      await act(() => {
+        setValue('C');
+      });
+      assertLog([
+        'x content:C',
+        'Suspend! [y]',
+        'y fallback:C',
+        'z content:C',
+        // pre-warming
+        'Suspend! [y]',
+        'y content:C',
+      ]);
+
+      // Unsuspend. The revealed content must show the latest value.
+      await act(async () => {
+        await resolveText('y');
+      });
+      assertLog(['y content:C']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          List 1<div>x content:C</div>
+          <div>y content:C</div>
+          <div>z content:C</div>
+        </>,
+      );
+    });
+
+    // @gate enableLegacyCache
+    it('propagates into a boundary that suspends during the update and is later retried', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={3}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <>
+            <Row id="x" />
+            <Row id="y" />
+          </>
+        );
+      });
+
+      const Row = memo(function Row({id}) {
+        return (
+          <div>
+            <Suspense fallback={<Text text={id + ' loading'} />}>
+              <AsyncConsumer id={id} />
+              <Padding depth={2}>
+                <Inner id={id} />
+              </Padding>
+            </Suspense>
+          </div>
+        );
+      });
+
+      // Suspends on the new value, so the boundary unwinds and re-renders
+      // with its fallback in the same pass that propagated the change.
+      function AsyncConsumer({id}) {
+        const value = useContext(Context);
+        readText(id + value);
+        return <Text text={id + ':' + value} />;
+      }
+
+      const Inner = memo(function Inner({id}) {
+        return <Consumer id={id + ' inner'} />;
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(async () => {
+        seedNextTextCache('xA');
+        root.render(<App />);
+      });
+      // 'yA' was not seeded, so y shows its fallback.
+      assertLog([
+        'x:A',
+        'x inner:A',
+        'Suspend! [yA]',
+        'y loading',
+        // pre-warming
+        'Suspend! [yA]',
+        'y inner:A',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <div>x:Ax inner:A</div>
+          <div>y loading</div>
+        </>,
+      );
+
+      await act(async () => {
+        await resolveText('yA');
+      });
+      assertLog(['y:A', 'y inner:A']);
+
+      // Change the provider. Both rows suspend on the new value.
+      await act(() => {
+        setValue('B');
+      });
+      assertLog([
+        'Suspend! [xB]',
+        'x loading',
+        'Suspend! [yB]',
+        'y loading',
+        // pre-warming
+        'Suspend! [xB]',
+        'x inner:B',
+        'Suspend! [yB]',
+        'y inner:B',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <div>x loading</div>
+          <div>y loading</div>
+        </>,
+      );
+
+      await act(async () => {
+        await resolveText('xB');
+        await resolveText('yB');
+      });
+      assertLog(['x:B', 'x inner:B', 'y:B', 'y inner:B']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <div>x:Bx inner:B</div>
+          <div>y:By inner:B</div>
+        </>,
+      );
+    });
+
+    it('propagates into hidden Activity subtrees of bailed-out siblings', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={4}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <div>
+            <List />
+          </div>
+        );
+      });
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        setTick = _setTick;
+        const rows = useMemo(
+          () => ['x', 'y'].map(id => <Row key={id} id={id} />),
+          [],
+        );
+        return (
+          <>
+            <Text text={'List ' + tick} />
+            {rows}
+          </>
+        );
+      }
+
+      const Row = memo(function Row({id}) {
+        return (
+          <>
+            <Consumer id={id + ' visible'} />
+            <Activity mode="hidden">
+              <Padding depth={2}>
+                <Consumer id={id + ' hidden'} />
+              </Padding>
+            </Activity>
+          </>
+        );
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog([
+        'List 0',
+        'x visible:A',
+        'y visible:A',
+        'x hidden:A',
+        'y hidden:A',
+      ]);
+
+      await act(() => {
+        setValue('B');
+        setTick(1);
+      });
+      assertLog([
+        'List 1',
+        'x visible:B',
+        'y visible:B',
+        'x hidden:B',
+        'y hidden:B',
+      ]);
+
+      await act(() => {
+        setValue('C');
+      });
+      assertLog(['x visible:C', 'y visible:C', 'x hidden:C', 'y hidden:C']);
+    });
+
+    // @gate enableSuspenseList
+    it('propagates through a SuspenseList that does a second pass', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={3}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <SuspenseList revealOrder="together">
+            <Row id="x" />
+            <Row id="y" />
+          </SuspenseList>
+        );
+      });
+
+      const Row = memo(function Row({id}) {
+        return (
+          <Suspense fallback={<Text text={id + ' loading'} />}>
+            <AsyncConsumer id={id} />
+            <Padding depth={2}>
+              <Inner id={id} />
+            </Padding>
+          </Suspense>
+        );
+      });
+
+      function AsyncConsumer({id}) {
+        const value = useContext(Context);
+        readText(id + value);
+        return <Text text={id + ':' + value} />;
+      }
+
+      const Inner = memo(function Inner({id}) {
+        return <Consumer id={id + ' inner'} />;
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(async () => {
+        seedNextTextCache('xA');
+        seedNextTextCache('yA');
+        root.render(<App />);
+      });
+      assertLog(['x:A', 'x inner:A', 'y:A', 'y inner:A']);
+      expect(root).toMatchRenderedOutput('x:Ax inner:Ay:Ay inner:A');
+
+      // Change the provider. Row y suspends on the new value, which forces
+      // the list to do a second pass over both rows to show them together.
+      await act(async () => {
+        await resolveText('xB');
+        setValue('B');
+      });
+      assertLog([
+        'x:B',
+        'x inner:B',
+        'Suspend! [yB]',
+        'y loading',
+        // second pass
+        'x:B',
+        'x inner:B',
+        'Suspend! [yB]',
+        'y loading',
+        // pre-warming
+        'Suspend! [yB]',
+        'y inner:B',
+      ]);
+      expect(root).toMatchRenderedOutput('x:Bx inner:By loading');
+
+      await act(async () => {
+        await resolveText('yB');
+      });
+      assertLog(['y:B', 'y inner:B']);
+      expect(root).toMatchRenderedOutput('x:Bx inner:By:By inner:B');
+    });
+
+    it('does not reuse walk results from an interrupted render attempt', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        return (
+          <Padding depth={3}>
+            <StaticMiddle />
+          </Padding>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <div>
+            <List />
+          </div>
+        );
+      });
+
+      // The provider sits directly between the re-rendering component and
+      // the bailing rows, so whether it changed is only discovered by the
+      // rows' own walks.
+      function List() {
+        const [tick, _setTick] = useState(0);
+        const [value, _setValue] = useState('A');
+        setTick = _setTick;
+        setValue = _setValue;
+        const children = useMemo(
+          () =>
+            [0, 1, 2].map(i => (
+              <React.Fragment key={i}>
+                <Row id={i} />
+                <Ticker id={i} />
+              </React.Fragment>
+            )),
+          [],
+        );
+        return (
+          <Context.Provider value={value}>
+            <TickContext.Provider value={tick}>
+              <Text text={'List ' + tick + ' ' + value} />
+              {children}
+            </TickContext.Provider>
+          </Context.Provider>
+        );
+      }
+
+      const TickContext = React.createContext(0);
+      function Ticker({id}) {
+        const tick = useContext(TickContext);
+        return <Text text={'T' + id + ':' + tick} />;
+      }
+
+      const Row = memo(function Row({id}) {
+        return (
+          <Padding depth={2}>
+            <Consumer id={id} />
+          </Padding>
+        );
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog(['List 0 A', '0:A', 'T0:0', '1:A', 'T1:0', '2:A', 'T2:0']);
+
+      // Start a transition that only bumps the tick. The rows bail out and
+      // record that nothing above them changed.
+      await act(async () => {
+        startTransition(() => {
+          setTick(1);
+        });
+        await waitFor(['List 1 A', 'T0:1']);
+
+        // Interrupt with a sync update that changes the provider. The rows
+        // are the same fibers as in the interrupted attempt, but this time
+        // the provider above them did change.
+        ReactNoop.flushSync(() => {
+          setValue('B');
+        });
+        assertLog(['List 0 B', '0:B', '1:B', '2:B']);
+        expect(root).toMatchRenderedOutput(
+          <div>List 0 B0:BT0:01:BT1:02:BT2:0</div>,
+        );
+
+        // The transition starts over on top of the new state. Nothing it
+        // renders reads a changed Context, so no consumer re-renders.
+        await waitForAll(['List 1 B', 'T0:1', 'T1:1', 'T2:1']);
+        expect(root).toMatchRenderedOutput(
+          <div>List 1 B0:BT0:11:BT1:12:BT2:1</div>,
+        );
+      });
+
+      // Now the other way around: the interrupted attempt saw a changed
+      // provider, the interrupting one must not.
+      await act(async () => {
+        startTransition(() => {
+          setValue('C');
+        });
+        await waitFor(['List 1 C', '0:C']);
+
+        ReactNoop.flushSync(() => {
+          setTick(2);
+        });
+        assertLog(['List 2 B', 'T0:2', 'T1:2', 'T2:2']);
+        expect(root).toMatchRenderedOutput(
+          <div>List 2 B0:BT0:21:BT1:22:BT2:2</div>,
+        );
+
+        await waitForAll(['List 2 C', '0:C', '1:C', '2:C']);
+        expect(root).toMatchRenderedOutput(
+          <div>List 2 C0:CT0:21:CT1:22:CT2:2</div>,
+        );
+      });
+    });
+
+    it('still propagates correctly when a render yields and resumes between siblings', async () => {
+      const root = ReactNoop.createRoot();
+      const Context = React.createContext('A');
+
+      let setValue;
+      let setTick;
+      function App() {
+        const [value, _setValue] = useState('A');
+        setValue = _setValue;
+        return (
+          <Context.Provider value={value}>
+            <Padding depth={4}>
+              <StaticMiddle />
+            </Padding>
+          </Context.Provider>
+        );
+      }
+
+      const StaticMiddle = memo(function StaticMiddle() {
+        return (
+          <div>
+            <List />
+          </div>
+        );
+      });
+
+      function List() {
+        const [tick, _setTick] = useState(0);
+        setTick = _setTick;
+        useContext(StableA);
+        const rows = useMemo(
+          () => [0, 1, 2, 3].map(i => <Row key={i} id={i} />),
+          [],
+        );
+        return (
+          <>
+            <Text text={'List ' + tick} />
+            {rows}
+          </>
+        );
+      }
+
+      const Row = memo(function Row({id}) {
+        return (
+          <Padding depth={2}>
+            <Consumer id={id + 'a'} />
+            <Consumer id={id + 'b'} />
+          </Padding>
+        );
+      });
+
+      function Consumer({id}) {
+        const value = useContext(Context);
+        return <Text text={id + ':' + value} />;
+      }
+
+      await act(() => {
+        root.render(<App />);
+      });
+      assertLog([
+        'List 0',
+        '0a:A',
+        '0b:A',
+        '1a:A',
+        '1b:A',
+        '2a:A',
+        '2b:A',
+        '3a:A',
+        '3b:A',
+      ]);
+
+      await act(async () => {
+        startTransition(() => {
+          setValue('B');
+          setTick(1);
+        });
+        // Yield in the middle of a row, then between rows, then finish.
+        await waitFor(['List 1', '0a:B']);
+        await waitFor(['0b:B', '1a:B', '1b:B']);
+        await waitForAll(['2a:B', '2b:B', '3a:B', '3b:B']);
+      });
+      expect(root).toMatchRenderedOutput(
+        <div>List 10a:B0b:B1a:B1b:B2a:B2b:B3a:B3b:B</div>,
+      );
+    });
+  });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -25,6 +25,11 @@
 // Enables the browser() API exported from react-dom.
 export const enableBrowserAPI: boolean = true;
 
+// Memoizes the upward provider walk done by lazy context propagation when a
+// fiber bails out, per render attempt, so wide bailing subtrees don't repeat
+// it. Off by default while it rolls out.
+export const enableMemoizedContextPropagation: boolean = false;
+
 // -----------------------------------------------------------------------------
 // Land or remove (moderate effort)
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -87,6 +87,7 @@ export const enablePerformanceIssueReporting: boolean =
   enableComponentPerformanceTrack;
 export const enableInternalInstanceMap: boolean = false;
 export const enableOptimisticKey: boolean = false;
+export const enableMemoizedContextPropagation: boolean = false;
 export const enableParallelTransitions: boolean = true;
 
 export const eprh_enableUseKeyedStateCompilerLint: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -87,6 +87,7 @@ export const enableProfilerTimer: boolean = __PROFILE__;
 export const enableProfilerCommitHooks: boolean = __PROFILE__;
 export const enableProfilerNestedUpdatePhase: boolean = __PROFILE__;
 export const enableUpdaterTracking: boolean = __PROFILE__;
+export const enableMemoizedContextPropagation: boolean = false;
 export const enableParallelTransitions: boolean = true;
 
 export const eprh_enableUseKeyedStateCompilerLint: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -96,6 +96,7 @@ export const enableReactTestRendererWarning: boolean = true;
 export const enableObjectFiber: boolean = false;
 
 export const enableOptimisticKey: boolean = false;
+export const enableMemoizedContextPropagation: boolean = false;
 export const enableParallelTransitions: boolean = true;
 
 export const eprh_enableUseKeyedStateCompilerLint: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -73,6 +73,7 @@ export const enableFragmentRefsInstanceHandles = false;
 export const enableFragmentRefsTextNodes = false;
 export const ownerStackLimit = 1e4;
 export const enableOptimisticKey = false;
+export const enableMemoizedContextPropagation = false;
 export const enableParallelTransitions = true;
 
 export const eprh_enableUseKeyedStateCompilerLint: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -88,6 +88,7 @@ export const ownerStackLimit = 1e4;
 export const enableInternalInstanceMap: boolean = false;
 
 export const enableOptimisticKey: boolean = false;
+export const enableMemoizedContextPropagation: boolean = false;
 export const enableParallelTransitions: boolean = true;
 
 export const eprh_enableUseKeyedStateCompilerLint: boolean = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -39,6 +39,7 @@ export const enableFragmentRefs: boolean = __VARIANT__;
 export const enableFragmentRefsScrollIntoView: boolean = __VARIANT__;
 export const enableFragmentRefsTextNodes: boolean = __VARIANT__;
 export const enableInternalInstanceMap: boolean = __VARIANT__;
+export const enableMemoizedContextPropagation: boolean = __VARIANT__;
 export const enableParallelTransitions: boolean = __VARIANT__;
 
 // TODO: These flags are hard-coded to the default values used in open source.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -35,6 +35,7 @@ export const {
   enableFragmentRefsScrollIntoView,
   enableFragmentRefsTextNodes,
   enableInternalInstanceMap,
+  enableMemoizedContextPropagation,
   enableParallelTransitions,
   enableViewTransitionParentEnterExit,
 } = dynamicFeatureFlags;


### PR DESCRIPTION
## Summary

When an update enters high in a deep tree and the subtrees around it bail out, every idle sibling runs `propagateParentContextChanges` all the way to the root and almost never finds anything. Ancestors with child work never get `DidPropagateContext`, so nothing cuts the walk short. The comment on that flag from #20890 already calls this out. In a real app (~290 fibers deep, ~100 providers, ~33 sync commits/s while streaming) it was ~13% of JS.

The set of changed providers at or above an already-begun ancestor is fixed for the rest of the attempt, so memoize it per provider fiber and let later walks stop at the first hit. Two maps (one per `NeedsPropagation` state), immutable linked lists so nested providers share structure, reset in `resetContextDependencies` and wherever the work loop re-enters an already begun fiber. Same contexts get propagated as before.

Behind `enableMemoizedContextPropagation` (off in OSS, `__VARIANT__` on www). In DEV every memo hit is checked against the full walk and falls back to it with a console.error if they disagree.

Chrome, prod builds, tree shaped like the profile above: -35% per commit when a provider changes on 15% of commits, -72% when none do. Walk iterations 380k -> 21k per run. Unrelated scenarios within noise.

The first two commits are small standalone bits this builds on (skip the walk when the bailing fiber has no children, share `fiber.dependencies` instead of cloning it). Happy to split them out.

## How did you test this change?

12 new tests in ReactContextPropagation-test (nested providers, DidPropagateContext boundaries, Suspense/Activity/SuspenseList, interrupted and resumed renders), run in both flag states. Full react-reconciler and react-dom suites, source and prod, flag off and on. www both variants. linc + flow.
