### PR TITLE
[DevTools] Use one commit for extension release inputs

### DIFF
--- a/scripts/devtools/build-and-test.js
+++ b/scripts/devtools/build-and-test.js
@@ -4,7 +4,6 @@
 
 const chalk = require('chalk');
 const {exec} = require('child-process-promise');
-const inquirer = require('inquirer');
 const {homedir} = require('os');
 const {join, relative} = require('path');
 const {DRY_RUN, ROOT_PATH} = require('./configuration');
@@ -49,8 +48,10 @@ async function main() {
     console.log(chalk.bold.green('  ' + pathToPrint));
   });
 
-  const archivePath = await archiveGitRevision();
-  const currentCommitHash = await downloadLatestReactBuild();
+  await ensureCleanWorkingTree();
+  const currentCommitHash = await getCurrentCommitHash();
+  const archivePath = await archiveGitRevision(currentCommitHash);
+  await downloadLatestReactBuild(currentCommitHash);
 
   await buildAndTestInlinePackage();
   await buildAndTestStandalonePackage();
@@ -61,7 +62,22 @@ async function main() {
   printFinalInstructions();
 }
 
-async function archiveGitRevision() {
+async function ensureCleanWorkingTree() {
+  const status = await execRead('git status --porcelain', {cwd: ROOT_PATH});
+  if (status !== '') {
+    throw new Error('Cannot build a release from a dirty working tree.');
+  }
+}
+
+async function getCurrentCommitHash() {
+  const commitHash = await execRead('git rev-parse HEAD', {cwd: ROOT_PATH});
+  if (commitHash === '') {
+    throw new Error('Failed to get current commit hash');
+  }
+  return commitHash;
+}
+
+async function archiveGitRevision(currentCommitHash) {
   const desktopPath = join(homedir(), 'Desktop');
   const archivePath = join(desktopPath, 'DevTools.tgz');
 
@@ -69,7 +85,10 @@ async function archiveGitRevision() {
   console.log('');
 
   if (!DRY_RUN) {
-    await exec(`git archive main | gzip > ${archivePath}`, {cwd: ROOT_PATH});
+    await exec(
+      `git archive --format=tar.gz --output="${archivePath}" ${currentCommitHash}`,
+      {cwd: ROOT_PATH}
+    );
   }
 
   return archivePath;
@@ -181,7 +200,7 @@ async function buildAndTestInlinePackage() {
   await confirmContinue();
 }
 
-async function downloadLatestReactBuild() {
+async function downloadLatestReactBuild(currentCommitHash) {
   const releaseScriptPath = join(ROOT_PATH, 'scripts', 'release');
   const installPromise = exec('yarn install', {cwd: releaseScriptPath});
 
@@ -197,34 +216,17 @@ async function downloadLatestReactBuild() {
 
   console.log('');
 
-  const currentCommitHash = (await exec('git rev-parse HEAD')).stdout.trim();
-  if (!currentCommitHash) {
-    throw new Error('Failed to get current commit hash');
-  }
-
-  const {commit} = await inquirer.prompt([
-    {
-      type: 'input',
-      name: 'commit',
-      message: 'Which React version (commit) should be used?',
-      default: currentCommitHash,
-    },
-  ]);
-  console.log('');
-
   const downloadScriptPath = join(
     releaseScriptPath,
     'download-experimental-build.js'
   );
   const downloadPromise = execRead(
-    `"${downloadScriptPath}" --commit=${commit}`
+    `"${downloadScriptPath}" --commit=${currentCommitHash}`
   );
 
   await logger(downloadPromise, 'Downloading React artifacts from CI.', {
     estimate: 15000,
   });
-
-  return currentCommitHash;
 }
 
 function printFinalInstructions() {


### PR DESCRIPTION
## Summary

`build-and-test.js` could feed three different commits into one release: `git archive main` (not `HEAD`), an interactively chosen React CI build, and `HEAD` saved as metadata. Firefox source review then could not reproduce the zip.

Require a clean tree, resolve `HEAD` once, and use that hash for the source archive, the experimental React download, and the metadata printed for AMO. Drop the prompt that let those diverge.

Depends on #37305 and #37306.

## How did you test this change?

Build-script only. The release helper now errors on a dirty tree and threads a single `git rev-parse HEAD` into archive, download, and metadata.