### PR TITLE
[DevTools] Use deterministic extension commit hashes

### DIFF
--- a/packages/react-devtools-extensions/utils.js
+++ b/packages/react-devtools-extensions/utils.js
@@ -6,39 +6,21 @@
  */
 
 const {execSync} = require('child_process');
-const {existsSync, readFileSync} = require('fs');
+const {readFileSync} = require('fs');
 const {resolve} = require('path');
 
 const GITHUB_URL = 'https://github.com/facebook/react';
+const GIT_COMMIT_HASH_LENGTH = 10;
+
+function shortenCommitHash(commitHash) {
+  return commitHash.trim().slice(0, GIT_COMMIT_HASH_LENGTH);
+}
 
 function getGitCommit() {
-  try {
-    return execSync('git show -s --no-show-signature --format=%h')
-      .toString()
-      .trim();
-  } catch (error) {
-    // Mozilla runs this command from a git archive.
-    // In that context, there is no Git context.
-    // Using the commit hash specified to download-experimental-build.js script as a fallback.
-
-    // Try to read from build/COMMIT_SHA file
-    const commitShaPath = resolve(__dirname, '..', '..', 'build', 'COMMIT_SHA');
-    if (!existsSync(commitShaPath)) {
-      throw new Error(
-        'Could not find build/COMMIT_SHA file. Did you run scripts/release/download-experimental-build.js script?',
-      );
-    }
-
-    try {
-      const commitHash = readFileSync(commitShaPath, 'utf8').trim();
-      // Return short hash (first 7 characters) to match abbreviated commit hash format
-      return commitHash.slice(0, 7);
-    } catch (readError) {
-      throw new Error(
-        `Failed to read build/COMMIT_SHA file: ${readError.message}`,
-      );
-    }
-  }
+  const commitHash = execSync(
+    'git show -s --no-show-signature --format=%H',
+  ).toString();
+  return shortenCommitHash(commitHash);
 }
 
 function getVersionString(packageVersion = null) {


### PR DESCRIPTION
## Summary

`git show --format=%h` is not stable: abbreviation length depends on `core.abbrev` and how unique the prefix is in that clone. Two rebuilds of the same commit can therefore embed different strings in `DEVTOOLS_VERSION` and the extension manifest.

Always take the full hash (`%H`) and slice it to 10 characters so the value is the same everywhere.

This also removes the `build/COMMIT_SHA` fallback used when Mozilla rebuilds from a git archive (no `.git`). That path used a different length (7) and a different source, so it could not match a git checkout of the same commit. Firefox source review should rebuild from a checkout of the commit in #37307, not from the tarball alone.

Stack: this PR → #37306 → #37307.

## How did you test this change?

Build-script only. `getGitCommit()` now returns `HEAD` sliced to 10 chars, independent of `core.abbrev`.