### PR TITLE
[DevTools] Remove build dates from extension manifests

### DIFF
--- a/packages/react-devtools-extensions/build.js
+++ b/packages/react-devtools-extensions/build.js
@@ -97,13 +97,8 @@ const build = async (tempPath, manifestPath, envExtension = {}) => {
   );
 
   const commit = getGitCommit();
-  const dateString = new Date().toLocaleDateString();
   const manifest = JSON.parse(readFileSync(copiedManifestPath).toString());
-  const versionDateString = `${manifest.version} (${dateString})`;
-  if (manifest.version_name) {
-    manifest.version_name = versionDateString;
-  }
-  manifest.description += `\n\nCreated from revision ${commit} on ${dateString}.`;
+  manifest.description += `\n\nCreated from revision ${commit}.`;
 
   if (process.env.NODE_ENV === 'development') {
     // When building the local development version of the


### PR DESCRIPTION
## Summary

The extension build writes `new Date().toLocaleDateString()` into Chrome/Edge `version_name` and into every browser's manifest description. That string changes with the calendar, timezone, and locale, so a Firefox AMO rebuild on another day cannot match the uploaded zip.

Stop stamping dates. `version_name` stays the value from the source manifest (still updated by `prepare-release.js` on version bumps). The description still records the commit from #37305.

Depends on #37305. Next: #37307.

## How did you test this change?

Build-script only. After this, `manifest.json` description is `Created from revision <commit>.` and Chrome/Edge `version_name` is the committed version string.