### PR TITLE
[DEV] Treat Window objects as opaque leaves in the Performance Tracks serializer

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js
@@ -308,6 +308,82 @@ describe('ReactPerformanceTracks', () => {
   });
 
   // @gate __DEV__ && enableComponentPerformanceTrack
+  it('shows window objects as opaque values instead of walking them', async () => {
+    const App = function App({popup}) {
+      Scheduler.unstable_advanceTime(10);
+      React.useEffect(() => {}, [popup]);
+    };
+
+    const createFakeWindow = name => {
+      const win = {};
+      // Real Window objects stringify as '[object Window]'.
+      Object.defineProperty(win, Symbol.toStringTag, {value: 'Window'});
+      // A Window's own enumerable properties include self-references, so
+      // walking it fans out across the entire global surface at every level
+      // of the depth limit (issue #37330).
+      win.window = win;
+      win.self = win;
+      win.frames = win;
+      win.top = win;
+      win.parent = win;
+      win.name = name;
+      return win;
+    };
+
+    Scheduler.unstable_advanceTime(1);
+    await act(() => {
+      ReactNoop.render(<App popup={createFakeWindow('one')} />);
+    });
+
+    expect(performanceMeasureCalls).toEqual([
+      [
+        'Mount',
+        {
+          detail: {
+            devtools: {
+              color: 'warning',
+              properties: null,
+              tooltipText: 'Mount',
+              track: 'Components ⚛',
+            },
+          },
+          end: 11,
+          start: 1,
+        },
+      ],
+    ]);
+    performanceMeasureCalls.length = 0;
+
+    Scheduler.unstable_advanceTime(10);
+
+    await act(() => {
+      ReactNoop.render(<App popup={createFakeWindow('two')} />);
+    });
+
+    expect(performanceMeasureCalls).toEqual([
+      [
+        '​App',
+        {
+          detail: {
+            devtools: {
+              color: 'primary-dark',
+              properties: [
+                ['Changed Props', ''],
+                ['-\xa0popup', 'Window'],
+                ['+\xa0popup', 'Window'],
+              ],
+              tooltipText: 'App',
+              track: 'Components ⚛',
+            },
+          },
+          end: 31,
+          start: 21,
+        },
+      ],
+    ]);
+  });
+
+  // @gate __DEV__ && enableComponentPerformanceTrack
   it('includes console.timeStamp spans for Components with no prop changes', async () => {
     function Left({value}) {
       Scheduler.unstable_advanceTime(5000);

--- a/packages/shared/ReactPerformanceTrackProperties.js
+++ b/packages/shared/ReactPerformanceTrackProperties.js
@@ -185,6 +185,19 @@ export function addValueToProperties(
               : objectName;
           break;
         }
+        if (objectName === 'Window' || objectName === 'global') {
+          // Browser globals like a `window` (e.g. the return value of
+          // window.open() or an iframe's contentWindow) are highly
+          // self-referential: their own enumerable properties include
+          // `window`, `self`, `frames`, `top` and `parent`, so recursing
+          // into them fans out across the entire global surface at every
+          // level of the depth limit. `opener`/`parent` can even cross into
+          // another document and serialize that page's globals. Showing the
+          // type is more useful than enumerating them (which is also
+          // prohibitively slow, see issue #37330).
+          desc = objectName;
+          break;
+        }
         if (objectName === 'Array') {
           const array: Array<any> = value as any;
           const didTruncate = array.length > OBJECT_WIDTH_LIMIT;


### PR DESCRIPTION
## Summary

Fixes #37330.

The DEV Performance Tracks serializer (`addValueToProperties` in `shared/ReactPerformanceTrackProperties`) recurses into `Window` objects passed through props (e.g. the return value of `window.open()`, or an iframe's `contentWindow`). Because a `Window`'s own enumerable properties include self-references (`window`, `self`, `frames`, `top`, `parent`), the depth-limited walk fans out across the entire global surface at every level — a single `Window` prop produces thousands of property entries per commit. Worse, the walk follows `opener`/`parent` across window boundaries and serializes the parent page's own globals; combined with a large enumerable global on the opener page this froze the main thread and crashed the renderer with OOM in a real app (traces and a repro in the issue).

This PR treats `Window` as an opaque leaf value — rendered as `Window`, not recursed into — the same way TypedArrays are already summarized. The check uses `Object.prototype.toString`, which the surrounding code already computes, so it catches same-realm and same-origin cross-realm windows (`[object Window]`, plus `[object global]` for older global objects). Cross-origin windows already stringify as plain objects and enumerate zero keys, so they were not the dangerous case and keep their current behavior.

Measured with the repro from the issue (https://github.com/93-0312/react-window-prop-oom-repro): on `19.3.0-canary-eafeac09-20260819` one commit with a `Window` prop still serialized 3,444 property entries (down from 7,988 on 19.2.8 only because of `OBJECT_WIDTH_LIMIT`). With this change a `Window` prop serializes as a single `popup: Window` line and the walk never reaches `opener` (covered by the added unit test).

## How did you test this change?

- Added a unit test (`shows window objects as opaque values instead of walking them`) with a fake `Window` carrying the real self-referential shape. Verified it fails without the source change and passes with it.
- `yarn test packages/react-reconciler/src/__tests__/ReactPerformanceTrack-test.js` — all 8 tests pass, including the existing `diffs HTML-like objects` opaque-origin coverage.
- `yarn linc` — lint passed for changed files.
- `prettier --check` — clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
