### PR TITLE
[Fiber] Don't remount Hoistables during dev effect validation

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+import {StrictMode} from 'react';
 import {
   insertNodesAndExecuteScripts,
   mergeOptions,
@@ -9557,7 +9558,11 @@ background-color: green;
         );
       }
       await act(() => {
-        renderToPipeableStream(<App />).pipe(writable);
+        renderToPipeableStream(
+          <StrictMode>
+            <App />
+          </StrictMode>,
+        ).pipe(writable);
       });
 
       expect(getMeaningfulChildren(document)).toEqual(
@@ -9576,19 +9581,24 @@ background-color: green;
         </html>,
       );
 
-      const root = ReactDOMClient.hydrateRoot(document, <App />);
+      const root = ReactDOMClient.hydrateRoot(
+        document,
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      );
       await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
-            <link rel="rel1" href="linkhref" />
-            <link rel="rel2" href="linkhref" />
-            <meta name="name1" content="metacontent" />
-            <meta name="name2" content="metacontent" />
             <link rel="rel3" href="linkhref" />
             <link rel="rel4" href="linkhref" />
             <meta name="name3" content="metacontent" />
             <meta name="name4" content="metacontent" />
+            <link rel="rel1" href="linkhref" />
+            <link rel="rel2" href="linkhref" />
+            <meta name="name1" content="metacontent" />
+            <meta name="name2" content="metacontent" />
           </head>
           <body>loading...</body>
         </html>,
@@ -9619,15 +9629,15 @@ background-color: green;
             <link rel="rel4" href="linkhref" />
             <meta name="name3" content="metacontent" />
             <meta name="name4" content="metacontent" />
+            <link rel="rel5" href="linkhref" />
+            <link rel="rel6" href="linkhref" />
+            <meta name="name5" content="metacontent" />
+            <meta name="name6" content="metacontent" />
           </head>
           <body>
             <meta name="3rdparty" content="metacontent" />
             <link rel="3rdparty" href="linkhref" />
             <div>hello world</div>
-            <link rel="rel5" href="linkhref" />
-            <link rel="rel6" href="linkhref" />
-            <meta name="name5" content="metacontent" />
-            <meta name="name6" content="metacontent" />
           </body>
         </html>,
       );

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -9591,14 +9591,14 @@ background-color: green;
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
-            <link rel="rel3" href="linkhref" />
-            <link rel="rel4" href="linkhref" />
-            <meta name="name3" content="metacontent" />
-            <meta name="name4" content="metacontent" />
             <link rel="rel1" href="linkhref" />
             <link rel="rel2" href="linkhref" />
             <meta name="name1" content="metacontent" />
             <meta name="name2" content="metacontent" />
+            <link rel="rel3" href="linkhref" />
+            <link rel="rel4" href="linkhref" />
+            <meta name="name3" content="metacontent" />
+            <meta name="name4" content="metacontent" />
           </head>
           <body>loading...</body>
         </html>,
@@ -9629,15 +9629,15 @@ background-color: green;
             <link rel="rel4" href="linkhref" />
             <meta name="name3" content="metacontent" />
             <meta name="name4" content="metacontent" />
-            <link rel="rel5" href="linkhref" />
-            <link rel="rel6" href="linkhref" />
-            <meta name="name5" content="metacontent" />
-            <meta name="name6" content="metacontent" />
           </head>
           <body>
             <meta name="3rdparty" content="metacontent" />
             <link rel="3rdparty" href="linkhref" />
             <div>hello world</div>
+            <link rel="rel5" href="linkhref" />
+            <link rel="rel6" href="linkhref" />
+            <meta name="name5" content="metacontent" />
+            <meta name="name6" content="metacontent" />
           </body>
         </html>,
       );

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -293,9 +293,14 @@ import type {Flags} from './ReactFiberFlags';
 
 type LayoutEffectTraversalFlags = number;
 
-const NoLayoutEffectTraversalFlags = /*        */ 0b00;
-const IncludeWorkInProgressEffects = /*       */ 0b01;
-const IncludeHostSingletons = /*              */ 0b10;
+const NoLayoutEffectTraversalFlags = /*        */ 0b000;
+const IncludeWorkInProgressEffects = /*       */ 0b001;
+const IncludeHostSingletons = /*              */ 0b010;
+// Only real Offscreen/Activity visibility transitions attach or detach
+// Hoistable DOM nodes. The StrictMode DEV double-invoke passes
+// NoLayoutEffectTraversalFlags so it leaves hoistables in place: re-inserting
+// appends to <head> and would reorder the document in DEV only.
+const IncludeHostHoistables = /*              */ 0b100;
 
 // Used during the commit phase to track the state of the Offscreen component stack.
 // Allows us to avoid traversing the return path to find the nearest Offscreen ancestor.
@@ -804,12 +809,15 @@ function commitLayoutEffectOnFiber(
             // traversing the layout effects, we must also re-mount layout
             // effects that were unmounted when the Offscreen subtree was
             // hidden. So this is a superset of the normal commitLayoutEffects.
-            let layoutEffectTraversalFlags: LayoutEffectTraversalFlags;
+            let layoutEffectTraversalFlags: LayoutEffectTraversalFlags =
+              NoLayoutEffectTraversalFlags;
             // $FlowFixMe[constant-condition]
             if (supportsSingletons) {
-              layoutEffectTraversalFlags = IncludeHostSingletons;
-            } else {
-              layoutEffectTraversalFlags = NoLayoutEffectTraversalFlags;
+              layoutEffectTraversalFlags |= IncludeHostSingletons;
+            }
+            // $FlowFixMe[constant-condition]
+            if (supportsResources) {
+              layoutEffectTraversalFlags |= IncludeHostHoistables;
             }
             if ((finishedWork.subtreeFlags & LayoutMask) !== NoFlags) {
               layoutEffectTraversalFlags |= IncludeWorkInProgressEffects;
@@ -2639,12 +2647,15 @@ function commitMutationEffectsOnFiber(
               (finishedWork.mode & ConcurrentMode) !== NoMode
             ) {
               // Disappear the layout effects of all the children
-              let layoutEffectTraversalFlags: LayoutEffectTraversalFlags;
+              let layoutEffectTraversalFlags: LayoutEffectTraversalFlags =
+                NoLayoutEffectTraversalFlags;
               // $FlowFixMe[constant-condition]
               if (supportsSingletons) {
-                layoutEffectTraversalFlags = IncludeHostSingletons;
-              } else {
-                layoutEffectTraversalFlags = NoLayoutEffectTraversalFlags;
+                layoutEffectTraversalFlags |= IncludeHostSingletons;
+              }
+              // $FlowFixMe[constant-condition]
+              if (supportsResources) {
+                layoutEffectTraversalFlags |= IncludeHostHoistables;
               }
               const newOffscreenSubtreeIsHidden =
                 // $FlowFixMe[constant-condition]
@@ -3187,17 +3198,22 @@ function disappearLayoutEffects(
 
       // $FlowFixMe[constant-condition]
       if (supportsResources) {
-        // We only act on Hoistable Instances (memoizedState === null).
-        // Resources (memoizedState !== null) are ref-counted and intentionally
-        // remain in the document across Activity visibility transitions;
-        // they are released only on actual deletion.
-        const instance = finishedWork.stateNode;
-        if (
-          finishedWork.memoizedState === null &&
-          instance !== null &&
-          !offscreenSubtreeWasHidden
-        ) {
-          unmountHoistable(instance);
+        const includeHostHoistables =
+          (layoutEffectTraversalFlags & IncludeHostHoistables) !==
+          NoLayoutEffectTraversalFlags;
+        if (includeHostHoistables) {
+          // We only act on Hoistable Instances (memoizedState === null).
+          // Resources (memoizedState !== null) are ref-counted and intentionally
+          // remain in the document across Activity visibility transitions;
+          // they are released only on actual deletion.
+          const instance = finishedWork.stateNode;
+          if (
+            finishedWork.memoizedState === null &&
+            instance !== null &&
+            !offscreenSubtreeWasHidden
+          ) {
+            unmountHoistable(instance);
+          }
         }
       }
 
@@ -3413,38 +3429,40 @@ function reappearLayoutEffects(
     case HostHoistable: {
       // $FlowFixMe[constant-condition]
       if (supportsResources) {
-        // The reappear traversal runs whenever an Activity transitions from
-        // hidden to visible. We piggy-back on it (rather than adding a
-        // separate recursive traversal) to insert hoistable metadata such as
-        // <title> and <meta> into the document.
-        //
-        // We only act on Hoistable Instances (memoizedState === null).
-        // Resources stay mounted across Activity visibility transitions.
-        //
-        // The parentNode guard makes this idempotent and safe under StrictMode
-        // dev double-invoke: if the instance is already attached we skip.
-        //
-        // Note: this runs in the layout phase. A useLayoutEffect on an earlier
-        // sibling can therefore observe document.title before the hoistable
-        // is re-attached. Moving this to the mutation phase would require an
-        // additional unconditional traversal of the Activity subtree (the
-        // mutation traversal is gated by subtreeFlags and would skip an
-        // unchanged hoistable). This is the same tradeoff as for HostSingleton.
-        const instance = finishedWork.stateNode;
-        if (
-          finishedWork.memoizedState === null &&
-          instance !== null &&
-          !offscreenSubtreeIsHidden
-        ) {
-          // currentHoistableRoot is only maintained during the mutation phase.
-          // Derive the hoistable root from the instance's owner document so
-          // this works in the layout phase too. Hoistable Instances are
-          // hoisted to document.head, which always lives in ownerDocument.
-          mountHoistable(
-            getHoistableRoot(instance.ownerDocument),
-            finishedWork.type,
-            instance,
-          );
+        const includeHostHoistables =
+          (layoutEffectTraversalFlags & IncludeHostHoistables) !==
+          NoLayoutEffectTraversalFlags;
+        if (includeHostHoistables) {
+          // The reappear traversal runs whenever an Activity transitions from
+          // hidden to visible. We piggy-back on it (rather than adding a
+          // separate recursive traversal) to insert hoistable metadata such as
+          // <title> and <meta> into the document.
+          //
+          // We only act on Hoistable Instances (memoizedState === null).
+          // Resources stay mounted across Activity visibility transitions.
+          //
+          // Note: this runs in the layout phase. A useLayoutEffect on an earlier
+          // sibling can therefore observe document.title before the hoistable
+          // is re-attached. Moving this to the mutation phase would require an
+          // additional unconditional traversal of the Activity subtree (the
+          // mutation traversal is gated by subtreeFlags and would skip an
+          // unchanged hoistable). This is the same tradeoff as for HostSingleton.
+          const instance = finishedWork.stateNode;
+          if (
+            finishedWork.memoizedState === null &&
+            instance !== null &&
+            !offscreenSubtreeIsHidden
+          ) {
+            // currentHoistableRoot is only maintained during the mutation phase.
+            // Derive the hoistable root from the instance's owner document so
+            // this works in the layout phase too. Hoistable Instances are
+            // hoisted to document.head, which always lives in ownerDocument.
+            mountHoistable(
+              getHoistableRoot(instance.ownerDocument),
+              finishedWork.type,
+              instance,
+            );
+          }
         }
       }
       recursivelyTraverseReappearLayoutEffects(


### PR DESCRIPTION
https://github.com/react/react/pull/34983 moved mounting of Hoistables into the shared Layout traversals so that Activity visibility transitions can detach and reattach metadata. StrictMode's DEV effect validation drives the same traversals so under StrictMode every hydrated Hoistable was removed and re-appended to `<head>` on commit. That reordered document metadata in DEV compared to production, and it relocated hoistables that a late Suspense boundary delivered inline in the body into the `<head>`. For `<title>` the order is observable, since the first titleelement in  document order determines `document.title`.

Like the HostSingleton release in #37113, a hoistable is not really an effect. This change gates the detach and reattach on a new `IncludeHostHoistables` layout traversal flag that is only set at real Offscreen and Activity visibility transitions. The validation wrappers keep passing `NoLayoutEffectTraversalFlags`, so the double-invoke leaves hoistable DOM nodes untouched and DEV matches production hydration. The characterization test from the previous commit now asserts the original document order again, with the StrictMode wrapper kept in place.

