### PR TITLE
[Flight] Add render() and createFromRender()

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -42,6 +42,13 @@ import type {
 
 import type {TemporaryReferenceSet} from './ReactFlightTemporaryReferences';
 
+import type {RenderResult} from 'shared/ReactFlightRenderResult';
+
+export type {
+  RenderConsumer,
+  RenderResult,
+} from 'shared/ReactFlightRenderResult';
+
 import {
   enableProfilerTimer,
   enableComponentPerformanceTrack,
@@ -126,7 +133,10 @@ export type {CallServerCallback, EncodeFormActionCallback};
 
 interface FlightStreamController {
   enqueueValue(value: any): void;
-  enqueueModel(json: UninitializedModel): void;
+  enqueueModel(
+    json: UninitializedModel | Object,
+    status: 'resolved_model' | 'resolved_object',
+  ): void;
   close(json: UninitializedModel): void;
   error(error: Error): void;
 }
@@ -150,6 +160,11 @@ type RowParserState = 0 | 1 | 2 | 3 | 4;
 const PENDING = 'pending';
 const BLOCKED = 'blocked';
 const RESOLVED_MODEL = 'resolved_model';
+// Like RESOLVED_MODEL, but the value is the row's already parsed (not yet
+// revived) model rather than its JSON text. Rows received in object form
+// from an in-process render resolve to this state, so the two forms never
+// have to be told apart by inspecting the value.
+const RESOLVED_OBJECT = 'resolved_object';
 const RESOLVED_MODULE = 'resolved_module';
 const INITIALIZED = 'fulfilled';
 const ERRORED = 'rejected';
@@ -178,6 +193,15 @@ type BlockedChunk<T> = {
 type ResolvedModelChunk<T> = {
   status: 'resolved_model',
   value: UninitializedModel,
+  reason: Response,
+  _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
+  _debugChunk: null | SomeChunk<ReactDebugInfoEntry>, // DEV-only
+  _debugInfo: ReactDebugInfo, // DEV-only
+  then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
+};
+type ResolvedObjectChunk<T> = {
+  status: 'resolved_object',
+  value: Object,
   reason: Response,
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null | SomeChunk<ReactDebugInfoEntry>, // DEV-only
@@ -235,6 +259,7 @@ type SomeChunk<T> =
   | PendingChunk<T>
   | BlockedChunk<T>
   | ResolvedModelChunk<T>
+  | ResolvedObjectChunk<T>
   | ResolvedModuleChunk<T>
   | InitializedChunk<T>
   | ErroredChunk<T>
@@ -266,6 +291,7 @@ ReactPromise.prototype.then = function <T>(
   // might put us back into one of the other states.
   switch (chunk.status) {
     case RESOLVED_MODEL:
+    case RESOLVED_OBJECT:
       initializeModelChunk(chunk);
       break;
     case RESOLVED_MODULE:
@@ -347,6 +373,15 @@ type Response = {
   _callServer: CallServerCallback,
   _encodeFormAction: void | EncodeFormActionCallback,
   _nonce: ?string,
+  // Only used when this response consumes an in-process render. Rows are
+  // delivered inside the producing renderer's async scope, where the
+  // consuming renderer (and its request storage) isn't reachable, so hint
+  // and module-destination dispatches can't run at row-receipt time the way
+  // they do for a byte stream, whose subscription callbacks inherit the
+  // consumer's scope. Until the consumer's scope is captured (at its first
+  // read), dispatches buffer here; afterwards they run through it.
+  _deferredDispatches: null | Array<() => void>,
+  _dispatchScope: null | ((dispatch: () => void) => void),
   _chunks: Map<number, SomeChunk<any>>,
   _stringDecoder: StringDecoder,
   _closed: boolean,
@@ -423,6 +458,7 @@ function readChunk<T>(chunk: SomeChunk<T>): T {
   // might put us back into one of the other states.
   switch (chunk.status) {
     case RESOLVED_MODEL:
+    case RESOLVED_OBJECT:
       initializeModelChunk(chunk);
       break;
     case RESOLVED_MODULE:
@@ -802,6 +838,14 @@ function createResolvedModelChunk<T>(
   return new ReactPromise(RESOLVED_MODEL, value, response);
 }
 
+function createResolvedObjectChunk<T>(
+  response: Response,
+  value: Object,
+): ResolvedObjectChunk<T> {
+  // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
+  return new ReactPromise(RESOLVED_OBJECT, value, response);
+}
+
 function createResolvedModuleChunk<T>(
   response: Response,
   value: ClientReference<T>,
@@ -854,48 +898,72 @@ function createInitializedStreamChunk<
   return new ReactPromise(INITIALIZED, value, controller);
 }
 
+function wrapIteratorResultModel(
+  value: UninitializedModel | Object,
+  done: boolean,
+  status: 'resolved_model' | 'resolved_object',
+): UninitializedModel | Object {
+  // To reuse as much code as possible we add the wrapper element as part of
+  // the model. For JSON text we concatenate it into the JSON. For an already
+  // parsed model we wrap it in an equivalent parsed object.
+  if (status === RESOLVED_MODEL) {
+    return (
+      (done ? '{"done":true,"value":' : '{"done":false,"value":') +
+      (value as any) +
+      '}'
+    );
+  }
+  return {done: done, value: value};
+}
+
 function createResolvedIteratorResultChunk<T>(
   response: Response,
-  value: UninitializedModel,
+  value: UninitializedModel | Object,
   done: boolean,
+  status: 'resolved_model' | 'resolved_object',
 ): ResolvedModelChunk<IteratorResult<T, T>> {
-  // To reuse code as much code as possible we add the wrapper element as part of the JSON.
-  const iteratorResultJSON =
-    (done ? '{"done":true,"value":' : '{"done":false,"value":') + value + '}';
   // $FlowFixMe[invalid-constructor] Flow doesn't support functions as constructors
-  return new ReactPromise(RESOLVED_MODEL, iteratorResultJSON, response);
+  return new ReactPromise(
+    status,
+    wrapIteratorResultModel(value, done, status),
+    response,
+  );
 }
 
 function resolveIteratorResultChunk<T>(
   response: Response,
   chunk: SomeChunk<IteratorResult<T, T>>,
-  value: UninitializedModel,
+  value: UninitializedModel | Object,
   done: boolean,
+  status: 'resolved_model' | 'resolved_object',
 ): void {
-  // To reuse code as much code as possible we add the wrapper element as part of the JSON.
-  const iteratorResultJSON =
-    (done ? '{"done":true,"value":' : '{"done":false,"value":') + value + '}';
-  resolveModelChunk(response, chunk, iteratorResultJSON);
+  resolveModelChunk(
+    response,
+    chunk,
+    wrapIteratorResultModel(value, done, status),
+    status,
+  );
 }
 
 function resolveModelChunk<T>(
   response: Response,
   chunk: SomeChunk<T>,
-  value: UninitializedModel,
+  value: UninitializedModel | Object,
+  status: 'resolved_model' | 'resolved_object',
 ): void {
   if (chunk.status !== PENDING) {
     // If we get more data to an already resolved ID, we assume that it's
     // a stream chunk since any other row shouldn't have more than one entry.
     const streamChunk: InitializedStreamChunk<any> = chunk as any;
     const controller = streamChunk.reason;
-    controller.enqueueModel(value);
+    controller.enqueueModel(value, status);
     return;
   }
   releasePendingChunk(response, chunk);
   const resolveListeners = chunk.value;
   const rejectListeners = chunk.reason;
-  const resolvedChunk: ResolvedModelChunk<T> = chunk as any;
-  resolvedChunk.status = RESOLVED_MODEL;
+  const resolvedChunk = chunk as any;
+  resolvedChunk.status = status;
   resolvedChunk.value = value;
   resolvedChunk.reason = response;
   if (resolveListeners !== null) {
@@ -965,7 +1033,7 @@ let isInitializingDebugInfo: boolean = false;
 
 function initializeDebugChunk(
   response: Response,
-  chunk: ResolvedModelChunk<any> | PendingChunk<any>,
+  chunk: ResolvedModelChunk<any> | ResolvedObjectChunk<any> | PendingChunk<any>,
 ): void {
   const debugChunk = chunk._debugChunk;
   if (debugChunk !== null) {
@@ -1042,11 +1110,14 @@ function initializeDebugChunk(
   }
 }
 
-function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
+function initializeModelChunk<T>(
+  chunk: ResolvedModelChunk<T> | ResolvedObjectChunk<T>,
+): void {
   const prevHandler = initializingHandler;
   const prevChunk = initializingChunk;
   initializingHandler = null;
 
+  const isObjectForm = chunk.status === RESOLVED_OBJECT;
   const resolvedModel = chunk.value;
   const response = chunk.reason;
 
@@ -1071,7 +1142,11 @@ function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
   }
 
   try {
-    const value: T = parseModel(response, resolvedModel);
+    const value: T = isObjectForm
+      ? // The row arrived in object form from an in-process render: already
+        // parsed, not yet revived. See parseModel for the wrapper object.
+        reviveModel(response, resolvedModel as any, {'': resolvedModel}, '')
+      : parseModel(response, resolvedModel as any);
     // Invoke any listeners added while resolving this model. I.e. cyclic
     // references. This may or may not fully resolve the model depending on
     // if they were blocked.
@@ -1532,6 +1607,7 @@ function fulfillReference(
         } else {
           switch (referencedChunk.status) {
             case RESOLVED_MODEL:
+            case RESOLVED_OBJECT:
               initializeModelChunk(referencedChunk);
               break;
             case RESOLVED_MODULE:
@@ -1620,6 +1696,7 @@ function fulfillReference(
       } else {
         switch (referencedChunk.status) {
           case RESOLVED_MODEL:
+          case RESOLVED_OBJECT:
             initializeModelChunk(referencedChunk);
             break;
           case RESOLVED_MODULE:
@@ -2078,6 +2155,7 @@ function getOutlinedModel<T>(
   }
   switch (chunk.status) {
     case RESOLVED_MODEL:
+    case RESOLVED_OBJECT:
       initializeModelChunk(chunk);
       break;
     case RESOLVED_MODULE:
@@ -2097,6 +2175,7 @@ function getOutlinedModel<T>(
           const referencedChunk: SomeChunk<any> = value._payload;
           switch (referencedChunk.status) {
             case RESOLVED_MODEL:
+            case RESOLVED_OBJECT:
               initializeModelChunk(referencedChunk);
               break;
             case RESOLVED_MODULE:
@@ -2173,6 +2252,7 @@ function getOutlinedModel<T>(
         const referencedChunk: SomeChunk<any> = value._payload;
         switch (referencedChunk.status) {
           case RESOLVED_MODEL:
+          case RESOLVED_OBJECT:
             initializeModelChunk(referencedChunk);
             break;
           case RESOLVED_MODULE:
@@ -2306,7 +2386,10 @@ function defineLazyGetter<T>(
   if (key !== __PROTO__) {
     Object.defineProperty(parentObject, key, {
       get: function () {
-        if (chunk.status === RESOLVED_MODEL) {
+        if (
+          chunk.status === RESOLVED_MODEL ||
+          chunk.status === RESOLVED_OBJECT
+        ) {
           // If it was now resolved, then we initialize it. This may then discover
           // a new set of lazy references that are then asked for eagerly in case
           // we get that deep.
@@ -2729,6 +2812,8 @@ function ResponseInstance(
   this._callServer = callServer !== undefined ? callServer : missingCall;
   this._encodeFormAction = encodeFormAction;
   this._nonce = nonce;
+  this._deferredDispatches = null;
+  this._dispatchScope = null;
   this._chunks = chunks;
   this._stringDecoder = createStringDecoder();
   this._closed = false;
@@ -3040,7 +3125,34 @@ function resolveModel(
     if (__DEV__) {
       resolveChunkDebugInfo(response, streamState, chunk);
     }
-    resolveModelChunk(response, chunk, model);
+    resolveModelChunk(response, chunk, model, RESOLVED_MODEL);
+  }
+}
+
+// Like resolveModel, but for a row that arrived in object form from an
+// in-process render: already parsed, not yet revived.
+function resolveModelObject(
+  response: Response,
+  id: number,
+  model: Object,
+  streamState: StreamState,
+): void {
+  const chunks = response._chunks;
+  const chunk = chunks.get(id);
+  if (!chunk) {
+    const newChunk: ResolvedObjectChunk<any> = createResolvedObjectChunk(
+      response,
+      model,
+    );
+    if (__DEV__) {
+      resolveChunkDebugInfo(response, streamState, newChunk);
+    }
+    chunks.set(id, newChunk);
+  } else {
+    if (__DEV__) {
+      resolveChunkDebugInfo(response, streamState, chunk);
+    }
+    resolveModelChunk(response, chunk, model, RESOLVED_OBJECT);
   }
 }
 
@@ -3113,10 +3225,12 @@ function resolveModule(
     clientReferenceMetadata,
   );
 
-  prepareDestinationForModule(
-    response._moduleLoading,
-    response._nonce,
-    clientReferenceMetadata,
+  scheduleDispatch(response, () =>
+    prepareDestinationForModule(
+      response._moduleLoading,
+      response._nonce,
+      clientReferenceMetadata,
+    ),
   );
 
   // TODO: Add an option to encode modules that are lazy loaded.
@@ -3262,14 +3376,17 @@ function startReadableStream<T>(
         });
       }
     },
-    enqueueModel(json: UninitializedModel): void {
+    enqueueModel(
+      json: UninitializedModel | Object,
+      status: 'resolved_model' | 'resolved_object',
+    ): void {
       if (previousBlockedChunk === null) {
         // If we're not blocked on any other chunks, we can try to eagerly initialize
         // this as a fast-path to avoid awaiting them.
-        const chunk: ResolvedModelChunk<T> = createResolvedModelChunk(
-          response,
-          json,
-        );
+        const chunk: ResolvedModelChunk<T> | ResolvedObjectChunk<T> =
+          status === RESOLVED_MODEL
+            ? createResolvedModelChunk(response, json as any)
+            : createResolvedObjectChunk(response, json as any);
         initializeModelChunk(chunk);
         const initializedChunk: SomeChunk<T> = chunk;
         if (initializedChunk.status === INITIALIZED) {
@@ -3296,7 +3413,7 @@ function startReadableStream<T>(
             // to synchronous emitting.
             previousBlockedChunk = null;
           }
-          resolveModelChunk(response, chunk, json);
+          resolveModelChunk(response, chunk, json, status);
         });
       }
     },
@@ -3391,12 +3508,16 @@ function startAsyncIterable<T>(
       }
       nextWriteIndex++;
     },
-    enqueueModel(value: UninitializedModel): void {
+    enqueueModel(
+      value: UninitializedModel | Object,
+      status: 'resolved_model' | 'resolved_object',
+    ): void {
       if (nextWriteIndex === buffer.length) {
         buffer[nextWriteIndex] = createResolvedIteratorResultChunk(
           response,
           value,
           false,
+          status,
         );
       } else {
         resolveIteratorResultChunk(
@@ -3404,6 +3525,7 @@ function startAsyncIterable<T>(
           buffer[nextWriteIndex],
           value,
           false,
+          status,
         );
       }
       nextWriteIndex++;
@@ -3418,6 +3540,7 @@ function startAsyncIterable<T>(
           response,
           value,
           true,
+          RESOLVED_MODEL,
         );
       } else {
         resolveIteratorResultChunk(
@@ -3425,6 +3548,7 @@ function startAsyncIterable<T>(
           buffer[nextWriteIndex],
           value,
           true,
+          RESOLVED_MODEL,
         );
       }
       nextWriteIndex++;
@@ -3435,6 +3559,7 @@ function startAsyncIterable<T>(
           buffer[nextWriteIndex++],
           '"$undefined"',
           true,
+          RESOLVED_MODEL,
         );
       }
     },
@@ -3667,7 +3792,7 @@ function resolveHint<Code: HintCode>(
   model: UninitializedModel,
 ): void {
   const hintModel: HintModel<Code> = parseModel(response, model);
-  dispatchHint(code, hintModel);
+  scheduleDispatch(response, () => dispatchHint(code, hintModel));
 }
 
 const supportsCreateTask = __DEV__ && !!(console as any).createTask;
@@ -4294,7 +4419,7 @@ function resolveConsoleEntry(
         // to synchronous emitting.
         response._blockedConsole = null;
       }
-      resolveModelChunk(response, chunk, json);
+      resolveModelChunk(response, chunk, json, RESOLVED_MODEL);
     };
     blockedChunk.then(unblock, unblock);
   }
@@ -4353,7 +4478,7 @@ function resolveIOInfo(
       chunks.set(id, chunk);
       initializeModelChunk(chunk);
     } else {
-      resolveModelChunk(response, chunk, model);
+      resolveModelChunk(response, chunk, model, RESOLVED_MODEL);
       if (chunk.status === RESOLVED_MODEL) {
         initializeModelChunk(chunk);
       }
@@ -5323,6 +5448,143 @@ export function processStringChunk(
   streamState._rowLength = rowLength;
 }
 
+function scheduleDispatch(response: Response, dispatch: () => void): void {
+  const scope = response._dispatchScope;
+  if (scope !== null) {
+    // Run within the consumer's captured async scope so the dispatch can
+    // resolve the consuming renderer's request.
+    scope(dispatch);
+    return;
+  }
+  const deferred = response._deferredDispatches;
+  if (deferred !== null) {
+    // The consumer hasn't read anything yet; hold the dispatch until its
+    // scope is captured.
+    deferred.push(dispatch);
+    return;
+  }
+  dispatch();
+}
+
+// Captures the async scope of the consumer's first read. Everything
+// buffered so far flushes through it, and future dispatches run through it
+// the moment their row is delivered — the same timing a byte stream's
+// subscription gives them.
+export function provideDispatchScope(
+  weakResponse: WeakResponse,
+  runInScope: (dispatch: () => void) => void,
+): void {
+  if (hasGCedResponse(weakResponse)) {
+    return;
+  }
+  const response = unwrapWeakResponse(weakResponse);
+  if (response._dispatchScope !== null) {
+    return;
+  }
+  response._dispatchScope = runInScope;
+  const deferred = response._deferredDispatches;
+  response._deferredDispatches = null;
+  if (deferred !== null && deferred.length > 0) {
+    // Enter the captured scope once for the whole backlog.
+    runInScope(() => {
+      for (let i = 0; i < deferred.length; i++) {
+        deferred[i]();
+      }
+    });
+  }
+}
+
+export function connectRenderResult(
+  weakResponse: WeakResponse,
+  result: RenderResult,
+  streamState: StreamState,
+): void {
+  if (!hasGCedResponse(weakResponse)) {
+    unwrapWeakResponse(weakResponse)._deferredDispatches = [];
+  }
+  result._attach({
+    row: (id: number, tag: string, payload: mixed) =>
+      processModelRow(weakResponse, streamState, id, tag, payload),
+    close: () => close(weakResponse),
+    error: (reason: mixed) => reportGlobalError(weakResponse, reason as any),
+  });
+}
+
+export function processModelRow(
+  weakResponse: WeakResponse,
+  streamState: StreamState,
+  id: number,
+  tag: string,
+  payload: mixed,
+): void {
+  if (hasGCedResponse(weakResponse)) {
+    // Ignore more rows if we've already GC:ed all listeners.
+    return;
+  }
+  const response = unwrapWeakResponse(weakResponse);
+  switch (tag) {
+    case '': {
+      // An untagged model row. Objects arrive parsed but not yet revived;
+      // strings are always the row's JSON text; an empty payload marks a
+      // DEV-only halted row which intentionally never resolves.
+      if (payload === '' || payload === undefined) {
+        if (__DEV__) {
+          resolveDebugHalt(response, id);
+        }
+        return;
+      }
+      if (typeof payload === 'string') {
+        // The model's JSON text: primitives and DEV-only pre-serialized rows.
+        resolveModel(response, id, payload, streamState);
+      } else {
+        resolveModelObject(response, id, payload as any, streamState);
+      }
+      return;
+    }
+    case 'T': {
+      // Text rows skip the wire's byte-length framing entirely.
+      resolveText(response, id, payload as any, streamState);
+      return;
+    }
+    case 'A': {
+      // An ArrayBuffer, delivered as a view over exactly its bytes.
+      resolveBuffer(response, id, (payload as any).buffer, streamState);
+      return;
+    }
+    case 'O':
+    case 'o':
+    case 'U':
+    case 'S':
+    case 's':
+    case 'L':
+    case 'l':
+    case 'G':
+    case 'g':
+    case 'M':
+    case 'm':
+    case 'V':
+    case 'b': {
+      // Binary rows are delivered as a view that already has the row's
+      // type, so nothing needs to be reconstructed from raw bytes.
+      resolveBuffer(response, id, payload as any, streamState);
+      return;
+    }
+    default: {
+      // Everything else is delivered as the same text that frames the row
+      // on the wire, so it takes the exact same path a byte stream takes
+      // after it has parsed a row.
+      processFullStringRow(
+        response,
+        streamState,
+        id,
+        tag.charCodeAt(0),
+        payload as any,
+      );
+      return;
+    }
+  }
+}
+
 function parseModel<T>(response: Response, json: UninitializedModel): T {
   const rawModel = JSON.parse(json);
   // Pass a wrapper object as parentObject to match the original JSON.parse
@@ -5348,7 +5610,12 @@ function reviveModel(
   }
   if (isArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      (value as any)[i] = reviveModel(response, value[i], value, '' + i);
+      const walked = reviveModel(response, value[i], value, '' + i);
+      if (walked !== value[i]) {
+        // Only write on change: unchanged values may be the producer's own
+        // objects, which can be frozen.
+        (value as any)[i] = walked;
+      }
     }
     // $FlowFixMe[invalid-compare]
     if (value[0] === REACT_ELEMENT_TYPE) {
@@ -5363,10 +5630,12 @@ function reviveModel(
       delete (value as any)[k];
     } else {
       const walked = reviveModel(response, (value as any)[k], value, k);
-      if (walked !== undefined) {
-        (value as any)[k] = walked;
-      } else {
+      if (walked === undefined) {
         delete (value as any)[k];
+      } else if (walked !== (value as any)[k]) {
+        // Only write on change: unchanged values may be the producer's own
+        // objects, which can be frozen.
+        (value as any)[k] = walked;
       }
     }
   }

--- a/packages/react-server-dom-turbopack/npm/server.node.js
+++ b/packages/react-server-dom-turbopack/npm/server.node.js
@@ -7,6 +7,7 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-turbopack-server.node.development.js');
 }
 
+exports.render = s.render;
 exports.renderToReadableStream = s.renderToReadableStream;
 exports.renderToPipeableStream = s.renderToPipeableStream;
 exports.decodeReply = s.decodeReply;

--- a/packages/react-server-dom-turbopack/server.node.js
+++ b/packages/react-server-dom-turbopack/server.node.js
@@ -8,6 +8,7 @@
  */
 
 export {
+  render,
   renderToPipeableStream,
   renderToReadableStream,
   decodeReply,

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -29,9 +29,15 @@ type ServerConsumerManifest = {
 
 import type {Readable} from 'stream';
 
+import {AsyncLocalStorage} from 'async_hooks';
+
+import type {RenderResult} from 'react-client/src/ReactFlightClient';
+
 import {
   createResponse,
   createStreamState,
+  connectRenderResult,
+  provideDispatchScope,
   getRoot,
   reportGlobalError,
   processStringChunk,
@@ -140,4 +146,58 @@ function createFromNodeStream<T>(
   return getRoot(response);
 }
 
-export {createFromNodeStream};
+// Consumes an in-process render() result through the normal Response, so
+// module resolution, dedupe, lazy chunks, hint dispatch and debug info all
+// behave exactly as they do for a byte stream. The consumer has to attach
+// before the render starts emitting, so this must be called synchronously
+// after render().
+function createFromRender<T>(
+  result: RenderResult,
+  serverConsumerManifest: ServerConsumerManifest,
+  options?: Options,
+): Thenable<T> {
+  const response: Response = createResponse(
+    serverConsumerManifest.moduleMap,
+    serverConsumerManifest.serverModuleMap,
+    serverConsumerManifest.moduleLoading,
+    noServerCall,
+    options ? options.encodeFormAction : undefined,
+    options && typeof options.nonce === 'string' ? options.nonce : undefined,
+    undefined, // TODO: If encodeReply is supported, this should support temporaryReferences
+    options && options.unstable_allowPartialStream
+      ? options.unstable_allowPartialStream
+      : false,
+    __DEV__ && options && options.findSourceMapURL
+      ? options.findSourceMapURL
+      : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
+    __DEV__ && options && options.startTime != null
+      ? options.startTime
+      : undefined,
+    __DEV__ && options && options.endTime != null ? options.endTime : undefined,
+    undefined, // debugChannel: debug rows arrive through the result itself
+  );
+  const streamState = createStreamState(response, result);
+  connectRenderResult(response, result, streamState);
+  const root = getRoot<T>(response);
+  let scopeCaptured = false;
+  return {
+    then(resolve: any, reject: any) {
+      if (!scopeCaptured) {
+        scopeCaptured = true;
+        // Module preinits and hints must land in whatever request consumes
+        // this response. A byte stream gets this implicitly: its
+        // subscription callbacks inherit the consumer's async scope. For an
+        // in-process render, capture the scope of the first read — the
+        // consuming renderer's — and route every dispatch through it.
+        provideDispatchScope(response, AsyncLocalStorage.snapshot());
+      }
+      return (root as any).then(resolve, reject);
+    },
+  } as any;
+}
+
+export {createFromNodeStream, createFromRender};

--- a/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-turbopack/src/server/ReactFlightDOMServerNode.js
@@ -24,7 +24,13 @@ import {Readable} from 'stream';
 
 import {ASYNC_ITERATOR} from 'shared/ReactSymbols';
 
+import type {
+  RenderResult as FlightRenderResult,
+  RenderConsumer,
+} from 'react-server/src/ReactFlightServer';
+
 import {
+  createRenderResult,
   createRequest,
   createPrerenderRequest,
   startWork,
@@ -167,24 +173,8 @@ function renderToPipeableStream(
   options?: Options,
 ): PipeableStream {
   const debugChannel = __DEV__ && options ? options.debugChannel : undefined;
-  const debugChannelReadable: void | Readable | WebSocket =
-    __DEV__ &&
-    debugChannel !== undefined &&
-    // $FlowFixMe[method-unbinding]
-    (typeof debugChannel.read === 'function' ||
-      typeof debugChannel.readyState === 'number')
-      ? (debugChannel as any)
-      : undefined;
-  const debugChannelWritable: void | Writable =
-    __DEV__ && debugChannel !== undefined
-      ? // $FlowFixMe[method-unbinding]
-        typeof debugChannel.write === 'function'
-        ? (debugChannel as any)
-        : // $FlowFixMe[method-unbinding]
-          typeof debugChannel.send === 'function'
-          ? createFakeWritableFromWebSocket(debugChannel as any)
-          : undefined
-      : undefined;
+  const debugChannelReadable = getDebugChannelReadable(debugChannel);
+  const debugChannelWritable = getDebugChannelWritable(debugChannel);
   const request = createRequest(
     model,
     turbopackMap,
@@ -196,7 +186,6 @@ function renderToPipeableStream(
     __DEV__ && options ? options.filterStackFrame : undefined,
     debugChannelReadable !== undefined,
   );
-  let hasStartedFlowing = false;
   startWork(request);
   if (debugChannelWritable !== undefined) {
     startFlowingDebug(request, debugChannelWritable);
@@ -204,6 +193,40 @@ function renderToPipeableStream(
   if (debugChannelReadable !== undefined) {
     startReadingFromDebugChannelReadable(request, debugChannelReadable);
   }
+  return createPipeableStream(request, debugChannelReadable);
+}
+
+function getDebugChannelReadable(
+  debugChannel: void | Readable | Writable | Duplex | WebSocket,
+): void | Readable | WebSocket {
+  return __DEV__ &&
+    debugChannel !== undefined &&
+    // $FlowFixMe[method-unbinding]
+    (typeof (debugChannel as any).read === 'function' ||
+      typeof (debugChannel as any).readyState === 'number')
+    ? (debugChannel as any)
+    : undefined;
+}
+
+function getDebugChannelWritable(
+  debugChannel: void | Readable | Writable | Duplex | WebSocket,
+): void | Writable {
+  return __DEV__ && debugChannel !== undefined
+    ? // $FlowFixMe[method-unbinding]
+      typeof (debugChannel as any).write === 'function'
+      ? (debugChannel as any)
+      : // $FlowFixMe[method-unbinding]
+        typeof (debugChannel as any).send === 'function'
+        ? createFakeWritableFromWebSocket(debugChannel as any)
+        : undefined
+    : undefined;
+}
+
+function createPipeableStream(
+  request: Request,
+  debugChannelReadable: void | Readable | WebSocket,
+): PipeableStream {
+  let hasStartedFlowing = false;
   return {
     pipe<T: Writable>(destination: T): T {
       if (hasStartedFlowing) {
@@ -775,7 +798,82 @@ function decodeReplyFromAsyncIterable<T>(
   return getRoot(response);
 }
 
+export type RenderOptions = {
+  identifierPrefix?: string,
+  signal?: AbortSignal,
+  onError?: (error: mixed) => void,
+  environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
+  temporaryReferences?: TemporaryReferenceSet,
+  startTime?: number,
+  // DEV-only: debug rows leave on this channel instead of reaching either
+  // the byte stream or the in-process consumer.
+  debugChannel?: Readable | Writable | Duplex | WebSocket,
+};
+
+export type RenderResult = {
+  _attach: (consumer: RenderConsumer) => void,
+  pipe<T: Writable>(destination: T): T,
+  abort(reason: mixed): void,
+};
+
+// Renders the model without deciding how it will be consumed: pass the
+// result to a paired Flight Client's createFromRender to read the render
+// back in the same process without going through the wire format, pipe it
+// to get the byte stream, or both from the same render. A consumer has to
+// attach before the render starts emitting, so createFromRender must be
+// called synchronously after render().
+function render(
+  model: ReactClientValue,
+  turbopackMap: ClientManifest,
+  options?: RenderOptions,
+): RenderResult {
+  const debugChannel = __DEV__ && options ? options.debugChannel : undefined;
+  const debugChannelReadable = getDebugChannelReadable(debugChannel);
+  const debugChannelWritable = getDebugChannelWritable(debugChannel);
+  const request = createRequest(
+    model,
+    turbopackMap,
+    options ? options.onError : undefined,
+    options ? options.identifierPrefix : undefined,
+    options ? options.temporaryReferences : undefined,
+    options ? options.startTime : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
+    debugChannelReadable !== undefined,
+  );
+  const result: FlightRenderResult = createRenderResult(request);
+  const pipeableStream = createPipeableStream(request, debugChannelReadable);
+  if (options && options.signal) {
+    const signal = options.signal;
+    if (signal.aborted) {
+      // Give the caller a chance to attach a consumer before the abort
+      // emits its error rows.
+      Promise.resolve().then(() => abort(request, (signal as any).reason));
+    } else {
+      const listener = () => {
+        abort(request, (signal as any).reason);
+        signal.removeEventListener('abort', listener);
+      };
+      signal.addEventListener('abort', listener);
+    }
+  }
+  startWork(request);
+  if (debugChannelWritable !== undefined) {
+    startFlowingDebug(request, debugChannelWritable);
+  }
+  if (debugChannelReadable !== undefined) {
+    startReadingFromDebugChannelReadable(request, debugChannelReadable);
+  }
+  return {
+    _attach: result._attach,
+    pipe: pipeableStream.pipe,
+    abort: pipeableStream.abort,
+  };
+}
+
 export {
+  render,
   renderToReadableStream,
   renderToPipeableStream,
   prerender,

--- a/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.js
+++ b/packages/react-server-dom-turbopack/src/server/react-flight-dom-server.node.js
@@ -8,6 +8,7 @@
  */
 
 export {
+  render,
   renderToReadableStream,
   renderToPipeableStream,
   prerender,

--- a/packages/react-server-dom-webpack/npm/server.node.js
+++ b/packages/react-server-dom-webpack/npm/server.node.js
@@ -7,6 +7,7 @@ if (process.env.NODE_ENV === 'production') {
   s = require('./cjs/react-server-dom-webpack-server.node.development.js');
 }
 
+exports.render = s.render;
 exports.renderToReadableStream = s.renderToReadableStream;
 exports.renderToPipeableStream = s.renderToPipeableStream;
 exports.decodeReply = s.decodeReply;

--- a/packages/react-server-dom-webpack/server.node.js
+++ b/packages/react-server-dom-webpack/server.node.js
@@ -8,6 +8,7 @@
  */
 
 export {
+  render,
   renderToPipeableStream,
   renderToReadableStream,
   decodeReply,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMRender-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMRender-test.js
@@ -1,0 +1,1160 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+'use strict';
+
+import {patchSetImmediate} from '../../../../scripts/jest/patchSetImmediate';
+
+// Every test in this suite renders the same model twice: once through the
+// byte stream (renderToPipeableStream -> createFromNodeStream) and once
+// in-process (render -> createFromRender), and asserts that the two are
+// observably identical. The byte stream is the long-standing behavior, so
+// it acts as the executable specification for the in-process path.
+
+let clientExports;
+let webpackMap;
+let webpackModules;
+let webpackModuleLoading;
+let React;
+let ReactDOMServer;
+let ReactServer;
+let ReactServerDOMServer;
+let ReactServerDOMClient;
+let FlightReactDOM;
+let Stream;
+let use;
+let serverAct;
+let assertConsoleErrorDev;
+
+describe('ReactFlightDOMRender', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    patchSetImmediate();
+    serverAct = require('internal-test-utils').serverAct;
+
+    // Simulate the condition resolution
+    jest.mock('react', () => require('react/react.react-server'));
+    jest.mock('react-server-dom-webpack/server', () =>
+      jest.requireActual('react-server-dom-webpack/server.node'),
+    );
+    ReactServer = require('react');
+    ReactServerDOMServer = require('react-server-dom-webpack/server');
+    FlightReactDOM = require('react-dom');
+
+    const WebpackMock = require('./utils/WebpackMock');
+    clientExports = WebpackMock.clientExports;
+    webpackMap = WebpackMock.webpackMap;
+    webpackModules = WebpackMock.webpackModules;
+    webpackModuleLoading = WebpackMock.moduleLoading;
+
+    jest.resetModules();
+    __unmockReact();
+    jest.unmock('react-server-dom-webpack/server');
+    jest.mock('react-server-dom-webpack/client', () =>
+      jest.requireActual('react-server-dom-webpack/client.node'),
+    );
+
+    React = require('react');
+    ReactDOMServer = require('react-dom/server.node');
+    ReactServerDOMClient = require('react-server-dom-webpack/client');
+    Stream = require('stream');
+    use = React.use;
+
+    assertConsoleErrorDev =
+      require('internal-test-utils').assertConsoleErrorDev;
+  });
+
+  function getTranslationMap() {
+    // For the SSR pass, act as if the client references resolve to the
+    // same modules (identity translation), like a real server consumer
+    // manifest would.
+    const translationMap = {};
+    for (const $$id in webpackMap) {
+      const metadata = webpackMap[$$id];
+      const forModule =
+        translationMap[metadata.id] || (translationMap[metadata.id] = {});
+      forModule[metadata.name] = metadata;
+      forModule['*'] = metadata;
+    }
+    return translationMap;
+  }
+
+  function readResult(stream) {
+    return new Promise((resolve, reject) => {
+      let buffer = '';
+      const writable = new Stream.PassThrough();
+      writable.setEncoding('utf8');
+      writable.on('data', chunk => {
+        buffer += chunk;
+      });
+      writable.on('error', error => {
+        reject(error);
+      });
+      writable.on('end', () => {
+        resolve(buffer);
+      });
+      stream.pipe(writable);
+    });
+  }
+
+  const ssrManifest = {
+    moduleMap: null,
+    moduleLoading: null,
+  };
+
+  // Renders the model through the byte stream and returns the Response.
+  async function renderThroughWire(model, serverOptions, manifest) {
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(
+        model,
+        webpackMap,
+        serverOptions,
+      ),
+    );
+    const readable = new Stream.PassThrough();
+    const response = ReactServerDOMClient.createFromNodeStream(
+      readable,
+      manifest || ssrManifest,
+    );
+    stream.pipe(readable);
+    // Boxed so that awaiting this async helper can't unwrap the thenable
+    // Response into its root model.
+    return {response};
+  }
+
+  // Renders the model in-process and returns the Response.
+  async function renderInProcess(model, serverOptions, manifest) {
+    let response;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(
+        model,
+        webpackMap,
+        serverOptions,
+      );
+      response = ReactServerDOMClient.createFromRender(
+        result,
+        manifest || ssrManifest,
+      );
+    });
+    return {response};
+  }
+
+  async function renderToHTML(response) {
+    function Root() {
+      return use(response);
+    }
+    const htmlStream = await serverAct(() =>
+      ReactDOMServer.renderToPipeableStream(React.createElement(Root)),
+    );
+    return readResult(htmlStream);
+  }
+
+  // The core parity assertion: the same model must produce the same HTML
+  // whether it went through the wire or not.
+  async function expectSameHTML(makeModel, serverOptions, manifest) {
+    const {response: wireResponse} = await renderThroughWire(
+      makeModel(),
+      serverOptions,
+      manifest,
+    );
+    const wireHTML = await renderToHTML(wireResponse);
+    const {response: renderResponse} = await renderInProcess(
+      makeModel(),
+      serverOptions,
+      manifest,
+    );
+    const renderHTML = await renderToHTML(renderResponse);
+    expect(renderHTML).toBe(wireHTML);
+    return renderHTML;
+  }
+
+  it('renders host elements, keys and fragments identically', async () => {
+    function makeModel() {
+      function Item({index}) {
+        return ReactServer.createElement('li', null, 'Item ', String(index));
+      }
+      function App() {
+        const items = [];
+        for (let i = 0; i < 10; i++) {
+          items.push(ReactServer.createElement(Item, {key: i, index: i}));
+        }
+        return ReactServer.createElement(
+          'div',
+          {className: 'root'},
+          ReactServer.createElement(
+            ReactServer.Fragment,
+            null,
+            ReactServer.createElement('h1', null, 'Hello'),
+            ReactServer.createElement('ul', null, items),
+          ),
+        );
+      }
+      return ReactServer.createElement(App);
+    }
+    const html = await expectSameHTML(makeModel);
+    expect(html).toContain('Item <!-- -->9');
+  });
+
+  it('renders client component references identically', async () => {
+    function Client({label, items}) {
+      return React.createElement(
+        'b',
+        {'data-count': String(items.length)},
+        label,
+        ': ',
+        items.join(','),
+      );
+    }
+    const ClientRef = clientExports(Client);
+    const manifest = {
+      moduleMap: getTranslationMap(),
+      moduleLoading: webpackModuleLoading,
+    };
+    function makeModel() {
+      function App() {
+        return ReactServer.createElement('section', null, [
+          ReactServer.createElement(ClientRef, {
+            key: 'a',
+            label: 'first',
+            items: [1, 2, 3],
+          }),
+          ReactServer.createElement(ClientRef, {
+            key: 'b',
+            label: 'second',
+            items: ['x'],
+          }),
+        ]);
+      }
+      return ReactServer.createElement(App);
+    }
+    const html = await expectSameHTML(makeModel, undefined, manifest);
+    expect(html).toContain('first');
+    expect(html).toContain('data-count="3"');
+  });
+
+  it('renders async server components identically', async () => {
+    function makeModel() {
+      async function Inner({id}) {
+        const data = await Promise.resolve('data-' + id);
+        return ReactServer.createElement('i', null, data);
+      }
+      async function App() {
+        await Promise.resolve();
+        return ReactServer.createElement(
+          'main',
+          null,
+          ReactServer.createElement(Inner, {id: 1}),
+          ReactServer.createElement(Inner, {id: 2}),
+        );
+      }
+      return ReactServer.createElement(App);
+    }
+    const html = await expectSameHTML(makeModel);
+    expect(html).toContain('data-1');
+    expect(html).toContain('data-2');
+  });
+
+  it('resolves promises and lazy values in the model identically', async () => {
+    function makeModel() {
+      function Inner() {
+        return ReactServer.createElement('span', null, 'lazy inner');
+      }
+      return {
+        promised: Promise.resolve('promised value'),
+        element: ReactServer.createElement(
+          'p',
+          null,
+          Promise.resolve(ReactServer.createElement(Inner)),
+        ),
+      };
+    }
+    const wire = await renderThroughWire(makeModel());
+    const inProcess = await renderInProcess(makeModel());
+    const wireRoot = await wire.response;
+    const renderRoot = await inProcess.response;
+    expect(await renderRoot.promised).toBe(await wireRoot.promised);
+    const wireHTML = await renderToHTML(
+      Promise.resolve(wireRoot.element) as any,
+    );
+    const renderHTML = await renderToHTML(
+      Promise.resolve(renderRoot.element) as any,
+    );
+    expect(renderHTML).toBe(wireHTML);
+  });
+
+  it('decodes special value types identically', async () => {
+    function makeModel() {
+      return {
+        date: new Date(12345),
+        map: new Map([['key', {nested: true}]]),
+        set: new Set(['a', 'b']),
+        bigint: 42n,
+        nan: NaN,
+        inf: Infinity,
+        neginf: -Infinity,
+        negzero: -0,
+        undef: undefined,
+        dollar: '$looks like a ref',
+        emptyString: '',
+      };
+    }
+    const a = await (await renderThroughWire(makeModel())).response;
+    const b = await (await renderInProcess(makeModel())).response;
+    expect(b.date).toEqual(a.date);
+    expect(b.date instanceof Date).toBe(true);
+    expect(Array.from(b.map)).toEqual(Array.from(a.map));
+    expect(Array.from(b.set)).toEqual(Array.from(a.set));
+    expect(b.bigint).toBe(a.bigint);
+    expect(b.nan).toBeNaN();
+    expect(a.nan).toBeNaN();
+    expect(b.inf).toBe(a.inf);
+    expect(b.neginf).toBe(a.neginf);
+    expect(Object.is(b.negzero, -0)).toBe(Object.is(a.negzero, -0));
+    expect(b.undef).toBe(a.undef);
+    expect('undef' in b).toBe('undef' in a);
+    expect(b.dollar).toBe(a.dollar);
+    expect(b.emptyString).toBe(a.emptyString);
+  });
+
+  it('decodes binary data identically', async () => {
+    function makeModel() {
+      const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+      return {
+        arrayBuffer: buffer,
+        uint8: new Uint8Array([9, 8, 7]),
+        int32: new Int32Array([100000, -100000]),
+        float64: new Float64Array([0.5, -2.25]),
+        dataView: new DataView(new Uint8Array([1, 2, 3, 4]).buffer),
+      };
+    }
+    const a = await (await renderThroughWire(makeModel())).response;
+    const b = await (await renderInProcess(makeModel())).response;
+    expect(new Uint8Array(b.arrayBuffer)).toEqual(
+      new Uint8Array(a.arrayBuffer),
+    );
+    expect(b.uint8).toEqual(a.uint8);
+    expect(b.int32).toEqual(a.int32);
+    expect(b.float64).toEqual(a.float64);
+    expect(b.dataView.getInt8(3)).toBe(a.dataView.getInt8(3));
+    expect(b.dataView.byteLength).toBe(a.dataView.byteLength);
+  });
+
+  it('decodes large strings (text rows) identically', async () => {
+    const big = 'ab'.repeat(2048) + 'end';
+    function makeModel() {
+      return {big, nested: {alsoBig: big + '!'}};
+    }
+    const a = await (await renderThroughWire(makeModel())).response;
+    const b = await (await renderInProcess(makeModel())).response;
+    expect(b.big).toBe(a.big);
+    expect(b.nested.alsoBig).toBe(a.nested.alsoBig);
+  });
+
+  it('streams ReadableStream values identically', async () => {
+    function makeModel() {
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue('first');
+            controller.enqueue({second: 2});
+            controller.close();
+          },
+        }),
+      };
+    }
+    async function readAll(boxed) {
+      const reader = (await boxed.response).stream.getReader();
+      const out = [];
+      while (true) {
+        const {done, value} = await reader.read();
+        if (done) {
+          break;
+        }
+        out.push(value);
+      }
+      return out;
+    }
+    const a = await serverAct(async () =>
+      readAll(await renderThroughWire(makeModel())),
+    );
+    const b = await serverAct(async () =>
+      readAll(await renderInProcess(makeModel())),
+    );
+    expect(b).toEqual(a);
+  });
+
+  it('streams async iterables identically, including the return value', async () => {
+    function makeModel() {
+      return {
+        iterable: (async function* () {
+          yield 'one';
+          yield 'two';
+          return 'done value';
+        })(),
+      };
+    }
+    async function readAll(boxed) {
+      const iterator = (await boxed.response).iterable[Symbol.asyncIterator]();
+      const out = [];
+      while (true) {
+        const {done, value} = await iterator.next();
+        out.push({done, value});
+        if (done) {
+          break;
+        }
+      }
+      return out;
+    }
+    const a = await serverAct(async () =>
+      readAll(await renderThroughWire(makeModel())),
+    );
+    const b = await serverAct(async () =>
+      readAll(await renderInProcess(makeModel())),
+    );
+    expect(b).toEqual(a);
+  });
+
+  it('handles suspended subtrees that resolve later identically', async () => {
+    async function run(renderPath) {
+      let resolveData;
+      const dataPromise = new Promise(resolve => (resolveData = resolve));
+      async function Slow() {
+        const text = await dataPromise;
+        return ReactServer.createElement('b', null, text);
+      }
+      function App() {
+        return ReactServer.createElement(
+          'div',
+          null,
+          ReactServer.createElement('span', null, 'ready'),
+          ReactServer.createElement(Slow),
+        );
+      }
+      const {response} = await renderPath(ReactServer.createElement(App));
+      const htmlPromise = renderToHTML(response);
+      await serverAct(() => resolveData('slow data'));
+      return htmlPromise;
+    }
+    const wireHTML = await run(model => renderThroughWire(model));
+    const renderHTML = await run(model => renderInProcess(model));
+    expect(renderHTML).toBe(wireHTML);
+    expect(renderHTML).toContain('slow data');
+  });
+
+  it('propagates errors with digests identically', async () => {
+    function makeOptions(errors) {
+      return {
+        onError(x) {
+          errors.push(x.message);
+          return 'digest("' + x.message + '")';
+        },
+      };
+    }
+    function makeModel() {
+      function Bad() {
+        throw new Error('kaboom');
+      }
+      function App() {
+        return ReactServer.createElement(
+          'div',
+          null,
+          ReactServer.createElement(Bad),
+        );
+      }
+      return ReactServer.createElement(App);
+    }
+    async function getError(response) {
+      try {
+        await renderToHTML(response);
+      } catch (x) {
+        return x;
+      }
+      throw new Error('expected the render to fail');
+    }
+    const wireErrors = [];
+    const wireError = await getError(
+      (await renderThroughWire(makeModel(), makeOptions(wireErrors))).response,
+    );
+    if (__DEV__) {
+      assertConsoleErrorDev(['[Server] Error: kaboom\n    in <stack>']);
+    }
+    const renderErrors = [];
+    const renderError = await getError(
+      (await renderInProcess(makeModel(), makeOptions(renderErrors))).response,
+    );
+    if (__DEV__) {
+      assertConsoleErrorDev(['[Server] Error: kaboom\n    in <stack>']);
+    }
+    expect(renderErrors).toEqual(wireErrors);
+    expect(renderError.digest).toBe(wireError.digest);
+    expect(renderError.message).toBe(wireError.message);
+  });
+
+  it('errors every pending task identically when the render is aborted', async () => {
+    const never = new Promise(() => {});
+    function makeModel() {
+      async function Hanging() {
+        await never;
+        return null;
+      }
+      return ReactServer.createElement(
+        'div',
+        null,
+        ReactServer.createElement('span', null, 'sync part'),
+        ReactServer.createElement(Hanging),
+      );
+    }
+    // Wire path.
+    const wireErrors = [];
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(makeModel(), webpackMap, {
+        onError(x) {
+          wireErrors.push(x.message);
+          return 'aborted-digest';
+        },
+      }),
+    );
+    const readable = new Stream.PassThrough();
+    const wireResponse = ReactServerDOMClient.createFromNodeStream(
+      readable,
+      ssrManifest,
+    );
+    stream.pipe(readable);
+    await serverAct(() => stream.abort(new Error('goodbye')));
+    let wireError = null;
+    try {
+      await renderToHTML(wireResponse);
+    } catch (x) {
+      wireError = x;
+    }
+    if (__DEV__) {
+      assertConsoleErrorDev(['[Server] Error: goodbye\n    in <stack>']);
+    }
+
+    // In-process path, aborted through the AbortSignal option.
+    const renderErrors = [];
+    const controller = new AbortController();
+    let renderResponse;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(makeModel(), webpackMap, {
+        signal: controller.signal,
+        onError(x) {
+          renderErrors.push(x.message);
+          return 'aborted-digest';
+        },
+      });
+      renderResponse = ReactServerDOMClient.createFromRender(
+        result,
+        ssrManifest,
+      );
+    });
+    await serverAct(() => controller.abort(new Error('goodbye')));
+    let renderError = null;
+    try {
+      await renderToHTML(renderResponse);
+    } catch (x) {
+      renderError = x;
+    }
+    if (__DEV__) {
+      assertConsoleErrorDev(['[Server] Error: goodbye\n    in <stack>']);
+    }
+    expect(renderErrors).toEqual(wireErrors);
+    expect(renderError).not.toBe(null);
+    expect(renderError.digest).toBe(wireError.digest);
+  });
+
+  it('dedupes shared objects identically', async () => {
+    function makeModel() {
+      const shared = {shared: 'value', list: [1, 2, 3]};
+      return {a: shared, b: shared, c: {deep: shared}};
+    }
+    const a = await (await renderThroughWire(makeModel())).response;
+    const b = await (await renderInProcess(makeModel())).response;
+    expect(a.a).toBe(a.b);
+    expect(b.a).toBe(b.b);
+    expect(b.c.deep).toBe(b.a);
+    expect(b.a).toEqual(a.a);
+  });
+
+  it('dispatches hints identically', async () => {
+    function makeModel() {
+      async function App() {
+        FlightReactDOM.prefetchDNS('example.com');
+        FlightReactDOM.preload('style.css', {as: 'style'});
+        await 1;
+        FlightReactDOM.preconnect('later.example.com');
+        return ReactServer.createElement('div', null, 'with hints');
+      }
+      return ReactServer.createElement(App);
+    }
+    function captureHints() {
+      // Capture what the Flight client dispatches through the react-dom
+      // dispatcher on the consuming side. Read the dispatcher from the same
+      // module the client does: in source runs that is the shared internals
+      // module (the www entry points re-export a different object); built
+      // bundles read the public react-dom export.
+      let ReactDOMSharedInternals;
+      try {
+        ReactDOMSharedInternals =
+          require('shared/ReactDOMSharedInternals').default;
+      } catch (x) {
+        ReactDOMSharedInternals =
+          require('react-dom').__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+      }
+      const previousDispatcher = ReactDOMSharedInternals.d;
+      const hints = [];
+      ReactDOMSharedInternals.d = {
+        f: previousDispatcher.f,
+        r: previousDispatcher.r,
+        D: href => hints.push(['D', href]),
+        C: (href, crossOrigin) => hints.push(['C', href, crossOrigin]),
+        L: (href, as, options) => hints.push(['L', href, as, options]),
+        m: (href, options) => hints.push(['m', href, options]),
+        X: (src, options) => hints.push(['X', src, options]),
+        S: (href, precedence, options) =>
+          hints.push(['S', href, precedence, options]),
+        M: (src, options) => hints.push(['M', src, options]),
+      };
+      return {
+        hints,
+        restore() {
+          ReactDOMSharedInternals.d = previousDispatcher;
+        },
+      };
+    }
+    const wireCapture = captureHints();
+    let wireHTML;
+    try {
+      const {response: wireResponse} = await renderThroughWire(makeModel());
+      wireHTML = await renderToHTML(wireResponse);
+    } finally {
+      wireCapture.restore();
+    }
+    const renderCapture = captureHints();
+    let renderHTML;
+    try {
+      const {response: renderResponse} = await renderInProcess(makeModel());
+      renderHTML = await renderToHTML(renderResponse);
+    } finally {
+      renderCapture.restore();
+    }
+    expect(wireCapture.hints.length).toBeGreaterThan(0);
+    expect(renderCapture.hints).toEqual(wireCapture.hints);
+    expect(renderHTML).toBe(wireHTML);
+  });
+
+  // @gate __DEV__
+  it('forwards debug info identically', async () => {
+    function makeModel() {
+      function Greeting({name}) {
+        return ReactServer.createElement('span', null, 'hi ', name);
+      }
+      function App() {
+        return ReactServer.createElement(Greeting, {name: 'Seb'});
+      }
+      return ReactServer.createElement(App);
+    }
+    function getDebugNames(root) {
+      const names = [];
+      const debugInfo = root._debugInfo;
+      if (debugInfo) {
+        for (let i = 0; i < debugInfo.length; i++) {
+          if (debugInfo[i].name) {
+            names.push(debugInfo[i].name);
+          }
+        }
+      }
+      return names;
+    }
+    const wireRoot = await (await renderThroughWire(makeModel())).response;
+    const renderRoot = await (await renderInProcess(makeModel())).response;
+    const wireNames = getDebugNames(wireRoot);
+    const renderNames = getDebugNames(renderRoot);
+    expect(renderNames).toEqual(wireNames);
+    expect(renderNames).toContain('App');
+  });
+
+  it('hands the consumer its own copy of the model', async () => {
+    // The in-process consumer receives the tree the resolve walk built for
+    // stringification, never the caller's objects: frozen input is fine,
+    // and mutating what the consumer got can't reach back into the server
+    // model (or anything the server model aliases, like a cache entry).
+    const data = Object.freeze({
+      items: Object.freeze([1, 2, 3]),
+      config: {nested: {deep: true}},
+    });
+    function makeModel() {
+      return {data, label: 'copied'};
+    }
+    const a = await (await renderThroughWire(makeModel())).response;
+    const b = await (await renderInProcess(makeModel())).response;
+    expect(a.data).toEqual(data);
+    expect(b.data).toEqual(data);
+    expect(a.data).not.toBe(data);
+    expect(b.data).not.toBe(data);
+    expect(b.data.items).not.toBe(data.items);
+    expect(Object.isFrozen(b.data)).toBe(false);
+    b.data.config.nested.deep = false;
+    expect(data.config.nested.deep).toBe(true);
+    expect(b.label).toBe('copied');
+  });
+
+  it('serves the object consumer and the byte stream from one render', async () => {
+    // The framework case: a single render() feeds SSR through
+    // createFromRender while its byte stream is piped out for hydration.
+    // All three views must agree.
+    function makeModel() {
+      function App() {
+        return ReactServer.createElement(
+          'main',
+          null,
+          ReactServer.createElement('h1', null, 'dual'),
+          ReactServer.createElement('p', null, 'consumption'),
+        );
+      }
+      return ReactServer.createElement(App);
+    }
+    // Reference HTML through the classic wire path.
+    const {response: wireResponse} = await renderThroughWire(makeModel());
+    const wireHTML = await renderToHTML(wireResponse);
+
+    // One render, two doors.
+    let renderResponse;
+    let pipedResponse;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(makeModel(), webpackMap);
+      renderResponse = ReactServerDOMClient.createFromRender(
+        result,
+        ssrManifest,
+      );
+      const readable = new Stream.PassThrough();
+      pipedResponse = ReactServerDOMClient.createFromNodeStream(
+        readable,
+        ssrManifest,
+      );
+      result.pipe(readable);
+    });
+    const renderHTML = await renderToHTML(renderResponse);
+    const pipedHTML = await renderToHTML(pipedResponse);
+    expect(renderHTML).toBe(wireHTML);
+    expect(pipedHTML).toBe(wireHTML);
+  });
+
+  it('supports piping from inside the consumer', async () => {
+    // A consumer that reacts to its first row by starting the byte stream
+    // runs inside the server's emit; this must not corrupt either output.
+    function makeModel() {
+      function App() {
+        return ReactServer.createElement('div', null, 'reentrant pipe');
+      }
+      return ReactServer.createElement(App);
+    }
+    const {response: wireResponse} = await renderThroughWire(makeModel());
+    const wireHTML = await renderToHTML(wireResponse);
+
+    let renderResponse;
+    let pipedResponse;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(makeModel(), webpackMap);
+      const readable = new Stream.PassThrough();
+      pipedResponse = ReactServerDOMClient.createFromNodeStream(
+        readable,
+        ssrManifest,
+      );
+      let piped = false;
+      const inner = ReactServerDOMClient.createFromRender(
+        {
+          _attach(consumer) {
+            result._attach({
+              row(id, tag, payload) {
+                if (!piped) {
+                  piped = true;
+                  result.pipe(readable);
+                }
+                consumer.row(id, tag, payload);
+              },
+              close: consumer.close,
+              error: consumer.error,
+            });
+          },
+        },
+        ssrManifest,
+      );
+      renderResponse = inner;
+    });
+    const renderHTML = await renderToHTML(renderResponse);
+    const pipedHTML = await renderToHTML(pipedResponse);
+    expect(renderHTML).toBe(wireHTML);
+    expect(pipedHTML).toBe(wireHTML);
+  });
+
+  it('aborts through the result', async () => {
+    const never = new Promise(() => {});
+    async function Hanging() {
+      await never;
+      return null;
+    }
+    const errors = [];
+    let response;
+    let result;
+    await serverAct(() => {
+      result = ReactServerDOMServer.render(
+        ReactServer.createElement(
+          'div',
+          null,
+          ReactServer.createElement(Hanging),
+        ),
+        webpackMap,
+        {
+          onError(x) {
+            errors.push(x.message);
+            return 'digest';
+          },
+        },
+      );
+      response = ReactServerDOMClient.createFromRender(result, ssrManifest);
+    });
+    await serverAct(() => result.abort(new Error('goodbye')));
+    let error = null;
+    try {
+      await renderToHTML(response);
+    } catch (x) {
+      error = x;
+    }
+    if (__DEV__) {
+      assertConsoleErrorDev(['[Server] Error: goodbye\n    in <stack>']);
+    }
+    expect(error).not.toBe(null);
+    expect(error.digest).toBe('digest');
+    expect(errors).toEqual(['goodbye']);
+  });
+
+  it('routes debug rows to a debug channel identically', async () => {
+    // When a debug channel is configured, debug rows leave on its byte
+    // stream in both modes, and neither the SSR byte stream nor the
+    // in-process consumer sees them.
+    function makeModel() {
+      function Greeting({name}) {
+        return ReactServer.createElement('span', null, 'hi ', name);
+      }
+      function App() {
+        return ReactServer.createElement(Greeting, {name: 'Seb'});
+      }
+      return ReactServer.createElement(App);
+    }
+    function makeDebugChannel() {
+      const readable = new Stream.PassThrough();
+      const forBytes = new Stream.PassThrough();
+      const forClient = new Stream.PassThrough();
+      readable.pipe(forBytes);
+      readable.pipe(forClient);
+      const writable = new Stream.Writable({
+        write(chunk, encoding, callback) {
+          readable.write(chunk, encoding);
+          callback();
+        },
+        final() {
+          readable.end();
+        },
+      });
+      return {writable, forClient, bytes: readResult(forBytes)};
+    }
+
+    // Wire path with a debug channel: the SSR client reads the debug rows
+    // from the channel alongside the main stream, or its debug references
+    // would dangle.
+    const wireDebug = makeDebugChannel();
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(makeModel(), webpackMap, {
+        debugChannel: wireDebug.writable,
+      }),
+    );
+    const readable = new Stream.PassThrough();
+    const wireResponse = ReactServerDOMClient.createFromNodeStream(
+      readable,
+      ssrManifest,
+      {debugChannel: wireDebug.forClient},
+    );
+    stream.pipe(readable);
+    const wireHTML = await renderToHTML(wireResponse);
+
+    // In-process path with a debug channel: the consumer receives every
+    // debug row inline, so nothing extra needs to be read back.
+    const renderDebug = makeDebugChannel();
+    renderDebug.forClient.resume(); // Unused; drain.
+    let renderResponse;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(makeModel(), webpackMap, {
+        debugChannel: renderDebug.writable,
+      });
+      renderResponse = ReactServerDOMClient.createFromRender(
+        result,
+        ssrManifest,
+      );
+      // Drain the byte stream so the debug channel closes.
+      result.pipe(new Stream.PassThrough());
+    });
+    const renderHTML = await renderToHTML(renderResponse);
+
+    expect(renderHTML).toBe(wireHTML);
+    // The rows are identical up to timestamps and the line numbers of the
+    // two call sites in this test file.
+    const normalize = payload =>
+      payload
+        .replace(/:N[\d.]+/g, ':N<time>')
+        .replace(/"time":[\d.]+/g, '"time":<time>')
+        .replace(/,\d+,\d+,\d+,\d+,(false|true)\]/g, ',<pos>,$1]');
+    if (__DEV__) {
+      const wireDebugRows = await wireDebug.bytes;
+      const renderDebugRows = await renderDebug.bytes;
+      expect(wireDebugRows.length).toBeGreaterThan(0);
+      expect(normalize(renderDebugRows)).toBe(normalize(wireDebugRows));
+    } else {
+      // The debugChannel option is DEV-only: in production nothing is ever
+      // written to it, on either path.
+      wireDebug.writable.end();
+      renderDebug.writable.end();
+      expect(await wireDebug.bytes).toBe('');
+      expect(await renderDebug.bytes).toBe('');
+    }
+  });
+
+  it('preinitializes client module chunks in the consuming render', async () => {
+    // The dispatch that preloads a client component's chunks has to land in
+    // the Fizz request that consumes the response, or the emitted script
+    // tags lose their attributes (or are dropped). The reference shape is
+    // the byte stream consumed lazily inside Fizz, which is how frameworks
+    // wire it.
+    function ClientComponent() {
+      return React.createElement('span', null, 'Client Component');
+    }
+    const ClientComponentOnTheClient = clientExports(
+      ClientComponent,
+      123,
+      'path/to/chunk.js',
+    );
+    const ClientComponentOnTheServer = clientExports(ClientComponent);
+    // In the SSR bundle this module won't exist; provide a translation from
+    // the client metadata to the SSR metadata.
+    const clientId = webpackMap[ClientComponentOnTheClient.$$id].id;
+    delete webpackModules[clientId];
+    const ssrMetadata = webpackMap[ClientComponentOnTheServer.$$id];
+    const serverConsumerManifest = {
+      moduleMap: {[clientId]: {'*': ssrMetadata}},
+      moduleLoading: webpackModuleLoading,
+    };
+    function makeModel() {
+      function App() {
+        return ReactServer.createElement(ClientComponentOnTheClient);
+      }
+      return ReactServer.createElement(App);
+    }
+
+    // Wire path, consumed lazily inside the Fizz render.
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(makeModel(), webpackMap),
+    );
+    const readable = new Stream.PassThrough();
+    stream.pipe(readable);
+    let lazyWireResponse;
+    function LazyWireRoot() {
+      if (!lazyWireResponse) {
+        lazyWireResponse = ReactServerDOMClient.createFromNodeStream(
+          readable,
+          serverConsumerManifest,
+        );
+      }
+      return use(lazyWireResponse);
+    }
+    const wireHTMLStream = await serverAct(() =>
+      ReactDOMServer.renderToPipeableStream(React.createElement(LazyWireRoot)),
+    );
+    const wireHTML = await readResult(wireHTMLStream);
+
+    // In-process path.
+    let renderResponse;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(makeModel(), webpackMap);
+      renderResponse = ReactServerDOMClient.createFromRender(
+        result,
+        serverConsumerManifest,
+      );
+    });
+    const renderHTML = await renderToHTML(renderResponse);
+
+    expect(wireHTML).toContain(
+      '<script src="/path/to/chunk.js" async=""></script>',
+    );
+    expect(renderHTML).toBe(wireHTML);
+  });
+
+  it('keeps module preinit attributes when DEV debug rows arrive first', async () => {
+    // Regression test: DEV-only debug machinery (console replay, IO info)
+    // initializes chunks eagerly while rows are still being delivered inside
+    // the producer's scope. That must not flush the deferred dispatches, or
+    // module preinits lose the manifest's crossOrigin (and nonce).
+    function ClientComponent() {
+      return React.createElement('span', null, 'Client Component');
+    }
+    const ClientComponentOnTheClient = clientExports(
+      ClientComponent,
+      821,
+      'path/to/dev-chunk.js',
+    );
+    const ClientComponentOnTheServer = clientExports(ClientComponent);
+    const clientId = webpackMap[ClientComponentOnTheClient.$$id].id;
+    delete webpackModules[clientId];
+    const ssrMetadata = webpackMap[ClientComponentOnTheServer.$$id];
+    const serverConsumerManifest = {
+      moduleMap: {[clientId]: {'*': ssrMetadata}},
+      moduleLoading: {prefix: '/', crossOrigin: 'use-credentials'},
+    };
+    function makeModel() {
+      // The await produces DEV-only IO debug rows ahead of the model rows.
+      async function App() {
+        await new Promise(resolve => setTimeout(resolve, 1));
+        return ReactServer.createElement(ClientComponentOnTheClient);
+      }
+      return ReactServer.createElement(App);
+    }
+
+    // Wire path, consumed lazily inside the Fizz render.
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(makeModel(), webpackMap),
+    );
+    const readable = new Stream.PassThrough();
+    stream.pipe(readable);
+    let lazyWireResponse;
+    function LazyWireRoot() {
+      if (!lazyWireResponse) {
+        lazyWireResponse = ReactServerDOMClient.createFromNodeStream(
+          readable,
+          serverConsumerManifest,
+        );
+      }
+      return use(lazyWireResponse);
+    }
+    const wireHTMLStream = await serverAct(() =>
+      ReactDOMServer.renderToPipeableStream(React.createElement(LazyWireRoot)),
+    );
+    const wireHTML = await readResult(wireHTMLStream);
+
+    // In-process path: the replayed console row is processed while the
+    // server is still delivering rows.
+    let renderResponse;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(makeModel(), webpackMap);
+      renderResponse = ReactServerDOMClient.createFromRender(
+        result,
+        serverConsumerManifest,
+      );
+    });
+    const renderHTML = await renderToHTML(renderResponse);
+
+    const preinitTag =
+      '<script src="/path/to/dev-chunk.js" async="" crossorigin="use-credentials"></script>';
+    expect(wireHTML).toContain(preinitTag);
+    expect(renderHTML).toContain(preinitTag);
+    expect(renderHTML).toBe(wireHTML);
+  });
+
+  it('still serves the byte stream after the consumer has read everything', async () => {
+    // The wire chunks stay queued until something pipes them, so a late
+    // pipe replays the full render rather than an empty or errored stream.
+    let response;
+    let result;
+    await serverAct(() => {
+      result = ReactServerDOMServer.render({greeting: 'hello'}, webpackMap);
+      response = ReactServerDOMClient.createFromRender(result, ssrManifest);
+    });
+    expect((await response).greeting).toBe('hello');
+    const wireStream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(
+        {greeting: 'hello'},
+        webpackMap,
+      ),
+    );
+    // The DEV time origin row carries a timestamp; compare everything else.
+    const stripTimeOrigin = text => text.replace(/^:N[^\n]*\n/, '');
+    const expected = stripTimeOrigin(await readResult(wireStream));
+    const late = stripTimeOrigin(await readResult(result));
+    expect(late).toBe(expected);
+    expect(late).toContain('{"greeting":"hello"}');
+  });
+
+  it('rejects the response without corrupting the render when the consumer throws', async () => {
+    // A buggy consumer must not corrupt the server render: the response it
+    // was attached to errors, but the byte stream is unaffected.
+    const consumerError = new Error('consumer kaputt');
+    let renderResponse;
+    let stream;
+    await serverAct(() => {
+      const result = ReactServerDOMServer.render(
+        {greeting: 'hello'},
+        webpackMap,
+      );
+      renderResponse = ReactServerDOMClient.createFromRender(
+        result,
+        ssrManifest,
+      );
+      // Sabotage the response's internal chunk map so processing the first
+      // row throws inside the server's emit.
+      // (Simulates any throwing consumer.)
+      stream = null;
+      const badResult = ReactServerDOMServer.render(
+        {greeting: 'hello'},
+        webpackMap,
+      );
+      badResult._attach({
+        row() {
+          throw consumerError;
+        },
+        close() {},
+        error(x) {
+          stream = x;
+        },
+      });
+    });
+    // The well-behaved response resolved fine.
+    expect((await renderResponse).greeting).toBe('hello');
+    // The broken consumer was detached and notified with its own error.
+    expect(stream).toBe(consumerError);
+  });
+
+  it('enforces that consumers attach before the render starts emitting', async () => {
+    let result;
+    await serverAct(() => {
+      result = ReactServerDOMServer.render({model: true}, webpackMap);
+      // Attaching synchronously is fine.
+    });
+    // The render has already emitted by now.
+    expect(() => {
+      ReactServerDOMClient.createFromRender(result, ssrManifest);
+    }).toThrow(
+      'Cannot attach a consumer to a render result that has already ' +
+        'started emitting. Attach the consumer synchronously after render().',
+    );
+  });
+
+  it('enforces a single consumer', async () => {
+    await serverAct(async () => {
+      const result = ReactServerDOMServer.render({model: true}, webpackMap);
+      const response = ReactServerDOMClient.createFromRender(
+        result,
+        ssrManifest,
+      );
+      expect(() => {
+        ReactServerDOMClient.createFromRender(result, ssrManifest);
+      }).toThrow('A render result can only have a single consumer.');
+      expect((await response).model).toBe(true);
+    });
+  });
+});

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -29,9 +29,15 @@ type ServerConsumerManifest = {
 
 import type {Readable} from 'stream';
 
+import {AsyncLocalStorage} from 'async_hooks';
+
+import type {RenderResult} from 'react-client/src/ReactFlightClient';
+
 import {
   createResponse,
   createStreamState,
+  connectRenderResult,
+  provideDispatchScope,
   getRoot,
   reportGlobalError,
   processStringChunk,
@@ -140,4 +146,58 @@ function createFromNodeStream<T>(
   return getRoot(response);
 }
 
-export {createFromNodeStream};
+// Consumes an in-process render() result through the normal Response, so
+// module resolution, dedupe, lazy chunks, hint dispatch and debug info all
+// behave exactly as they do for a byte stream. The consumer has to attach
+// before the render starts emitting, so this must be called synchronously
+// after render().
+function createFromRender<T>(
+  result: RenderResult,
+  serverConsumerManifest: ServerConsumerManifest,
+  options?: Options,
+): Thenable<T> {
+  const response: Response = createResponse(
+    serverConsumerManifest.moduleMap,
+    serverConsumerManifest.serverModuleMap,
+    serverConsumerManifest.moduleLoading,
+    noServerCall,
+    options ? options.encodeFormAction : undefined,
+    options && typeof options.nonce === 'string' ? options.nonce : undefined,
+    undefined, // TODO: If encodeReply is supported, this should support temporaryReferences
+    options && options.unstable_allowPartialStream
+      ? options.unstable_allowPartialStream
+      : false,
+    __DEV__ && options && options.findSourceMapURL
+      ? options.findSourceMapURL
+      : undefined,
+    __DEV__ && options ? options.replayConsoleLogs === true : false, // defaults to false
+    __DEV__ && options && options.environmentName
+      ? options.environmentName
+      : undefined,
+    __DEV__ && options && options.startTime != null
+      ? options.startTime
+      : undefined,
+    __DEV__ && options && options.endTime != null ? options.endTime : undefined,
+    undefined, // debugChannel: debug rows arrive through the result itself
+  );
+  const streamState = createStreamState(response, result);
+  connectRenderResult(response, result, streamState);
+  const root = getRoot<T>(response);
+  let scopeCaptured = false;
+  return {
+    then(resolve: any, reject: any) {
+      if (!scopeCaptured) {
+        scopeCaptured = true;
+        // Module preinits and hints must land in whatever request consumes
+        // this response. A byte stream gets this implicitly: its
+        // subscription callbacks inherit the consumer's async scope. For an
+        // in-process render, capture the scope of the first read — the
+        // consuming renderer's — and route every dispatch through it.
+        provideDispatchScope(response, AsyncLocalStorage.snapshot());
+      }
+      return (root as any).then(resolve, reject);
+    },
+  } as any;
+}
+
+export {createFromNodeStream, createFromRender};

--- a/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/server/ReactFlightDOMServerNode.js
@@ -24,7 +24,13 @@ import {Readable} from 'stream';
 
 import {ASYNC_ITERATOR} from 'shared/ReactSymbols';
 
+import type {
+  RenderResult as FlightRenderResult,
+  RenderConsumer,
+} from 'react-server/src/ReactFlightServer';
+
 import {
+  createRenderResult,
   createRequest,
   createPrerenderRequest,
   startWork,
@@ -167,24 +173,8 @@ function renderToPipeableStream(
   options?: Options,
 ): PipeableStream {
   const debugChannel = __DEV__ && options ? options.debugChannel : undefined;
-  const debugChannelReadable: void | Readable | WebSocket =
-    __DEV__ &&
-    debugChannel !== undefined &&
-    // $FlowFixMe[method-unbinding]
-    (typeof debugChannel.read === 'function' ||
-      typeof debugChannel.readyState === 'number')
-      ? (debugChannel as any)
-      : undefined;
-  const debugChannelWritable: void | Writable =
-    __DEV__ && debugChannel !== undefined
-      ? // $FlowFixMe[method-unbinding]
-        typeof debugChannel.write === 'function'
-        ? (debugChannel as any)
-        : // $FlowFixMe[method-unbinding]
-          typeof debugChannel.send === 'function'
-          ? createFakeWritableFromWebSocket(debugChannel as any)
-          : undefined
-      : undefined;
+  const debugChannelReadable = getDebugChannelReadable(debugChannel);
+  const debugChannelWritable = getDebugChannelWritable(debugChannel);
   const request = createRequest(
     model,
     webpackMap,
@@ -196,7 +186,6 @@ function renderToPipeableStream(
     __DEV__ && options ? options.filterStackFrame : undefined,
     debugChannelReadable !== undefined,
   );
-  let hasStartedFlowing = false;
   startWork(request);
   if (debugChannelWritable !== undefined) {
     startFlowingDebug(request, debugChannelWritable);
@@ -204,6 +193,40 @@ function renderToPipeableStream(
   if (debugChannelReadable !== undefined) {
     startReadingFromDebugChannelReadable(request, debugChannelReadable);
   }
+  return createPipeableStream(request, debugChannelReadable);
+}
+
+function getDebugChannelReadable(
+  debugChannel: void | Readable | Writable | Duplex | WebSocket,
+): void | Readable | WebSocket {
+  return __DEV__ &&
+    debugChannel !== undefined &&
+    // $FlowFixMe[method-unbinding]
+    (typeof (debugChannel as any).read === 'function' ||
+      typeof (debugChannel as any).readyState === 'number')
+    ? (debugChannel as any)
+    : undefined;
+}
+
+function getDebugChannelWritable(
+  debugChannel: void | Readable | Writable | Duplex | WebSocket,
+): void | Writable {
+  return __DEV__ && debugChannel !== undefined
+    ? // $FlowFixMe[method-unbinding]
+      typeof (debugChannel as any).write === 'function'
+      ? (debugChannel as any)
+      : // $FlowFixMe[method-unbinding]
+        typeof (debugChannel as any).send === 'function'
+        ? createFakeWritableFromWebSocket(debugChannel as any)
+        : undefined
+    : undefined;
+}
+
+function createPipeableStream(
+  request: Request,
+  debugChannelReadable: void | Readable | WebSocket,
+): PipeableStream {
+  let hasStartedFlowing = false;
   return {
     pipe<T: Writable>(destination: T): T {
       if (hasStartedFlowing) {
@@ -776,7 +799,82 @@ function decodeReplyFromAsyncIterable<T>(
   return getRoot(response);
 }
 
+export type RenderOptions = {
+  identifierPrefix?: string,
+  signal?: AbortSignal,
+  onError?: (error: mixed) => void,
+  environmentName?: string | (() => string),
+  filterStackFrame?: (url: string, functionName: string) => boolean,
+  temporaryReferences?: TemporaryReferenceSet,
+  startTime?: number,
+  // DEV-only: debug rows leave on this channel instead of reaching either
+  // the byte stream or the in-process consumer.
+  debugChannel?: Readable | Writable | Duplex | WebSocket,
+};
+
+export type RenderResult = {
+  _attach: (consumer: RenderConsumer) => void,
+  pipe<T: Writable>(destination: T): T,
+  abort(reason: mixed): void,
+};
+
+// Renders the model without deciding how it will be consumed: pass the
+// result to a paired Flight Client's createFromRender to read the render
+// back in the same process without going through the wire format, pipe it
+// to get the byte stream, or both from the same render. A consumer has to
+// attach before the render starts emitting, so createFromRender must be
+// called synchronously after render().
+function render(
+  model: ReactClientValue,
+  webpackMap: ClientManifest,
+  options?: RenderOptions,
+): RenderResult {
+  const debugChannel = __DEV__ && options ? options.debugChannel : undefined;
+  const debugChannelReadable = getDebugChannelReadable(debugChannel);
+  const debugChannelWritable = getDebugChannelWritable(debugChannel);
+  const request = createRequest(
+    model,
+    webpackMap,
+    options ? options.onError : undefined,
+    options ? options.identifierPrefix : undefined,
+    options ? options.temporaryReferences : undefined,
+    options ? options.startTime : undefined,
+    __DEV__ && options ? options.environmentName : undefined,
+    __DEV__ && options ? options.filterStackFrame : undefined,
+    debugChannelReadable !== undefined,
+  );
+  const result: FlightRenderResult = createRenderResult(request);
+  const pipeableStream = createPipeableStream(request, debugChannelReadable);
+  if (options && options.signal) {
+    const signal = options.signal;
+    if (signal.aborted) {
+      // Give the caller a chance to attach a consumer before the abort
+      // emits its error rows.
+      Promise.resolve().then(() => abort(request, (signal as any).reason));
+    } else {
+      const listener = () => {
+        abort(request, (signal as any).reason);
+        signal.removeEventListener('abort', listener);
+      };
+      signal.addEventListener('abort', listener);
+    }
+  }
+  startWork(request);
+  if (debugChannelWritable !== undefined) {
+    startFlowingDebug(request, debugChannelWritable);
+  }
+  if (debugChannelReadable !== undefined) {
+    startReadingFromDebugChannelReadable(request, debugChannelReadable);
+  }
+  return {
+    _attach: result._attach,
+    pipe: pipeableStream.pipe,
+    abort: pipeableStream.abort,
+  };
+}
+
 export {
+  render,
   renderToReadableStream,
   renderToPipeableStream,
   prerender,

--- a/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.js
+++ b/packages/react-server-dom-webpack/src/server/react-flight-dom-server.node.js
@@ -8,6 +8,7 @@
  */
 
 export {
+  render,
   renderToReadableStream,
   renderToPipeableStream,
   prerender,

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -587,12 +587,35 @@ const PRERENDER = 21;
 // emitTypedArrayChunk for why, and flushCompletedChunks for how it's read.
 const NEXT_TWO_CHUNKS_ARE_ATOMIC: symbol = Symbol();
 
+import type {
+  RenderConsumer,
+  RenderResult,
+} from 'shared/ReactFlightRenderResult';
+
+export type {RenderConsumer, RenderResult};
+
 export type Request = {
   status: 10 | 11 | 12 | 13 | 14,
   type: 20 | 21,
   flushScheduled: boolean,
   fatalError: mixed,
   destination: null | Destination,
+  consumer: null | RenderConsumer,
+  // Rows delivered since the last flush, as flat [id, tag, payload] triples.
+  // Delivering at flush boundaries batches the consumer's wake-ups the same
+  // way flushing batches the destination's, which matters for tail latency:
+  // every extra wake-up is a task boundary on the request's critical path.
+  pendingDeliveries: Array<mixed>,
+  drainingDeliveries: boolean,
+  // The number of rows delivered to the consumer (or that would have been).
+  // Monotonic; used to enforce that consumers attach before emissions start.
+  emittedRows: number,
+  // How many of the chunks counted by pendingChunks/pendingDebugChunks have
+  // reached the completed queues. When these pairs are equal, every reserved
+  // row has been emitted (and therefore delivered): nothing more is coming.
+  queuedChunks: number,
+  queuedDebugChunks: number,
+  sentTimeOrigin: boolean,
   bundlerConfig: ClientManifest,
   cache: Map<Function, mixed>,
   cacheController: AbortController,
@@ -727,6 +750,13 @@ function RequestInstance(
   this.cacheController = new AbortController();
   this.nextChunkId = 0;
   this.pendingChunks = 0;
+  this.consumer = null;
+  this.pendingDeliveries = [];
+  this.drainingDeliveries = false;
+  this.emittedRows = 0;
+  this.queuedChunks = 0;
+  this.queuedDebugChunks = 0;
+  this.sentTimeOrigin = false;
   this.hints = hints;
   this.abortableTasks = abortSet;
   this.pingedTasks = pingedTasks;
@@ -794,12 +824,10 @@ function RequestInstance(
     } else {
       timeOrigin = this.timeOrigin = performance.now();
     }
-    emitTimeOriginChunk(
-      this,
-      timeOrigin +
-        // $FlowFixMe[prop-missing]
-        performance.timeOrigin,
-    );
+    // The time origin row itself is emitted lazily by the first work (see
+    // ensureTimeOriginIsSent): nothing may emit while the request is being
+    // constructed, since an in-process consumer can only attach after
+    // construction and must observe every row.
     this.abortTime = -0.0;
   } else {
     timeOrigin = 0;
@@ -1229,6 +1257,7 @@ function serializeReadableStream(
   const startStreamRow =
     streamTask.id.toString(16) + ':' + (isByteStream ? 'r' : 'R') + '\n';
   request.completedRegularChunks.push(stringToChunk(startStreamRow));
+  deliverRow(request, streamTask.id, isByteStream ? 'r' : 'R', '', 1, false);
 
   function progress(entry: {done: boolean, value: ReactClientValue, ...}) {
     if (streamTask.status !== PENDING) {
@@ -1239,6 +1268,7 @@ function serializeReadableStream(
       streamTask.status = COMPLETED;
       const endStreamRow = streamTask.id.toString(16) + ':C\n';
       request.completedRegularChunks.push(stringToChunk(endStreamRow));
+      deliverRow(request, streamTask.id, 'C', '', 1, false);
       request.abortableTasks.delete(streamTask);
       request.cacheController.signal.removeEventListener('abort', abortStream);
       enqueueFlush(request);
@@ -1339,6 +1369,7 @@ function serializeAsyncIterable(
   const startStreamRow =
     streamTask.id.toString(16) + ':' + (isIterator ? 'x' : 'X') + '\n';
   request.completedRegularChunks.push(stringToChunk(startStreamRow));
+  deliverRow(request, streamTask.id, isIterator ? 'x' : 'X', '', 1, false);
 
   function progress(
     entry:
@@ -1351,25 +1382,24 @@ function serializeAsyncIterable(
 
     if (entry.done) {
       streamTask.status = COMPLETED;
-      let endStreamRow;
+      let endStreamPayload;
       if (entry.value === undefined) {
-        endStreamRow = streamTask.id.toString(16) + ':C\n';
+        endStreamPayload = '';
       } else {
         // Unlike streams, the last value may not be undefined. If it's not
         // we outline it and encode a reference to it in the closing instruction.
         try {
           const chunkId = outlineModel(request, entry.value);
-          endStreamRow =
-            streamTask.id.toString(16) +
-            ':C' +
-            stringify(serializeByValueID(chunkId)) +
-            '\n';
+          endStreamPayload = stringify(serializeByValueID(chunkId));
         } catch (x) {
           error(x);
           return;
         }
       }
+      const endStreamRow =
+        streamTask.id.toString(16) + ':C' + endStreamPayload + '\n';
       request.completedRegularChunks.push(stringToChunk(endStreamRow));
+      deliverRow(request, streamTask.id, 'C', endStreamPayload, 1, false);
       request.abortableTasks.delete(streamTask);
       request.cacheController.signal.removeEventListener(
         'abort',
@@ -3004,6 +3034,139 @@ function serializeBigInt(n: bigint): string {
   return '$n' + n.toString(10);
 }
 
+function deliverRow(
+  request: Request,
+  id: number,
+  tag: string,
+  // Call sites whose payload is expensive to prepare (clones, extra
+  // stringification) pass null when no consumer is attached; the payload is
+  // never read in that case, but the chunk accounting below still runs.
+  payload: mixed,
+  // How many chunks flushing this row will subtract from pendingChunks (or
+  // pendingDebugChunks for debug rows). Text and binary rows write an extra
+  // header chunk; hint rows are never reserved at all.
+  chunkCount: number,
+  debug: boolean,
+): void {
+  request.emittedRows++;
+  if (__DEV__ && debug) {
+    request.queuedDebugChunks += chunkCount;
+  } else {
+    request.queuedChunks += chunkCount;
+  }
+  if (request.consumer === null) {
+    return;
+  }
+  // Debug rows are delivered even when a debug channel carries their bytes:
+  // the rows on the main queue reference the outlined debug rows, so a
+  // consumer that skipped them would be left with dangling references. This
+  // matches a byte stream consumer that reads the debug channel alongside
+  // the main stream.
+  request.pendingDeliveries.push(id, tag, payload);
+}
+
+function drainDeliveries(request: Request): void {
+  if (request.drainingDeliveries) {
+    // The consumer called back into the request (e.g. started piping) and
+    // flushed reentrantly. The outer drain finishes the deliveries.
+    return;
+  }
+  const deliveries = request.pendingDeliveries;
+  request.drainingDeliveries = true;
+  try {
+    // The length is re-read on purpose: rows delivered while the consumer
+    // runs are appended and drained in the same pass.
+    for (let i = 0; i < deliveries.length; i += 3) {
+      const consumer = request.consumer;
+      if (consumer === null) {
+        // Detached (by an earlier throw) while draining.
+        break;
+      }
+      try {
+        consumer.row(
+          deliveries[i] as any,
+          deliveries[i + 1] as any,
+          deliveries[i + 2],
+        );
+      } catch (x) {
+        // The consumer threw. Detach it so it can't corrupt this render; the
+        // byte stream is unaffected. This mirrors how a byte stream
+        // consumer's errors don't propagate into the server.
+        request.consumer = null;
+        try {
+          consumer.error(x);
+        } catch (_) {
+          // If even the error handler throws there's nothing further we can
+          // do to notify this consumer.
+        }
+      }
+    }
+    deliveries.length = 0;
+  } finally {
+    request.drainingDeliveries = false;
+  }
+}
+
+function closeConsumerIfDone(request: Request): void {
+  const consumer = request.consumer;
+  if (
+    consumer !== null &&
+    !request.drainingDeliveries &&
+    request.pendingDeliveries.length === 0 &&
+    request.abortableTasks.size === 0 &&
+    // Every chunk that has ever been reserved has reached the completed
+    // queues, which means every row has also been delivered: nothing more
+    // will be emitted.
+    request.pendingChunks === request.queuedChunks &&
+    (!__DEV__ || request.pendingDebugChunks === request.queuedDebugChunks)
+  ) {
+    request.consumer = null;
+    try {
+      consumer.close();
+    } catch (x) {
+      // The consumer is already detached; there's no one to notify.
+    }
+  }
+}
+
+function cloneBinaryValue(value: $ArrayBufferView): $ArrayBufferView {
+  // The consumer may read this view lazily after the wire copy of these
+  // bytes has been written, and the destination is allowed to transfer or
+  // detach what we hand it, so the consumer gets its own copy.
+  if (typeof (value as any).slice === 'function') {
+    return (value as any).slice();
+  }
+  // DataView has no slice; copy the underlying range instead.
+  return new DataView(
+    value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength),
+  );
+}
+
+export function createRenderResult(request: Request): RenderResult {
+  return {
+    _attach(consumer: RenderConsumer): void {
+      if (request.consumer !== null) {
+        throw new Error('A render result can only have a single consumer.');
+      }
+      if (request.emittedRows > 0) {
+        // Nothing emits until the first scheduled work runs, so attaching
+        // synchronously after render() always precedes the first row.
+        throw new Error(
+          'Cannot attach a consumer to a render result that has already ' +
+            'started emitting. Attach the consumer synchronously after ' +
+            'render().',
+        );
+      }
+      if (request.status === CLOSING || request.status === CLOSED) {
+        // The request already failed fatally before the consumer attached.
+        consumer.error(request.fatalError);
+        return;
+      }
+      request.consumer = consumer;
+    },
+  };
+}
+
 function serializeRowHeader(tag: string, id: number) {
   return id.toString(16) + ':' + tag;
 }
@@ -4248,6 +4411,15 @@ function logRecoverableError(
 function fatalError(request: Request, error: mixed): void {
   const onFatalError = request.onFatalError;
   onFatalError(error);
+  const consumer = request.consumer;
+  if (consumer !== null) {
+    request.consumer = null;
+    try {
+      consumer.error(error);
+    } catch (x) {
+      // The consumer is already detached; there's no one to notify.
+    }
+  }
   if (enableTaint) {
     cleanupTaintQueue(request);
   }
@@ -4437,13 +4609,15 @@ function emitErrorChunk(
   } else {
     errorInfo = {digest};
   }
-  const row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
+  const json: string = stringify(errorInfo);
+  const row = serializeRowHeader('E', id) + json + '\n';
   const processedChunk = stringToChunk(row);
   if (__DEV__ && debug) {
     request.completedDebugChunks.push(processedChunk);
   } else {
     request.completedErrorChunks.push(processedChunk);
   }
+  deliverRow(request, id, 'E', json, 1, debug);
 }
 
 function emitImportChunk(
@@ -4461,6 +4635,7 @@ function emitImportChunk(
   } else {
     request.completedImportChunks.push(processedChunk);
   }
+  deliverRow(request, id, 'I', json, 1, debug);
 }
 
 function emitHintChunk<Code: HintCode>(
@@ -4472,18 +4647,51 @@ function emitHintChunk<Code: HintCode>(
   const row = ':H' + code + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedHintChunks.push(processedChunk);
+  deliverRow(
+    request,
+    0,
+    'H',
+    request.consumer === null ? null : code + json,
+    0,
+    false,
+  );
 }
 
 function emitSymbolChunk(request: Request, id: number, name: string): void {
   const symbolReference = serializeSymbolReference(name);
   const processedChunk = encodeReferenceChunk(request, id, symbolReference);
   request.completedImportChunks.push(processedChunk);
+  deliverRow(
+    request,
+    id,
+    '',
+    request.consumer === null ? null : stringify(symbolReference),
+    1,
+    false,
+  );
 }
 
-function emitModelChunk(request: Request, id: number, json: string): void {
+function emitModelChunk(
+  request: Request,
+  id: number,
+  json: string,
+  model: ReactJSONValue,
+): void {
   const row = id.toString(16) + ':' + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedRegularChunks.push(processedChunk);
+  // Deliver the object form so an in-process consumer doesn't parse and
+  // re-allocate what we already have. Primitive models are delivered as
+  // their JSON text: a string payload of a model row always unambiguously
+  // means JSON text, never a model that happens to be a string.
+  deliverRow(
+    request,
+    id,
+    '',
+    typeof model === 'object' && model !== null ? model : json,
+    1,
+    false,
+  );
 }
 
 function emitDebugHaltChunk(request: Request, id: number): void {
@@ -4499,6 +4707,7 @@ function emitDebugHaltChunk(request: Request, id: number): void {
   const row = id.toString(16) + ':\n';
   const processedChunk = stringToChunk(row);
   request.completedDebugChunks.push(processedChunk);
+  deliverRow(request, id, '', '', 1, true);
 }
 
 function emitDebugChunk(
@@ -4521,19 +4730,23 @@ function emitDebugChunk(
       // without an unnecessary indirection.
       const row = serializeRowHeader('D', id) + json + '\n';
       request.completedRegularChunks.push(stringToChunk(row));
+      deliverRow(request, id, 'D', json, 1, false);
     } else {
       // Outline the debug information to the debug channel.
       const outlinedId = request.nextChunkId++;
       const debugRow = outlinedId.toString(16) + ':' + json + '\n';
       request.pendingDebugChunks++;
       request.completedDebugChunks.push(stringToChunk(debugRow));
-      const row =
-        serializeRowHeader('D', id) + '"$' + outlinedId.toString(16) + '"\n';
+      deliverRow(request, outlinedId, '', json, 1, true);
+      const refJSON = '"$' + outlinedId.toString(16) + '"';
+      const row = serializeRowHeader('D', id) + refJSON + '\n';
       request.completedRegularChunks.push(stringToChunk(row));
+      deliverRow(request, id, 'D', refJSON, 1, false);
     }
   } else {
     const row = serializeRowHeader('D', id) + json + '\n';
     request.completedRegularChunks.push(stringToChunk(row));
+    deliverRow(request, id, 'D', json, 1, false);
   }
 }
 
@@ -4661,6 +4874,7 @@ function emitIOInfoChunk(
   const row = id.toString(16) + ':J' + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedDebugChunks.push(processedChunk);
+  deliverRow(request, id, 'J', json, 1, true);
 }
 
 function outlineIOInfo(request: Request, ioInfo: ReactIOInfo): void {
@@ -4837,6 +5051,15 @@ function emitTypedArrayChunk(
       binaryChunk,
     );
   }
+  deliverRow(
+    request,
+    id,
+    tag,
+    // Cloning is only for the consumer; don't pay for it otherwise.
+    request.consumer === null ? null : cloneBinaryValue(typedArray),
+    2,
+    debug,
+  );
 }
 
 function emitTextChunk(
@@ -4875,6 +5098,7 @@ function emitTextChunk(
       textChunk,
     );
   }
+  deliverRow(request, id, 'T', text, 2, debug);
 }
 
 function serializeEval(source: string): string {
@@ -5350,6 +5574,14 @@ function renderDebugModel(
     const id = request.nextChunkId++;
     const processedChunk = encodeReferenceChunk(request, id, serializedValue);
     request.completedDebugChunks.push(processedChunk);
+    deliverRow(
+      request,
+      id,
+      '',
+      request.consumer === null ? null : stringify(serializedValue),
+      1,
+      true,
+    );
     const reference = serializeByValueID(id);
     writtenDebugObjects.set(value, reference);
     return reference;
@@ -5491,6 +5723,7 @@ function emitOutlinedDebugModelChunk(
   const row = id.toString(16) + ':' + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedDebugChunks.push(processedChunk);
+  deliverRow(request, id, '', json, 1, true);
 }
 
 function outlineDebugModel(
@@ -5555,6 +5788,7 @@ function emitConsoleChunk(
   const row = ':W' + json + '\n';
   const processedChunk = stringToChunk(row);
   request.completedDebugChunks.push(processedChunk);
+  deliverRow(request, 0, 'W', json, 1, true);
 }
 
 function emitTimeOriginChunk(request: Request, timeOrigin: number): void {
@@ -5566,6 +5800,28 @@ function emitTimeOriginChunk(request: Request, timeOrigin: number): void {
   const processedChunk = stringToChunk(row);
   // TODO: Move to its own priority queue.
   request.completedDebugChunks.push(processedChunk);
+  deliverRow(request, 0, 'N', timeOrigin.toString(), 1, true);
+}
+
+// Emits the time origin row exactly once, before the first row that could
+// carry a timestamp relative to it. This runs at the start of work rather
+// than during request construction so that no row predates an in-process
+// consumer, which can only attach after construction.
+function ensureTimeOriginIsSent(request: Request): void {
+  if (
+    enableProfilerTimer &&
+    (enableComponentPerformanceTrack || enableAsyncDebugInfo)
+  ) {
+    if (!request.sentTimeOrigin) {
+      request.sentTimeOrigin = true;
+      emitTimeOriginChunk(
+        request,
+        request.timeOrigin +
+          // $FlowFixMe[prop-missing]
+          performance.timeOrigin,
+      );
+    }
+  }
 }
 
 function forwardDebugInfo(
@@ -5770,12 +6026,15 @@ function emitTimingChunk(
     const debugRow = outlinedId.toString(16) + ':' + json + '\n';
     request.pendingDebugChunks++;
     request.completedDebugChunks.push(stringToChunk(debugRow));
-    const row =
-      serializeRowHeader('D', id) + '"$' + outlinedId.toString(16) + '"\n';
+    deliverRow(request, outlinedId, '', json, 1, true);
+    const refJSON = '"$' + outlinedId.toString(16) + '"';
+    const row = serializeRowHeader('D', id) + refJSON + '\n';
     request.completedRegularChunks.push(stringToChunk(row));
+    deliverRow(request, id, 'D', refJSON, 1, false);
   } else {
     const row = serializeRowHeader('D', id) + json + '\n';
     request.completedRegularChunks.push(stringToChunk(row));
+    deliverRow(request, id, 'D', json, 1, false);
   }
 }
 
@@ -5912,7 +6171,7 @@ function emitChunk(
   const resolvedModel = resolveModel(request, task, {'': value}, '', value);
   // $FlowFixMe[incompatible-type] stringify can return null for undefined but we never do
   const json: string = stringify(resolvedModel);
-  emitModelChunk(request, task.id, json);
+  emitModelChunk(request, task.id, json, resolvedModel);
 }
 
 function erroredTask(request: Request, task: Task, error: mixed): void {
@@ -6020,7 +6279,7 @@ function retryTask(request: Request, task: Task): void {
       // We don't need to escape it again so it's not passed through resolveModel.
       // $FlowFixMe[incompatible-type] stringify can return null for undefined but we never do
       const json: string = stringify(resolvedModel);
-      emitModelChunk(request, task.id, json);
+      emitModelChunk(request, task.id, json, resolvedModel);
     }
 
     task.status = COMPLETED;
@@ -6096,6 +6355,7 @@ function tryStreamTask(request: Request, task: Task): void {
 
 function performWork(request: Request): void {
   markAsyncSequenceRootTask();
+  ensureTimeOriginIsSent(request);
 
   const prevDispatcher = ReactSharedInternals.H;
   ReactSharedInternals.H = HooksDispatcher;
@@ -6153,6 +6413,14 @@ function finishAbortedTask(
   const ref = serializeByValueID(errorId);
   const processedChunk = encodeReferenceChunk(request, task.id, ref);
   request.completedErrorChunks.push(processedChunk);
+  deliverRow(
+    request,
+    task.id,
+    '',
+    request.consumer === null ? null : stringify(ref),
+    1,
+    false,
+  );
 }
 
 function haltTask(task: Task, request: Request): void {
@@ -6174,7 +6442,49 @@ function finishHaltedTask(task: Task, request: Request): void {
   request.pendingChunks--;
 }
 
+function countQueuedChunks(queue: Array<mixed>): number {
+  // An atomic pair is three queue items (the marker and two chunks) but two
+  // reserved chunks.
+  let count = 0;
+  for (let i = 0; i < queue.length; i++) {
+    if (queue[i] !== NEXT_TWO_CHUNKS_ARE_ATOMIC) {
+      count++;
+    }
+  }
+  return count;
+}
+
 function flushCompletedChunks(request: Request): void {
+  if (__DEV__) {
+    // queuedChunks mirrors pendingChunks at every emit site so that an
+    // in-process consumer can tell when the render is done. A site that
+    // pushes a reserved chunk without calling deliverRow makes the consumer
+    // hang silently, so check that the counter describes exactly what's in
+    // the completed queues (hint rows are never reserved).
+    const queued =
+      countQueuedChunks(request.completedImportChunks) +
+      countQueuedChunks(request.completedRegularChunks) +
+      countQueuedChunks(request.completedErrorChunks);
+    if (queued !== request.queuedChunks) {
+      console.error(
+        'Flight emitted %s chunk(s) without delivering their rows. This is a bug in React.',
+        queued - request.queuedChunks,
+      );
+    }
+    const queuedDebug = countQueuedChunks(request.completedDebugChunks);
+    if (queuedDebug !== request.queuedDebugChunks) {
+      console.error(
+        'Flight emitted %s debug chunk(s) without delivering their rows. This is a bug in React.',
+        queuedDebug - request.queuedDebugChunks,
+      );
+    }
+  }
+  drainDeliveries(request);
+  // Every path that finishes emitting ends in a flush, so this is where a
+  // consumer learns that nothing more is coming. (Flushing itself can't
+  // change the outcome: it decrements the reserved and queued counters in
+  // lockstep.)
+  closeConsumerIfDone(request);
   if (__DEV__ && request.debugDestination !== null) {
     const debugDestination = request.debugDestination;
     beginWriting(debugDestination);
@@ -6190,6 +6500,7 @@ function flushCompletedChunks(request: Request): void {
             );
           }
           request.pendingDebugChunks -= 2;
+          request.queuedDebugChunks -= 2;
           writeChunk(
             debugDestination,
             debugChunks[i + 1] as any as Chunk | BinaryChunk,
@@ -6201,6 +6512,7 @@ function flushCompletedChunks(request: Request): void {
           i += 2;
         } else {
           request.pendingDebugChunks--;
+          request.queuedDebugChunks--;
           writeChunk(debugDestination, item as any as Chunk | BinaryChunk);
         }
       }
@@ -6220,6 +6532,7 @@ function flushCompletedChunks(request: Request): void {
       let i = 0;
       for (; i < importsChunks.length; i++) {
         request.pendingChunks--;
+        request.queuedChunks--;
         const chunk = importsChunks[i];
         const keepWriting: boolean = writeChunkAndReturn(destination, chunk);
         if (!keepWriting) {
@@ -6259,6 +6572,7 @@ function flushCompletedChunks(request: Request): void {
               );
             }
             request.pendingDebugChunks -= 2;
+            request.queuedDebugChunks -= 2;
             writeChunk(
               destination,
               debugChunks[i + 1] as any as Chunk | BinaryChunk,
@@ -6270,6 +6584,7 @@ function flushCompletedChunks(request: Request): void {
             i += 2;
           } else {
             request.pendingDebugChunks--;
+            request.queuedDebugChunks--;
             keepWriting = writeChunkAndReturn(
               destination,
               item as any as Chunk | BinaryChunk,
@@ -6297,6 +6612,7 @@ function flushCompletedChunks(request: Request): void {
             );
           }
           request.pendingChunks -= 2;
+          request.queuedChunks -= 2;
           writeChunk(
             destination,
             regularChunks[i + 1] as any as Chunk | BinaryChunk,
@@ -6308,6 +6624,7 @@ function flushCompletedChunks(request: Request): void {
           i += 2;
         } else {
           request.pendingChunks--;
+          request.queuedChunks--;
           keepWriting = writeChunkAndReturn(
             destination,
             item as any as Chunk | BinaryChunk,
@@ -6328,6 +6645,7 @@ function flushCompletedChunks(request: Request): void {
       i = 0;
       for (; i < errorChunks.length; i++) {
         request.pendingChunks--;
+        request.queuedChunks--;
         const chunk = errorChunks[i];
         const keepWriting: boolean = writeChunkAndReturn(destination, chunk);
         if (!keepWriting) {
@@ -6414,9 +6732,10 @@ function enqueueFlush(request: Request): void {
     request.flushScheduled === false &&
     // If there are pinged tasks we are going to flush anyway after work completes
     request.pingedTasks.length === 0 &&
-    // If there is no destination there is nothing we can flush to. A flush will
-    // happen when we start flowing again
+    // If there is no destination there is nothing we can flush to, but an
+    // in-process consumer still gets its deliveries on the flush schedule.
     (request.destination !== null ||
+      request.consumer !== null ||
       (__DEV__ && request.debugDestination !== null))
   ) {
     request.flushScheduled = true;
@@ -6526,6 +6845,7 @@ export function abort(request: Request, reason: mixed): void {
       enableProfilerTimer &&
       (enableComponentPerformanceTrack || enableAsyncDebugInfo)
     ) {
+      ensureTimeOriginIsSent(request);
       request.abortTime = performance.now();
     }
     request.cacheController.abort(reason);

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -6696,6 +6696,11 @@ function flushCompletedChunks(request: Request): void {
     if (enableTaint) {
       cleanupTaintQueue(request);
     }
+    // Nothing is serialized after this point, so the dedupe registry (one
+    // entry per object the render visited, each with its path string) can
+    // go even if the caller keeps a handle to this render around, e.g. the
+    // result object from render() for as long as a consumer reads from it.
+    request.writtenObjects = new WeakMap();
     if (request.status < ABORTING) {
       const abortReason = new Error(
         'This render completed successfully. All cacheSignals are now aborted to allow clean up of any unused resources.',

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -6479,12 +6479,6 @@ function flushCompletedChunks(request: Request): void {
       );
     }
   }
-  drainDeliveries(request);
-  // Every path that finishes emitting ends in a flush, so this is where a
-  // consumer learns that nothing more is coming. (Flushing itself can't
-  // change the outcome: it decrements the reserved and queued counters in
-  // lockstep.)
-  closeConsumerIfDone(request);
   if (__DEV__ && request.debugDestination !== null) {
     const debugDestination = request.debugDestination;
     beginWriting(debugDestination);
@@ -6661,6 +6655,16 @@ function flushCompletedChunks(request: Request): void {
     }
     flushBuffered(destination);
   }
+  // Deliveries drain after the same rows' bytes are written: the buffered
+  // wire chunks are ready to go as-is, while delivering runs consumer code
+  // (revival, renderer wake-ups) that would otherwise sit between the byte
+  // stream and the destination on every flush.
+  drainDeliveries(request);
+  // Every path that finishes emitting ends in a flush, so this is where a
+  // consumer learns that nothing more is coming. (Flushing itself can't
+  // change the outcome: it decrements the reserved and queued counters in
+  // lockstep.)
+  closeConsumerIfDone(request);
   if (request.pendingChunks === 0) {
     if (__DEV__) {
       const debugDestination = request.debugDestination;

--- a/packages/shared/ReactFlightRenderResult.js
+++ b/packages/shared/ReactFlightRenderResult.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// The contract between a Flight Server render and a Flight Client consuming
+// it in the same process. It only consists of plain functions so that it can
+// cross the boundary between the react-server module graph and the client
+// module graph; this module holds the single definition both graphs type
+// against.
+
+// A same-process consumer of the rows of a render, receiving each row when
+// it's emitted instead of decoding it from the byte stream. Model rows are
+// delivered in their object form so the consumer doesn't need to parse and
+// re-allocate what this process already has; binary rows are delivered as
+// cloned, correctly-typed views; every other row is delivered as the same
+// text that frames it on the wire.
+export type RenderConsumer = {
+  +row: (id: number, tag: string, payload: mixed) => void,
+  +close: () => void,
+  +error: (reason: mixed) => void,
+};
+
+// The base result of render(). Each server entry point composes it with its
+// platform's byte stream doors; a paired Flight Client's createFromRender
+// attaches a consumer to it.
+export type RenderResult = {
+  +_attach: (consumer: RenderConsumer) => void,
+};

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -586,5 +586,7 @@
   "598": "Maximum update depth exceeded. This could be an infinite loop. This can happen when a component repeatedly calls setState during render phase or inside useLayoutEffect, causing infinite render loop. React limits the number of nested updates to prevent infinite loops.",
   "599": "Expected an initialized chunk but got an initialized stream chunk instead. This payload may have been submitted by an older version of React.",
   "600": "A rejected Promise was passed to React without a `reason` property. React threw a generic error from where the Promise was used to assist in identifying the problematic Promise. Make sure that instrumented Promises correctly set the `reason` property when setting `status` to `'rejected'`.",
-  "601": "A chunk pair is incomplete. This is a bug in React."
+  "601": "A chunk pair is incomplete. This is a bug in React.",
+  "602": "A render result can only have a single consumer.",
+  "603": "Cannot attach a consumer to a render result that has already started emitting. Attach the consumer synchronously after render()."
 }

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -251,6 +251,10 @@ declare module 'async_hooks' {
     getStore(): T | void;
     run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R;
     enterWith(store: T): void;
+    static snapshot(): <R>(
+      callback: (...args: any[]) => R,
+      ...args: any[]
+    ) => R;
   }
   declare class AsyncResource {
     asyncId(): number;
@@ -283,6 +287,7 @@ declare class AsyncLocalStorage<T> {
   getStore(): T | void;
   run<R>(store: T, callback: (...args: any[]) => R, ...args: any[]): R;
   enterWith(store: T): void;
+  static snapshot(): <R>(callback: (...args: any[]) => R, ...args: any[]) => R;
 }
 
 declare const async_hooks: {

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -508,7 +508,7 @@ const bundles = [
     global: 'ReactServerDOMClient',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom', 'util', 'crypto'],
+    externals: ['react', 'react-dom', 'util', 'crypto', 'async_hooks'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
@@ -620,7 +620,7 @@ const bundles = [
     global: 'ReactServerDOMClient',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,
-    externals: ['react', 'react-dom', 'util'],
+    externals: ['react', 'react-dom', 'util', 'async_hooks'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],


### PR DESCRIPTION
vibed

---


<details>

Focused extraction from #37070: just the render-to-object mode, Node only.

`render(model, manifest, options)` renders without deciding how the result will be consumed. `createFromRender(result, manifest, options)` consumes it in the same process through the normal Flight `Response`, skipping the serialize/parse roundtrip and the second copy of the payload's object graph; `pipe()` on the same result still serves the hydration bytes. This is the "render to an object" mode from #36143.

### Why this is small to verify

Since #36795, `resolveModel` builds a fresh, React-owned, JSON-faithful tree before `JSON.stringify`. The wire path on the client is `reviveModel(JSON.parse(json))`; the in-process path is `reviveModel(tree)` on the tree `json` came from. They can only differ if `JSON.parse(JSON.stringify(tree))` differs from `tree`, which the resolve walk rules out by construction. Every non-model row (imports, hints, errors, text, binary, stream control, debug) is delivered as its wire text and goes through the existing row parser — no new parsing logic.

The consumer receives React's own allocation, never the caller's objects, so nothing it does can reach the server model. (The copy-on-write resolve walk from #37070 is deliberately left out: it changes that property and deserves its own review.)

### Not in this PR

- Edge / web-streams entry points: hint and module-preinit dispatches are routed into the consuming Fizz request with `AsyncLocalStorage.snapshot()` on the consumer's first read, which a web-streams runtime can't be assumed to have. Follow-up once the contract is agreed.
- COW resolve walk, skip-revival, import rows in object form, row packing, import dedupe, lazy dedupe paths, rows door, inline data channel (#37069).

### Tests

`ReactFlightDOMRender-test` renders every pattern through both the byte stream and `createFromRender` and asserts the two are observably identical. A DEV-only invariant in `flushCompletedChunks` checks that every emit site delivered its row (a missed `deliverRow` would otherwise hang an in-process consumer silently); dropping any one call fails the suite.

</details>