### PR TITLE
[Fiber] Guard thrown-value `then` inspection against hostile getters

### DIFF
--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -19,6 +19,7 @@ import type {
 import type {RetryQueue} from './ReactFiberSuspenseComponent';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
+import isThenable from 'shared/isThenable';
 import {
   ClassComponent,
   HostRoot,
@@ -379,7 +380,7 @@ function throwException(
   }
 
   if (value !== null && typeof value === 'object') {
-    if (typeof value.then === 'function') {
+    if (isThenable(value)) {
       // This is a wakeable. The component suspended.
       const wakeable: Wakeable = value as any;
       resetSuspendedComponent(sourceFiber, rootRenderLanes);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -64,6 +64,7 @@ import {
 import {resetOwnerStackLimit} from 'shared/ReactOwnerStackReset';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import is from 'shared/objectIs';
+import isThenable from 'shared/isThenable';
 
 import reportGlobalError from 'shared/reportGlobalError';
 
@@ -2352,11 +2353,10 @@ function handleThrow(root: FiberRoot, thrownValue: any): void {
     // case where we think this should happen.
     workInProgressSuspendedReason = SuspendedOnHydration;
   } else {
-    // This is a regular error.
-    const isWakeable =
-      thrownValue !== null &&
-      typeof thrownValue === 'object' &&
-      typeof thrownValue.then === 'function';
+    // This is a regular error. `isThenable` is getter-safe: if a hostile
+    // `then` getter threw here, the exception would escape renderRootSync/
+    // renderRootConcurrent before `executionContext` is restored (#37323).
+    const isWakeable = isThenable(thrownValue);
 
     workInProgressSuspendedReason = isWakeable
       ? // A wakeable object was thrown by a legacy Suspense implementation.

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1535,6 +1535,75 @@ describe('ReactIncrementalErrorHandling', () => {
     }
   });
 
+  it('error boundaries capture thrown objects with a hostile `then` getter', async () => {
+    spyOnProd(console, 'error').mockImplementation(() => {});
+    spyOnDev(console, 'error').mockImplementation(() => {});
+
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        Scheduler.log('componentDidCatch');
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          Scheduler.log('ErrorBoundary (catch)');
+          return <span prop={`Caught: ${this.state.error.reason}`} />;
+        }
+        Scheduler.log('ErrorBoundary (try)');
+        return this.props.children;
+      }
+    }
+
+    // React inspects thrown values to decide whether the component suspended.
+    // A throwing `then` getter must not escape that inspection: it would blow
+    // through the error-handling machinery mid-render, leaving the work loop's
+    // executionContext permanently flagged as rendering (see #37323).
+    const hostileValue = {
+      reason: 'oops',
+      get then() {
+        throw new Error('hostile then getter');
+      },
+    };
+    function BadRender({unused}) {
+      Scheduler.log('BadRender');
+      throw hostileValue;
+    }
+
+    ReactNoop.render(
+      <ErrorBoundary>
+        <BadRender />
+      </ErrorBoundary>,
+    );
+
+    await waitForAll([
+      'ErrorBoundary (try)',
+      'BadRender',
+
+      // React retries one more time
+      'ErrorBoundary (try)',
+      'BadRender',
+
+      // Errored again on retry. Now handle it.
+      'componentDidCatch',
+      'ErrorBoundary (catch)',
+    ]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop="Caught: oops" />);
+
+    if (__DEV__) {
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error.mock.calls[0][1]).toBe(hostileValue);
+    } else {
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error.mock.calls[0][0]).toBe(hostileValue);
+    }
+
+    // The work loop is not left in a broken state: unrelated updates render.
+    ReactNoop.render(<span prop="after" />);
+    await waitForAll([]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop="after" />);
+  });
+
   // TODO: Error boundary does not catch promises
 
   it('continues working on siblings of a component that throws', async () => {

--- a/packages/shared/isThenable.js
+++ b/packages/shared/isThenable.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Getter-safe thenable check for arbitrary (user-controlled) values. A hostile
+// `then` getter must not throw from inside React's own error handling.
+export default function isThenable(value: mixed): boolean {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  let then;
+  try {
+    then = (value as any).then;
+  } catch (x) {
+    return false;
+  }
+  return typeof then === 'function';
+}


### PR DESCRIPTION
Fixes #37323.

## Summary

React inspects thrown values to decide whether a component suspended, via bare `typeof <value>.then` property accesses in two places. A thrown object whose `then` getter throws (or any proxy-like value whose property access throws) detonates inside React's own error handling:

- In `handleThrow` (ReactFiberWorkLoop), the access runs in the work loop's `catch` block, so the getter's exception escapes `renderRootSync`/`renderRootConcurrent` **before `executionContext` is restored** (the restore is not in a `finally`). The RenderContext bit is then stuck for the lifetime of the page: every subsequent `useEffectEvent` call from outside React (event listeners, timers, MessagePorts) throws `A function wrapped in useEffectEvent can't be called during rendering.` forever — the production-scale symptom reported in #37323.
- In `throwException` (ReactFiberThrow), the same access breaks error-boundary unwinding: instead of the nearest boundary catching the thrown value, React declares a root fatal and unmounts the tree.

This PR adds a getter-safe `isThenable(value)` helper in `shared/` and uses it at both inspection sites. A value whose `then` access throws is treated as what it is — a regular (non-thenable) error — so it flows through the normal error-boundary path, and the work loop's state stays consistent.

The single-file browser reproduction in #37323 shows both symptoms on react-dom 19.2.4 (Firefox and Chromium), and shows full recovery with exactly these two call sites guarded: the error boundary catches the thrown value, the tree survives, and effect events keep working.

## How did you test this change?

- New regression test in `ReactIncrementalErrorHandling-test.internal.js` (`error boundaries capture thrown objects with a hostile \`then\` getter`), modeled on the adjacent "error boundaries capture non-errors" test. Without the fix it fails: the getter's exception escapes the work loop instead of the boundary catching. With the fix, the boundary catches the original thrown object and a subsequent unrelated render works.
- `yarn test packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js` — passes.
- `yarn test --prod packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js` — passes.
- `yarn linc`, `yarn prettier`, `yarn flow dom-node` — clean.
- Additionally verified at the browser level by applying the equivalent patch to the react-dom 19.2.4 build and re-running the #37323 reproduction in Firefox 153 and Chromium: `probe 1: effect event ran fine / error boundary caught the render error / probe 2: effect event ran fine`.

---

*This fix was developed and verified with the help of Claude (AI); all test commands above were actually run and their results confirmed.*
