### PR TITLE
[Fizz] Restore Hooks state after reentrant work

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -99,6 +99,23 @@ describe('ReactDOMServerHooks', () => {
       expect(domNode.textContent).toEqual('Count: 0');
     });
 
+    it('preserves hook state across nested renderToString calls', async () => {
+      function Inner() {
+        const [value] = useState('inner');
+        return <span>{value}</span>;
+      }
+
+      function Outer() {
+        const [before] = useState('before');
+        ReactDOMServer.renderToString(<Inner />);
+        const [after] = useState('after');
+        return <span>{before + ' ' + after}</span>;
+      }
+
+      const domNode = await serverRender(<Outer />);
+      expect(domNode.textContent).toEqual('before after');
+    });
+
     itRenders('lazy state initialization', async render => {
       function Counter(props) {
         const [count] = useState(() => {

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -167,6 +167,26 @@ let isInHookUserCodeInDev = false;
 // In DEV, this is the name of the currently executing primitive hook
 let currentHookNameInDev: ?string;
 
+type HooksState = {
+  currentlyRenderingComponent: Object | null,
+  currentlyRenderingTask: Task | null,
+  currentlyRenderingRequest: Request | null,
+  currentlyRenderingKeyPath: KeyNode | null,
+  firstWorkInProgressHook: Hook | null,
+  workInProgressHook: Hook | null,
+  isReRender: boolean,
+  didScheduleRenderPhaseUpdate: boolean,
+  localIdCounter: number,
+  actionStateCounter: number,
+  actionStateMatchingIndex: number,
+  thenableIndexCounter: number,
+  thenableState: ThenableState | null,
+  renderPhaseUpdates: Map<UpdateQueue<any>, Update<any>> | null,
+  numberOfReRenders: number,
+  isInHookUserCodeInDev: boolean,
+  currentHookNameInDev: ?string,
+};
+
 function resolveCurrentlyRenderingComponent(): Object {
   if (currentlyRenderingComponent === null) {
     throw new Error(
@@ -362,6 +382,48 @@ export function getActionStateMatchingIndex(): number {
   // Conceptually, it's part of the return value of finishHooks; it's only a
   // separate function to avoid using an array tuple.
   return actionStateMatchingIndex;
+}
+
+export function getCurrentHooksState(): HooksState {
+  return {
+    currentlyRenderingComponent,
+    currentlyRenderingTask,
+    currentlyRenderingRequest,
+    currentlyRenderingKeyPath,
+    firstWorkInProgressHook,
+    workInProgressHook,
+    isReRender,
+    didScheduleRenderPhaseUpdate,
+    localIdCounter,
+    actionStateCounter,
+    actionStateMatchingIndex,
+    thenableIndexCounter,
+    thenableState,
+    renderPhaseUpdates,
+    numberOfReRenders,
+    isInHookUserCodeInDev,
+    currentHookNameInDev,
+  };
+}
+
+export function restoreHooksState(state: HooksState): void {
+  currentlyRenderingComponent = state.currentlyRenderingComponent;
+  currentlyRenderingTask = state.currentlyRenderingTask;
+  currentlyRenderingRequest = state.currentlyRenderingRequest;
+  currentlyRenderingKeyPath = state.currentlyRenderingKeyPath;
+  firstWorkInProgressHook = state.firstWorkInProgressHook;
+  workInProgressHook = state.workInProgressHook;
+  isReRender = state.isReRender;
+  didScheduleRenderPhaseUpdate = state.didScheduleRenderPhaseUpdate;
+  localIdCounter = state.localIdCounter;
+  actionStateCounter = state.actionStateCounter;
+  actionStateMatchingIndex = state.actionStateMatchingIndex;
+  thenableIndexCounter = state.thenableIndexCounter;
+  thenableState = state.thenableState;
+  renderPhaseUpdates = state.renderPhaseUpdates;
+  numberOfReRenders = state.numberOfReRenders;
+  isInHookUserCodeInDev = state.isInHookUserCodeInDev;
+  currentHookNameInDev = state.currentHookNameInDev;
 }
 
 // Reset the internal hooks state if an error occurs while rendering a component

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -134,6 +134,8 @@ import {
   readPreviousThenableFromState,
   getActionStateCount,
   getActionStateMatchingIndex,
+  getCurrentHooksState,
+  restoreHooksState,
   createRecoverableError,
   isRecoverableError,
   cloneRecoverableErrorAsFatal,
@@ -1116,6 +1118,12 @@ function rerenderStalledTask(request: Request, task: Task): void {
 
   const prevContext = getActiveContext();
   const prevDispatcher = ReactSharedInternals.H;
+  const prevHooksState =
+    prevDispatcher === HooksDispatcher ? getCurrentHooksState() : null;
+  if (prevHooksState !== null) {
+    // Hook nodes are mutable, so isolate the nested work from the outer list.
+    resetHooksState();
+  }
   ReactSharedInternals.H = HooksDispatcher;
   const prevAsyncDispatcher = ReactSharedInternals.A;
   ReactSharedInternals.A = DefaultAsyncDispatcher;
@@ -1144,15 +1152,16 @@ function rerenderStalledTask(request: Request, task: Task): void {
     ReactSharedInternals.A = prevAsyncDispatcher;
 
     ReactSharedInternals.getCurrentStack = prevGetCurrentStackImpl;
-    if (prevDispatcher === HooksDispatcher) {
+    if (prevHooksState !== null) {
       // This means that we were in a reentrant work loop. This could happen
       // in a renderer that supports synchronous work like renderToString,
       // when it's called from within another renderer.
       // Normally we don't bother switching the contexts to their root/default
       // values when leaving because we'll likely need the same or similar
       // context again. However, when we're inside a synchronous loop like this
-      // we'll to restore the context to what it was before returning.
+      // we need to restore the context and Hooks state before returning.
       switchContext(prevContext);
+      restoreHooksState(prevHooksState);
     }
     currentRequest = prevRequest;
     request.status = prevStatus;
@@ -5584,6 +5593,12 @@ export function performWork(request: Request): void {
   }
   const prevContext = getActiveContext();
   const prevDispatcher = ReactSharedInternals.H;
+  const prevHooksState =
+    prevDispatcher === HooksDispatcher ? getCurrentHooksState() : null;
+  if (prevHooksState !== null) {
+    // Hook nodes are mutable, so isolate the nested work from the outer list.
+    resetHooksState();
+  }
   ReactSharedInternals.H = HooksDispatcher;
   const prevAsyncDispatcher = ReactSharedInternals.A;
   ReactSharedInternals.A = DefaultAsyncDispatcher;
@@ -5622,15 +5637,16 @@ export function performWork(request: Request): void {
     if (__DEV__) {
       ReactSharedInternals.getCurrentStack = prevGetCurrentStackImpl;
     }
-    if (prevDispatcher === HooksDispatcher) {
+    if (prevHooksState !== null) {
       // This means that we were in a reentrant work loop. This could happen
       // in a renderer that supports synchronous work like renderToString,
       // when it's called from within another renderer.
       // Normally we don't bother switching the contexts to their root/default
       // values when leaving because we'll likely need the same or similar
       // context again. However, when we're inside a synchronous loop like this
-      // we'll to restore the context to what it was before returning.
+      // we need to restore the context and Hooks state before returning.
       switchContext(prevContext);
+      restoreHooksState(prevHooksState);
     }
     currentRequest = prevRequest;
   }


### PR DESCRIPTION
## Summary

Fixes #22214.

A synchronous nested `renderToString` call can re-enter Fizz while an outer function component is still rendering. The nested render resets the module-level Hooks state, so a Hook called by the outer component afterwards either throws an invalid Hook call or reads the nested render's Hook node.

This change:

- snapshots the outer Fizz Hooks state when server work is re-entered
- starts nested work with an isolated Hooks list so it cannot mutate the outer list
- restores both the Hooks state and the active context in `finally`, including diagnostic rerenders and error paths
- adds a regression test that calls `useState` before and after a nested `renderToString`

### Before

The second outer `useState` call fails after the nested render resets its Hooks state.

<img width="1265" height="1000" alt="Before fix: nested renderToString resets the outer Hooks state and causes an invalid Hook call" src="https://github.com/user-attachments/assets/b10326c1-4cc3-4f69-bc99-0a86b858a48d" />

### After

The outer Hooks state is restored, and the built server bundle renders `<span>before after</span>`.

<img width="1265" height="928" alt="After fix: outer Hooks state is preserved and the server renders before after" src="https://github.com/user-attachments/assets/ba7bee41-7c4e-4875-b0ff-b137b8fe97d1" />

## How did you test this change?

- `yarn test ReactDOMServerIntegrationHooks --runInBand` (142 tests passed)
- `yarn test ReactDOMServerIntegrationHooks --runInBand --prod` (142 tests passed)
- `yarn test-stable ReactDOMServerIntegrationHooks --runInBand` (142 tests passed)
- `yarn test ReactDOMFizzServer --runInBand` (223 tests passed)
- `yarn test ReactDOMServerIntegrationNewContext --runInBand` (51 tests passed)
- `yarn flow dom-node`
- `yarn linc`
- `yarn prettier`
- clean Docker install plus the focused regression test
- official `NODE_DEV` React/ReactDOM server bundles, followed by a standalone `react-dom/server` render using the built packages
