### PR TITLE
[Fabric] Fix FragmentInstance.compareDocumentPosition portal and fiber-tree parity with DOM

### DIFF
--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -26,6 +26,12 @@ import {HostText} from 'react-reconciler/src/ReactWorkTags';
 import {
   getFragmentParentInstanceOrContainerFiber,
   traverseFragmentInstancesAndTextInstances,
+  fiberIsPortaledIntoHost,
+  getFragmentPortalContainerInfo,
+  isFiberContainedByFragment,
+  isFragmentContainedByFiber,
+  isFiberPreceding,
+  isFiberFollowing,
 } from 'react-reconciler/src/ReactFiberTreeReflection';
 
 // Modules provided by RN:
@@ -36,6 +42,7 @@ import {
   createPublicTextInstance,
   createAttributePayload,
   diffAttributePayloads,
+  getInternalInstanceHandleFromPublicInstance,
   type PublicInstance as ReactNativePublicInstance,
   type PublicTextInstance,
   type PublicRootInstance,
@@ -764,8 +771,22 @@ FragmentInstance.prototype.compareDocumentPosition = function (
     collectChildren,
     children,
   );
+
+  // If the fragment has been portaled into another host instance, position
+  // against the portal container rather than the React host parent.
+  let parentHostInstance = getPublicInstanceFromHostFiber(parentHostFiber);
+  if (fiberIsPortaledIntoHost(this._fragmentFiber)) {
+    const portalContainer = getFragmentPortalContainerInfo(
+      this._fragmentFiber,
+    );
+    if (portalContainer != null && portalContainer.publicInstance != null) {
+      // $FlowFixMe[incompatible-type] Container's publicInstance is typed as
+      // PublicRootInstance, but it's used the same way as PublicInstance.
+      parentHostInstance = portalContainer.publicInstance;
+    }
+  }
+
   if (children.length === 0) {
-    const parentHostInstance = getPublicInstanceFromHostFiber(parentHostFiber);
     return compareDocumentPositionForEmptyFragment<PublicInstance>(
       this._fragmentFiber,
       parentHostInstance,
@@ -779,6 +800,19 @@ FragmentInstance.prototype.compareDocumentPosition = function (
     children[children.length - 1],
   );
 
+  // Check if first and last node are actually in the expected position
+  // before relying on them as source of truth for other contained nodes.
+  // $FlowFixMe[incompatible-use] Fabric PublicInstance is opaque
+  // $FlowFixMe[prop-missing]
+  const firstNodeIsContained =
+    parentHostInstance.compareDocumentPosition(firstInstance) &
+    Node.DOCUMENT_POSITION_CONTAINED_BY;
+  // $FlowFixMe[incompatible-use] Fabric PublicInstance is opaque
+  // $FlowFixMe[prop-missing]
+  const lastNodeIsContained =
+    parentHostInstance.compareDocumentPosition(lastInstance) &
+    Node.DOCUMENT_POSITION_CONTAINED_BY;
+
   // $FlowFixMe[incompatible-use] Fabric PublicInstance is opaque
   // $FlowFixMe[prop-missing]
   const firstResult = firstInstance.compareDocumentPosition(otherNode);
@@ -787,13 +821,20 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   const lastResult = lastInstance.compareDocumentPosition(otherNode);
 
   const otherNodeIsFirstOrLastChild =
-    firstInstance === otherNode || lastInstance === otherNode;
+    (firstNodeIsContained && firstInstance === otherNode) ||
+    (lastNodeIsContained && lastInstance === otherNode);
+  const otherNodeIsFirstOrLastChildDisconnected =
+    (!firstNodeIsContained && firstInstance === otherNode) ||
+    (!lastNodeIsContained && lastInstance === otherNode);
   const otherNodeIsWithinFirstOrLastChild =
     firstResult & Node.DOCUMENT_POSITION_CONTAINED_BY ||
     lastResult & Node.DOCUMENT_POSITION_CONTAINED_BY;
   const otherNodeIsBetweenFirstAndLastChildren =
+    firstNodeIsContained &&
+    lastNodeIsContained &&
     firstResult & Node.DOCUMENT_POSITION_FOLLOWING &&
     lastResult & Node.DOCUMENT_POSITION_PRECEDING;
+
   let result;
   if (
     otherNodeIsFirstOrLastChild ||
@@ -801,12 +842,78 @@ FragmentInstance.prototype.compareDocumentPosition = function (
     otherNodeIsBetweenFirstAndLastChildren
   ) {
     result = Node.DOCUMENT_POSITION_CONTAINED_BY;
+  } else if (otherNodeIsFirstOrLastChildDisconnected) {
+    // otherNode has been portaled into another container.
+    result = Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
   } else {
     result = firstResult;
   }
 
-  return result;
+  if (
+    result & Node.DOCUMENT_POSITION_DISCONNECTED ||
+    result & Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+  ) {
+    return result;
+  }
+
+  // Now that we have the result from the native API, double check it
+  // matches the state of the React tree. If it doesn't, we have a case of
+  // portaled or otherwise injected instances and we return
+  // DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC.
+  const documentPositionMatchesFiberPosition =
+    validateDocumentPositionWithFiberTree(
+      result,
+      this._fragmentFiber,
+      children[0],
+      children[children.length - 1],
+      otherNode,
+    );
+  if (documentPositionMatchesFiberPosition) {
+    return result;
+  }
+  return Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
 };
+
+function validateDocumentPositionWithFiberTree(
+  documentPosition: number,
+  fragmentFiber: Fiber,
+  precedingBoundaryFiber: Fiber,
+  followingBoundaryFiber: Fiber,
+  otherNode: PublicInstance,
+): boolean {
+  const otherFiber: Fiber | null =
+    // $FlowFixMe[incompatible-type] internal instance handle is the fiber.
+    getInternalInstanceHandleFromPublicInstance(otherNode);
+  if (documentPosition & Node.DOCUMENT_POSITION_CONTAINED_BY) {
+    return (
+      !!otherFiber && isFiberContainedByFragment(otherFiber, fragmentFiber)
+    );
+  }
+  if (documentPosition & Node.DOCUMENT_POSITION_CONTAINS) {
+    if (otherFiber === null) {
+      // otherNode isn't a React-managed instance (e.g. a foreign native
+      // view), so we can't validate it against the fiber tree.
+      return false;
+    }
+    return isFragmentContainedByFiber(fragmentFiber, otherFiber);
+  }
+  if (documentPosition & Node.DOCUMENT_POSITION_PRECEDING) {
+    return (
+      !!otherFiber &&
+      (otherFiber === precedingBoundaryFiber ||
+        isFiberPreceding(precedingBoundaryFiber, otherFiber))
+    );
+  }
+  if (documentPosition & Node.DOCUMENT_POSITION_FOLLOWING) {
+    return (
+      !!otherFiber &&
+      (otherFiber === followingBoundaryFiber ||
+        isFiberFollowing(followingBoundaryFiber, otherFiber))
+    );
+  }
+
+  return false;
+}
 
 function collectChildren(child: Fiber, collection: Array<Fiber>): boolean {
   collection.push(child);

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
@@ -22,6 +22,100 @@ function dumpSubtree(info, indent) {
   return out;
 }
 
+// document.compareDocumentPosition() bits, replicated here because this file
+// runs under `@jest-environment node`, which has no DOM `Node` global.
+const DOCUMENT_POSITION_DISCONNECTED = 1;
+const DOCUMENT_POSITION_PRECEDING = 2;
+const DOCUMENT_POSITION_FOLLOWING = 4;
+const DOCUMENT_POSITION_CONTAINS = 8;
+const DOCUMENT_POSITION_CONTAINED_BY = 16;
+const DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
+
+// Fabric persists/clones nodes on nearly every commit, so a node object's
+// identity (and any parent pointer we'd cache on it) goes stale almost
+// immediately. Instead, walk the *live* `roots` map fresh on every query, so
+// this always reflects the currently committed tree.
+function computeDocumentOrder() {
+  const positions = new Map();
+  let order = 0;
+  function visit(node, ancestorTags, rootTag) {
+    positions.set(node.reactTag, {ancestorTags, order: order++, rootTag});
+    const childAncestorTags = ancestorTags.concat(node.reactTag);
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const child of node.children) {
+      visit(child, childAncestorTags, rootTag);
+    }
+  }
+  // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+  for (const [rootTag, childSet] of roots) {
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const child of childSet) {
+      visit(child, [], rootTag);
+    }
+  }
+  return positions;
+}
+
+// Test-only stand-in for the native compareDocumentPosition method that a
+// real Fabric PublicInstance exposes. Not a claim about the real native
+// module's shape or naming.
+function compareDocumentPositionForJestTestsOnly(reactTagA, reactTagB) {
+  if (reactTagA === reactTagB) {
+    return 0;
+  }
+  const positions = computeDocumentOrder();
+  const a = positions.get(reactTagA);
+  const b = positions.get(reactTagB);
+  if (a === undefined || b === undefined || a.rootTag !== b.rootTag) {
+    return (
+      DOCUMENT_POSITION_DISCONNECTED |
+      DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC |
+      (reactTagA < reactTagB
+        ? DOCUMENT_POSITION_FOLLOWING
+        : DOCUMENT_POSITION_PRECEDING)
+    );
+  }
+  if (b.ancestorTags.includes(reactTagA)) {
+    return DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING;
+  }
+  if (a.ancestorTags.includes(reactTagB)) {
+    return DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING;
+  }
+  return a.order < b.order
+    ? DOCUMENT_POSITION_FOLLOWING
+    : DOCUMENT_POSITION_PRECEDING;
+}
+
+// Test-only lookup so tests can splice a foreign (non-React-tracked) node
+// directly into a shadow node's children, to simulate an injected native
+// view. Not a real native API.
+function findNodeForJestTestsOnly(reactTag) {
+  function search(node) {
+    if (node.reactTag === reactTag) {
+      return node;
+    }
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const child of node.children) {
+      const found = search(child);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+  // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+  for (const childSet of roots.values()) {
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (const child of childSet) {
+      const found = search(child);
+      if (found != null) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
 const RCTFabricUIManager = {
   __dumpChildSetForJestTestsOnly: function (childSet) {
     const result = [];
@@ -191,6 +285,11 @@ const RCTFabricUIManager = {
     },
   ),
   setIsJSResponder: jest.fn(),
+
+  compareDocumentPositionForJestTestsOnly: jest.fn(
+    compareDocumentPositionForJestTestsOnly,
+  ),
+  findNodeForJestTestsOnly: jest.fn(findNodeForJestTestsOnly),
 };
 
 global.nativeFabricUIManager = RCTFabricUIManager;

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -26,6 +26,9 @@ module.exports = {
   get getNodeFromPublicInstance() {
     return require('./getNodeFromPublicInstance').default;
   },
+  get getInternalInstanceHandleFromPublicInstance() {
+    return require('./getInternalInstanceHandleFromPublicInstance').default;
+  },
   get createPublicInstance() {
     return require('./createPublicInstance').default;
   },

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/createPublicInstance.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/createPublicInstance.js
@@ -22,5 +22,12 @@ export default function createPublicInstance(
     __nativeTag: tag,
     __internalInstanceHandle: internalInstanceHandle,
     __rootPublicInstance: rootPublicInstance,
+    compareDocumentPosition(otherPublicInstance: PublicInstance): number {
+      return global.nativeFabricUIManager.compareDocumentPositionForJestTestsOnly(
+        tag,
+        // $FlowFixMe[prop-missing]
+        otherPublicInstance.__nativeTag,
+      );
+    },
   };
 }

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/getInternalInstanceHandleFromPublicInstance.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/getInternalInstanceHandleFromPublicInstance.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type {PublicInstance} from './ReactNativePrivateInterface';
+
+export default function getInternalInstanceHandleFromPublicInstance(
+  publicInstance: PublicInstance,
+): mixed {
+  return publicInstance.__internalInstanceHandle;
+}

--- a/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
@@ -23,6 +23,18 @@ describe('Fabric FragmentRefs', () => {
 
     require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
 
+    // This file runs under `@jest-environment node`, so unlike the DOM
+    // FragmentRefs tests, there's no browser `Node` global providing these
+    // constants.
+    global.Node = {
+      DOCUMENT_POSITION_DISCONNECTED: 1,
+      DOCUMENT_POSITION_PRECEDING: 2,
+      DOCUMENT_POSITION_FOLLOWING: 4,
+      DOCUMENT_POSITION_CONTAINS: 8,
+      DOCUMENT_POSITION_CONTAINED_BY: 16,
+      DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: 32,
+    };
+
     React = require('react');
     ReactFabric = require('react-native-renderer/fabric');
     createReactNativeComponentClass =
@@ -120,6 +132,177 @@ describe('Fabric FragmentRefs', () => {
         ReactFabric.render(<Test showB={true} />, 11, null, true);
       });
       expect(logs).toEqual(['B']);
+    });
+  });
+
+  describe('compareDocumentPosition', () => {
+    function expectPosition(position, spec) {
+      expect({
+        following: (position & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+        preceding: (position & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
+        contains: (position & Node.DOCUMENT_POSITION_CONTAINS) !== 0,
+        containedBy: (position & Node.DOCUMENT_POSITION_CONTAINED_BY) !== 0,
+        disconnected: (position & Node.DOCUMENT_POSITION_DISCONNECTED) !== 0,
+        implementationSpecific:
+          (position & Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC) !== 0,
+      }).toEqual(spec);
+    }
+
+    // @gate enableFragmentRefs
+    it('returns the relationship between the fragment instance and a given node', async () => {
+      const fragmentRef = React.createRef();
+      const beforeRef = React.createRef();
+      const afterRef = React.createRef();
+      const firstChildRef = React.createRef();
+      const middleChildRef = React.createRef();
+      const lastChildRef = React.createRef();
+      const containerRef = React.createRef();
+
+      function Test() {
+        return (
+          <View nativeID="container" ref={containerRef}>
+            <View nativeID="before" ref={beforeRef} />
+            <React.Fragment ref={fragmentRef}>
+              <View nativeID="first" ref={firstChildRef} />
+              <View nativeID="middle" ref={middleChildRef} />
+              <View nativeID="last" ref={lastChildRef} />
+            </React.Fragment>
+            <View nativeID="after" ref={afterRef} />
+          </View>
+        );
+      }
+
+      await act(() => {
+        ReactFabric.render(<Test />, 11, null, true);
+      });
+
+      // beforeRef is preceding the fragment
+      expectPosition(
+        fragmentRef.current.compareDocumentPosition(beforeRef.current),
+        {
+          preceding: true,
+          following: false,
+          contains: false,
+          containedBy: false,
+          disconnected: false,
+          implementationSpecific: false,
+        },
+      );
+
+      // afterRef is following the fragment
+      expectPosition(
+        fragmentRef.current.compareDocumentPosition(afterRef.current),
+        {
+          preceding: false,
+          following: true,
+          contains: false,
+          containedBy: false,
+          disconnected: false,
+          implementationSpecific: false,
+        },
+      );
+
+      // firstChildRef, middleChildRef, and lastChildRef are contained by the fragment
+      [firstChildRef, middleChildRef, lastChildRef].forEach(ref => {
+        expectPosition(fragmentRef.current.compareDocumentPosition(ref.current), {
+          preceding: false,
+          following: false,
+          contains: false,
+          containedBy: true,
+          disconnected: false,
+          implementationSpecific: false,
+        });
+      });
+
+      // containerRef precedes and contains the fragment
+      expectPosition(
+        fragmentRef.current.compareDocumentPosition(containerRef.current),
+        {
+          preceding: true,
+          following: false,
+          contains: true,
+          containedBy: false,
+          disconnected: false,
+          implementationSpecific: false,
+        },
+      );
+
+      // A node from a disconnected tree is reported as disconnected. Per
+      // spec, preceding/following is implementation-defined in this case,
+      // so only assert the bits that are well-defined.
+      const disconnectedInstance = {
+        __nativeTag: -1,
+        __internalInstanceHandle: null,
+      };
+      const disconnectedPosition = fragmentRef.current.compareDocumentPosition(
+        disconnectedInstance,
+      );
+      expect(
+        disconnectedPosition & Node.DOCUMENT_POSITION_DISCONNECTED,
+      ).not.toBe(0);
+      expect(
+        disconnectedPosition & Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+      ).not.toBe(0);
+      expect(disconnectedPosition & Node.DOCUMENT_POSITION_CONTAINS).toBe(0);
+      expect(
+        disconnectedPosition & Node.DOCUMENT_POSITION_CONTAINED_BY,
+      ).toBe(0);
+    });
+
+    // @gate enableFragmentRefs
+    it('does not report a foreign native view spliced between the fragment children as contained', async () => {
+      const fragmentRef = React.createRef();
+      const containerRef = React.createRef();
+      const firstChildRef = React.createRef();
+      const lastChildRef = React.createRef();
+
+      function Test() {
+        return (
+          <View nativeID="container" ref={containerRef}>
+            <React.Fragment ref={fragmentRef}>
+              <View nativeID="first" ref={firstChildRef} />
+              <View nativeID="last" ref={lastChildRef} />
+            </React.Fragment>
+          </View>
+        );
+      }
+
+      await act(() => {
+        ReactFabric.render(<Test />, 11, null, true);
+      });
+
+      // Simulate a native view that was inserted directly into the host
+      // tree without React's knowledge (e.g. by a native module), sitting
+      // between the fragment's tracked first and last children.
+      const foreignTag = 999999;
+      const foreignNode = global.nativeFabricUIManager.createNode(
+        foreignTag,
+        'RCTView',
+        11,
+        {},
+        null,
+      );
+      const containerNode = global.nativeFabricUIManager.findNodeForJestTestsOnly(
+        containerRef.current.__nativeTag,
+      );
+      const firstIndex = containerNode.children.findIndex(
+        child => child.reactTag === firstChildRef.current.__nativeTag,
+      );
+      containerNode.children.splice(firstIndex + 1, 0, foreignNode);
+
+      const foreignPublicInstance = {
+        __nativeTag: foreignTag,
+        __internalInstanceHandle: null,
+      };
+
+      const position =
+        fragmentRef.current.compareDocumentPosition(foreignPublicInstance);
+      // It must not be misreported as contained by the fragment just
+      // because it sits between the first and last children natively.
+      expect(position & Node.DOCUMENT_POSITION_CONTAINED_BY).toBe(0);
+      expect(
+        position & Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC,
+      ).not.toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

The DOM `FragmentInstance.compareDocumentPosition` implementation (`packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js`) does two things the Fabric implementation (`packages/react-native-renderer/src/ReactFiberConfigFabric.js`) never got:

1. When the fragment's children have been portaled elsewhere, it repositions the empty-fragment comparison against the portal container instead of the React host parent (`fiberIsPortaledIntoHost` / `getFragmentPortalContainerInfo`).
2. It cross-checks the native-level comparison result against the fiber tree (`validateDocumentPositionWithFiberTree`) before trusting it, falling back to `DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC` when the native result and the fiber tree disagree (e.g. a native view that isn't part of the React tree happens to sit between a fragment's first and last tracked children).

Fabric's implementation was a simplified port from the original feature PR (#32722) that never picked up either of these. This means a native-level result inconsistent with React's own tree (portaled content, or a foreign/injected native view) can be misreported as `DOCUMENT_POSITION_CONTAINED_BY` on Fabric when it shouldn't be.

This PR ports both pieces of logic to Fabric, reusing the same renderer-agnostic fiber-tree helpers (`fiberIsPortaledIntoHost`, `getFragmentPortalContainerInfo`, `isFiberContainedByFragment`, `isFragmentContainedByFiber`, `isFiberPreceding`, `isFiberFollowing`) that the DOM implementation already relies on, plus `getInternalInstanceHandleFromPublicInstance` (already declared in the `react-native-host-hooks` Flow libdef and already used the same way by `isChildPublicInstance` in `ReactNativePublicCompat.js`) to resolve a `PublicInstance` back to its fiber for the tree cross-check.

This code path had no test coverage on Fabric at all before this PR — the test mock's public instance didn't implement `compareDocumentPosition` (or any native "DOM Node API" method), so it wasn't even callable in a test. Added a minimal tree-walking mock (`compareDocumentPositionForJestTestsOnly` in `InitializeNativeFabricUIManager.js`) that computes real document-order/containment from the mock's shadow-node tree, and a `getInternalInstanceHandleFromPublicInstance` mock, so the Fabric behavior can actually be exercised and asserted in Jest.

## How did you test this change?

Added `packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js` tests under a new `describe('compareDocumentPosition', ...)` block:

- `returns the relationship between the fragment instance and a given node` — ports the DOM test's basic precedes/follows/contains/containedBy/disconnected assertions to Fabric, to confirm the common cases still work.
- `does not report a foreign native view spliced between the fragment children as contained` — simulates a native view inserted directly into the shadow tree without a corresponding fiber, sitting between the fragment's first and last tracked children. **This test fails on the pre-fix code** (it returns `DOCUMENT_POSITION_CONTAINED_BY`) and passes after the fix (`DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC`), so it's a real regression test for the fiber-tree cross-check, not just a non-regression check.

Ran:
- `node ./scripts/jest/jest-cli.js packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js` — 5/5 passing.
- `node ./scripts/jest/jest-cli.js packages/react-native-renderer` (full renderer suite) — 71/72 passing. The one failure (`ResponderEventPlugin-test.internal.js`, a 60s Jest timeout) is pre-existing and unrelated: verified by stashing this change and running that file in isolation, where it passes in <1s. It reproduces only under full-suite resource contention on this machine.
- `node ./scripts/tasks/linc.js` (eslint on changed files) — passes cleanly.

Not verified in this environment, disclosed for transparency:
- `yarn flow fabric` / `yarn prettier` — both crash on this local machine independent of this change (Flow's server never finishes parsing under a ~5 min timeout; prettier's `prettier-plugin-hermes-parser` throws `Cannot read properties of undefined (reading 'type')` even on completely untouched files like `packages/react/src/ReactChildren.js`). This looks like a Node 24 / tool-version incompatibility in this sandbox rather than anything caused by this diff, but I wasn't able to get a clean local Flow/Prettier run to confirm — please let CI double check both.

Portal handling specifically (item 1 above) is ported and guarded (no-op unless `fiberIsPortaledIntoHost` is true) but isn't covered by a dedicated new test — there's no existing Fabric portal test in this repo to pattern-match against, and building that test harness from scratch felt out of scope for this fix. Happy to add it if a maintainer can point at an existing RN portal test pattern I missed.