### PR TITLE
Restore executionContext when a render throws out of the work loop

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2353,10 +2353,15 @@ function handleThrow(root: FiberRoot, thrownValue: any): void {
     workInProgressSuspendedReason = SuspendedOnHydration;
   } else {
     // This is a regular error.
-    const isWakeable =
-      thrownValue !== null &&
-      typeof thrownValue === 'object' &&
-      typeof thrownValue.then === 'function';
+    let isWakeable = false;
+    try {
+      isWakeable =
+        thrownValue !== null &&
+        typeof thrownValue === 'object' &&
+        typeof thrownValue.then === 'function';
+    } catch (thenAccessError) {
+      thrownValue = thenAccessError;
+    }
 
     workInProgressSuspendedReason = isWakeable
       ? // A wakeable object was thrown by a legacy Suspense implementation.
@@ -2630,6 +2635,10 @@ function renderRootSync(
   const prevDispatcher = pushDispatcher(root.containerInfo);
   const prevAsyncDispatcher = pushAsyncDispatcher();
 
+  // Restore executionContext even if the work loop throws (for example a
+  // throwing `then` getter on a thrown value). Otherwise RenderContext stays
+  // set and useEffectEvent later thinks it is still rendering.
+  try {
   // If the root or lanes have changed, throw out the existing stack
   // and prepare a fresh one. Otherwise we'll continue where we left off.
   if (workInProgressRoot !== root || workInProgressRootRenderLanes !== lanes) {
@@ -2741,10 +2750,11 @@ function renderRootSync(
   }
 
   resetContextDependencies();
-
-  executionContext = prevExecutionContext;
-  popDispatcher(prevDispatcher);
-  popAsyncDispatcher(prevAsyncDispatcher);
+  } finally {
+    executionContext = prevExecutionContext;
+    popDispatcher(prevDispatcher);
+    popAsyncDispatcher(prevAsyncDispatcher);
+  }
 
   if (enableSchedulingProfiler) {
     markRenderStopped();
@@ -2782,6 +2792,8 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes): RootExitStatus {
   const prevDispatcher = pushDispatcher(root.containerInfo);
   const prevAsyncDispatcher = pushAsyncDispatcher();
 
+  // Same as renderRootSync: always restore executionContext if the loop throws.
+  try {
   // If the root or lanes have changed, throw out the existing stack
   // and prepare a fresh one. Otherwise we'll continue where we left off.
   if (workInProgressRoot !== root || workInProgressRootRenderLanes !== lanes) {
@@ -3022,10 +3034,11 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes): RootExitStatus {
     }
   } while (true);
   resetContextDependencies();
-
-  popDispatcher(prevDispatcher);
-  popAsyncDispatcher(prevAsyncDispatcher);
-  executionContext = prevExecutionContext;
+  } finally {
+    popDispatcher(prevDispatcher);
+    popAsyncDispatcher(prevAsyncDispatcher);
+    executionContext = prevExecutionContext;
+  }
 
   // Check if the tree has completed.
   if (workInProgress !== null) {

--- a/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+++ b/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
@@ -1326,4 +1326,38 @@ describe('useEffectEvent', () => {
         : ['insertion destroy: 2', 'insertion create: 2', 'layout create: 2']),
     ]);
   });
+
+  it('can still call useEffectEvent after a fatal render error escapes the work loop', async () => {
+    let onEvent;
+    function Probe() {
+      onEvent = useEffectEvent(() => {
+        Scheduler.log('effect event');
+      });
+      return <Text text="Probe" />;
+    }
+
+    function Poisoned() {
+      throw {
+        get then() {
+          throw new Error('poisoned thenable getter');
+        },
+      };
+    }
+
+    function App({crash}) {
+      return crash ? <Poisoned /> : <Probe />;
+    }
+
+    ReactNoop.render(<App crash={false} />);
+    await waitForAll(['Probe']);
+    expect(() => onEvent()).not.toThrow();
+    assertLog(['effect event']);
+
+    await expect(act(() => {
+      ReactNoop.render(<App crash={true} />);
+    })).rejects.toThrow('poisoned thenable getter');
+
+    expect(() => onEvent()).not.toThrow();
+    assertLog(['effect event']);
+  });
 });


### PR DESCRIPTION
Fixes facebook/react#37323

renderRootSync and renderRootConcurrent restore executionContext after the work loop, not in a finally. handleThrow also reads thrownValue.then with no guard. A throwing then getter therefore escapes the render with RenderContext still set, and every later useEffectEvent call from a browser callback throws as if it were still rendering.

This wraps both render roots in try/finally so executionContext is always restored, and treats a throwing then getter as a regular error.

The useEffectEvent test covers calling the event after a poisoned thenable escapes the work loop.