### PR TITLE
[DOM/RN] Unobserve deleted Fragment children

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3826,6 +3826,11 @@ export function deleteChildFromFragmentInstance(
     return;
   }
   const instance: InstanceWithFragmentHandles = childInstance as any;
+  if (fragmentInstance._observers !== null) {
+    fragmentInstance._observers.forEach(observer => {
+      observer.unobserve(instance);
+    });
+  }
   if (enableFragmentRefsInstanceHandles) {
     if (instance.reactFragments != null) {
       instance.reactFragments.delete(fragmentInstance);

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1779,6 +1779,41 @@ describe('FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs
+    it('keeps children removed from the fragment in the observer target set', async () => {
+      const observerMock = mockIntersectionObserver();
+      const fragmentRef = React.createRef();
+      const childARef = React.createRef();
+      const childBRef = React.createRef();
+      const observer = new IntersectionObserver(() => {});
+
+      function Test({showB}) {
+        return (
+          <React.Fragment ref={fragmentRef}>
+            <div ref={childARef}>A</div>
+            {showB && <div ref={childBRef}>B</div>}
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test showB={true} />));
+      fragmentRef.current.observeUsing(observer);
+
+      const childA = childARef.current;
+      const childB = childBRef.current;
+      expect(observerMock.observedTargets).toEqual([childA, childB]);
+
+      await act(() => root.render(<Test showB={false} />));
+      // Deleted children stay in the observer's target set.
+      expect(observerMock.observedTargets).toEqual([childA, childB]);
+
+      // unobserveUsing only walks current children, so it cannot clean up
+      // deleted ones either.
+      fragmentRef.current.unobserveUsing(observer);
+      expect(observerMock.observedTargets).toEqual([childB]);
+    });
+
+    // @gate enableFragmentRefs
     it('warns when unobserveUsing() is called with an observer that was not observed', async () => {
       const fragmentRef = React.createRef();
       const observer = new IntersectionObserver(() => {});

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1779,7 +1779,7 @@ describe('FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs
-    it('keeps children removed from the fragment in the observer target set', async () => {
+    it('unobserves children removed from the fragment', async () => {
       const observerMock = mockIntersectionObserver();
       const fragmentRef = React.createRef();
       const childARef = React.createRef();
@@ -1804,13 +1804,10 @@ describe('FragmentRefs', () => {
       expect(observerMock.observedTargets).toEqual([childA, childB]);
 
       await act(() => root.render(<Test showB={false} />));
-      // Deleted children stay in the observer's target set.
-      expect(observerMock.observedTargets).toEqual([childA, childB]);
+      expect(observerMock.observedTargets).toEqual([childA]);
 
-      // unobserveUsing only walks current children, so it cannot clean up
-      // deleted ones either.
       fragmentRef.current.unobserveUsing(observer);
-      expect(observerMock.observedTargets).toEqual([childB]);
+      expect(observerMock.observedTargets).toEqual([]);
     });
 
     // @gate enableFragmentRefs

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -943,6 +943,16 @@ export function deleteChildFromFragmentInstance(
   const publicInstance = getPublicInstance(
     instance,
   ) as any as PublicInstanceWithFragmentHandles;
+  if (fragmentInstance._observers !== null) {
+    if (publicInstance == null) {
+      throw new Error('Expected to find a host node. This is a bug in React.');
+    }
+    // $FlowFixMe[incompatible-type]
+    fragmentInstance._observers.forEach(observer => {
+      // $FlowFixMe[incompatible-type] Element types are behind a flag in RN
+      observer.unobserve(publicInstance);
+    });
+  }
   if (enableFragmentRefsInstanceHandles) {
     if (publicInstance.reactFragments != null) {
       publicInstance.reactFragments.delete(fragmentInstance);

--- a/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
@@ -121,5 +121,54 @@ describe('Fabric FragmentRefs', () => {
       });
       expect(logs).toEqual(['B']);
     });
+
+    // @gate enableFragmentRefs
+    it('keeps children removed from the fragment in the observer target set', async () => {
+      const observed = [];
+      const observer = {
+        observe: instance => {
+          observed.push(instance);
+        },
+        unobserve: instance => {
+          const index = observed.indexOf(instance);
+          if (index >= 0) {
+            observed.splice(index, 1);
+          }
+        },
+      };
+      const fragmentRef = React.createRef();
+      const childARef = React.createRef();
+      const childBRef = React.createRef();
+      function Test({showB}) {
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(observer);
+          const lastRefValue = fragmentRef.current;
+          return () => {
+            lastRefValue.unobserveUsing(observer);
+          };
+        }, []);
+        return (
+          <View>
+            <React.Fragment ref={fragmentRef}>
+              <View ref={childARef} />
+              {showB && <View ref={childBRef} />}
+            </React.Fragment>
+          </View>
+        );
+      }
+
+      await act(() => {
+        ReactFabric.render(<Test showB={true} />, 11, null, true);
+      });
+      const childA = childARef.current;
+      const childB = childBRef.current;
+      expect(observed).toEqual([childA, childB]);
+
+      await act(() => {
+        ReactFabric.render(<Test showB={false} />, 11, null, true);
+      });
+      // Deleted children stay in the observer's target set.
+      expect(observed).toEqual([childA, childB]);
+    });
   });
 });

--- a/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
@@ -123,7 +123,7 @@ describe('Fabric FragmentRefs', () => {
     });
 
     // @gate enableFragmentRefs
-    it('keeps children removed from the fragment in the observer target set', async () => {
+    it('unobserves children removed from the fragment', async () => {
       const observed = [];
       const observer = {
         observe: instance => {
@@ -167,8 +167,7 @@ describe('Fabric FragmentRefs', () => {
       await act(() => {
         ReactFabric.render(<Test showB={false} />, 11, null, true);
       });
-      // Deleted children stay in the observer's target set.
-      expect(observed).toEqual([childA, childB]);
+      expect(observed).toEqual([childA]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `commitNewChildToFragmentInstance` observes newly inserted Fragment children, but `deleteChildFromFragmentInstance` never called `unobserve`.
- Deleted element children stayed in `IntersectionObserver` / `ResizeObserver` target sets. `unobserveUsing()` could not clean them up because it only walks current children.
- Mirror the insert path on delete for DOM and Fabric.

## Test plan
- added test characterizing the bug in the first commit