### PR TITLE
[DOM] Preserve autofocus for controls inside dialogs

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -888,6 +888,32 @@ function handleErrorInNextTick(error: any) {
 
 export const supportsMutation = true;
 
+function isInsideDialog(domElement: Instance): boolean {
+  let ancestor = domElement.parentElement;
+  while (ancestor != null) {
+    const currentAncestor = ancestor;
+    if (currentAncestor.tagName === 'DIALOG') {
+      return true;
+    }
+    ancestor = currentAncestor.parentElement;
+  }
+  return false;
+}
+
+function updateDialogAutoFocusAttribute(
+  domElement: Instance,
+  autoFocus: mixed,
+): void {
+  if (!isInsideDialog(domElement)) {
+    return;
+  }
+  if (autoFocus) {
+    domElement.setAttribute('autofocus', '');
+  } else {
+    domElement.removeAttribute('autofocus');
+  }
+}
+
 export function commitMount(
   domElement: Instance,
   type: string,
@@ -906,6 +932,11 @@ export function commitMount(
     case 'select':
     case 'textarea':
       if (newProps.autoFocus) {
+        // Unlike the document-level autofocus behavior that we polyfill below,
+        // dialogs look for the attribute when they are opened. The dialog may
+        // still be closed at this point, so preserve the attribute for the
+        // browser to use when showModal() or show() is called later.
+        updateDialogAutoFocusAttribute(domElement, true);
         (
           domElement as any as
             | HTMLButtonElement
@@ -1005,6 +1036,17 @@ export function commitUpdate(
 ): void {
   // Diff and update the properties.
   updateProperties(domElement, type, oldProps, newProps);
+
+  if (oldProps.autoFocus !== newProps.autoFocus) {
+    switch (type) {
+      case 'button':
+      case 'input':
+      case 'select':
+      case 'textarea':
+        updateDialogAutoFocusAttribute(domElement, newProps.autoFocus);
+        break;
+    }
+  }
 
   // Update the props handle so that we know which props are the ones with
   // with current event handlers.

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -386,6 +386,64 @@ describe('ReactDOM', () => {
     }
   });
 
+  it('preserves autoFocus only on controls inside a dialog', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOMClient.createRoot(container);
+
+    try {
+      await act(() => {
+        root.render(
+          <>
+            <input id="outside" autoFocus={true} />
+            <dialog>
+              <div>
+                <input id="inside" autoFocus={true} />
+              </div>
+            </dialog>
+          </>,
+        );
+      });
+
+      const outsideInput = container.querySelector('#outside');
+      const insideInput = container.querySelector('#inside');
+      expect(outsideInput.hasAttribute('autofocus')).toBe(false);
+      expect(insideInput.hasAttribute('autofocus')).toBe(true);
+
+      await act(() => {
+        root.render(
+          <>
+            <input id="outside" autoFocus={false} />
+            <dialog>
+              <div>
+                <input id="inside" autoFocus={false} />
+              </div>
+            </dialog>
+          </>,
+        );
+      });
+      expect(outsideInput.hasAttribute('autofocus')).toBe(false);
+      expect(insideInput.hasAttribute('autofocus')).toBe(false);
+
+      await act(() => {
+        root.render(
+          <>
+            <input id="outside" autoFocus={true} />
+            <dialog>
+              <div>
+                <input id="inside" autoFocus={true} />
+              </div>
+            </dialog>
+          </>,
+        );
+      });
+      expect(outsideInput.hasAttribute('autofocus')).toBe(false);
+      expect(insideInput.hasAttribute('autofocus')).toBe(true);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
   it("shouldn't fire duplicate event handler while handling other nested dispatch", async () => {
     const actual = [];
 


### PR DESCRIPTION
## Summary

Fixes #23301.

React implements autoFocus on client-created controls by calling focus() during commit and omitting the native autofocus attribute. That call has no effect while a parent dialog is closed, so opening the dialog later lets the browser focus the first focusable control instead.

This change:
- preserves the native autofocus attribute for button, input, select, and textarea elements inside a dialog;
- keeps the attribute synchronized when the autoFocus prop changes;
- leaves existing behavior outside dialogs and during hydration unchanged.

The logic lives in the DOM host config so dialog-specific behavior stays out of the reconciler.

## How did you test this change?

- yarn test ReactDOM-test ReactDOMComponent-test ReactServerRenderingHydration-test --runInBand — 208 tests passed in experimental development mode
- yarn test-stable ReactDOM-test ReactDOMComponent-test ReactServerRenderingHydration-test --runInBand — 208 tests passed
- yarn test ReactDOM-test ReactDOMComponent-test ReactServerRenderingHydration-test --prod --runInBand — 208 tests passed
- yarn linc
- yarn flow dom-browser
- yarn prettier
- Docker clean-room runs with Node 20.19.0 and Yarn 1.22.22
- React DOM bundle verified with Playwright in Chromium, Firefox, and WebKit: after dialog.showModal(), the control with autoFocus became document.activeElement