### PR TITLE
[Flight] Abort the cache signal when debug objects are retained

### DIFF
--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -3082,6 +3082,85 @@ describe('ReactFlightDOMBrowser', () => {
     }
   });
 
+  it('should abort the cache signal when a render completes while debug objects are still retained', async () => {
+    // A debug channel with a readable side lets the client fetch debug objects
+    // lazily. React serializes each component's props into the debug model, and
+    // it defers the part of an object tree that exceeds the model's object
+    // limit. A deferred object stays retained, and its debug chunk stays
+    // pending, until the client asks for it or the channel closes. The render
+    // below finishes while one such object is outstanding.
+    function createDeepJSX(n) {
+      if (n <= 0) {
+        return null;
+      }
+      return <div>{createDeepJSX(n - 1)}</div>;
+    }
+
+    let cacheSignal;
+
+    function ServerComponent() {
+      cacheSignal = ReactServer.cacheSignal();
+      return <div>not using props</div>;
+    }
+
+    let debugChannelReadableController;
+    const debugChunks = [];
+
+    const debugChannelReadable = new ReadableStream({
+      start(controller) {
+        debugChannelReadableController = controller;
+      },
+    });
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        // These children nest deeper than the debug model's object limit.
+        <ServerComponent>{createDeepJSX(20)}</ServerComponent>,
+        webpackMap,
+        {
+          debugChannel: {
+            readable: debugChannelReadable,
+            writable: new WritableStream({
+              write(chunk) {
+                debugChunks.push(chunk);
+              },
+            }),
+          },
+        },
+      ),
+    );
+
+    const reader = stream.getReader();
+    while (true) {
+      const {done} = await reader.read();
+      if (done) {
+        break;
+      }
+    }
+    await serverAct(() => {});
+
+    if (__DEV__) {
+      // Fail loudly if the setup stops deferring anything, for example because
+      // the object limit changed. Without a retained object this test passes
+      // for the wrong reason.
+      const debugOutput = debugChunks
+        .map(chunk => new TextDecoder().decode(chunk))
+        .join('');
+      expect(debugOutput).toContain('$Y');
+    }
+
+    expect(cacheSignal.aborted).toBe(true);
+
+    // Closing the debug channel drops the retained objects. The signal must
+    // already be aborted at that point, and must stay aborted.
+    await serverAct(() => {
+      debugChannelReadableController.close();
+    });
+    await serverAct(() => {});
+
+    expect(cacheSignal.aborted).toBe(true);
+  });
+
   it('should resolve a cycle between debug info and the value it produces when using a debug channel', async () => {
     // Same as `should resolve a cycle between debug info and the value it produces`, but using a debug channel.
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -6488,6 +6488,25 @@ function flushCompletedChunks(request: Request): void {
     flushBuffered(destination);
   }
   if (request.pendingChunks === 0) {
+    // There are no pending chunks left, so the render is complete. This code
+    // releases its resources. Debug chunks can still be pending, but they carry
+    // development-only instrumentation rather than the render's output.
+    //
+    // The release runs before the stream bookkeeping below, because that
+    // bookkeeping can close the main stream and set the status to CLOSED while
+    // debug chunks are outstanding. The cache controller is only aborted below
+    // ABORTING, so a later flush would skip it. Repeated flushes are safe,
+    // because emptying the taint queue and aborting an aborted controller both
+    // do nothing a second time.
+    if (enableTaint) {
+      cleanupTaintQueue(request);
+    }
+    if (request.status < ABORTING) {
+      const abortReason = new Error(
+        'This render completed successfully. All cacheSignals are now aborted to allow clean up of any unused resources.',
+      );
+      request.cacheController.abort(abortReason);
+    }
     if (__DEV__) {
       const debugDestination = request.debugDestination;
       if (request.pendingDebugChunks === 0) {
@@ -6515,15 +6534,6 @@ function flushCompletedChunks(request: Request): void {
       }
     }
     // We're done.
-    if (enableTaint) {
-      cleanupTaintQueue(request);
-    }
-    if (request.status < ABORTING) {
-      const abortReason = new Error(
-        'This render completed successfully. All cacheSignals are now aborted to allow clean up of any unused resources.',
-      );
-      request.cacheController.abort(abortReason);
-    }
     if (request.destination !== null) {
       request.status = CLOSED;
       close(request.destination);

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -6488,19 +6488,19 @@ function flushCompletedChunks(request: Request): void {
     flushBuffered(destination);
   }
   if (request.pendingChunks === 0) {
-    // There are no pending chunks left, so the render is complete. This code
-    // releases its resources. Debug chunks can still be pending, but they carry
+    // There are no pending chunks left, so the render is complete and its cache
+    // signal is aborted here. Debug chunks can still be pending, but they carry
     // development-only instrumentation rather than the render's output.
     //
-    // The release runs before the stream bookkeeping below, because that
-    // bookkeeping can close the main stream and set the status to CLOSED while
-    // debug chunks are outstanding. The cache controller is only aborted below
-    // ABORTING, so a later flush would skip it. Repeated flushes are safe,
-    // because emptying the taint queue and aborting an aborted controller both
-    // do nothing a second time.
-    if (enableTaint) {
-      cleanupTaintQueue(request);
-    }
+    // This runs before the stream bookkeeping below, because that bookkeeping
+    // can close the main stream and set the status to CLOSED while debug chunks
+    // are outstanding. The abort only happens below ABORTING, so a later flush
+    // would skip it. Repeated flushes are safe, because aborting an aborted
+    // controller does nothing a second time.
+    //
+    // The taint queue stays untouched here. Debug chunks are checked against
+    // the taint registry as they are written, and a deferred debug object can
+    // be written long after this point.
     if (request.status < ABORTING) {
       const abortReason = new Error(
         'This render completed successfully. All cacheSignals are now aborted to allow clean up of any unused resources.',
@@ -6534,6 +6534,9 @@ function flushCompletedChunks(request: Request): void {
       }
     }
     // We're done.
+    if (enableTaint) {
+      cleanupTaintQueue(request);
+    }
     if (request.destination !== null) {
       request.status = CLOSED;
       close(request.destination);


### PR DESCRIPTION
A debug channel with a readable side lets the client fetch debug objects lazily. For example, React serializes each component's props into the debug model and defers the part of an object tree that exceeds the model's object limit. A deferred object stays retained, and its debug chunk stays pending, until the client asks for it or the channel closes. The render can therefore complete while such an object is still outstanding.

When that happens, `flushCompletedChunks` closes the main stream, sets the request status to `CLOSED`, and returns before it reaches the block that releases the render's resources. Once the client closes the debug channel and the retained objects drop, a later flush does reach that block, but the cache controller is only aborted while the status is below `ABORTING`, and `CLOSED` is above it. The signal is therefore never aborted at all rather than merely released late, so anything that waits on `cacheSignal()` to clean up resources waits for the lifetime of the process.

This change moves the cache controller abort above the debug stream bookkeeping. An empty pending chunk count already means the render is complete, and debug chunks carry development-only instrumentation rather than the render's output, so the cache signal can abort at that point no matter what the debug stream is still doing. The path that writes debug chunks on the main stream can now reach this code on several flushes, which is safe because aborting an aborted controller does nothing a second time.

The taint queue cleanup stays where it is. A tainted typed array, `DataView` or blob is checked against the taint registry as its chunk is written, and such a write can happen long after the render completes, either because the client queried a deferred debug object or because a blob's stream resolved late. Moving it up would let those writes through unchecked, and it would fix nothing, because unlike the abort it never sat behind the status guard.