### PR TITLE
[DevTools] Keep console specifiers literal when arguments run out

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -163,6 +163,16 @@ describe('utils', () => {
       );
     });
 
+    it('should keep specifiers literal when arguments run out', () => {
+      expect(formatConsoleArgumentsToSingleString('%s %s', 'value')).toEqual(
+        'value %s',
+      );
+      expect(formatConsoleArgumentsToSingleString('%d %d', 1)).toEqual('1 %d');
+      expect(formatConsoleArgumentsToSingleString('%f %f', 0.5)).toEqual(
+        '0.5 %f',
+      );
+    });
+
     it('should gracefully handle Symbol types', () => {
       expect(
         formatConsoleArgumentsToSingleString(Symbol('a'), 'b', Symbol('c')),

--- a/packages/react-devtools-shared/src/backend/utils/index.js
+++ b/packages/react-devtools-shared/src/backend/utils/index.js
@@ -197,6 +197,11 @@ export function formatConsoleArgumentsToSingleString(
 
       // $FlowFixMe[incompatible-type]
       formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+        if (args.length === 0) {
+          // No argument left for this specifier. Keep it as a literal, like
+          // the browser console does, rather than emitting 'undefined' or NaN.
+          return match;
+        }
         let arg = args.shift();
         switch (flag) {
           case 's':


### PR DESCRIPTION
## Summary
formatConsoleArgumentsToSingleString builds the message keys DevTools uses to correlate console warnings and errors. When a format string contained more substitution specifiers than arguments, the unmatched specifier consumed an undefined value and rendered "undefined" or NaN (e.g. "%s %s" with one arg produced "value undefined") instead of staying literal, so the tracked key could differ from what the browser console printed. This returns the specifier unchanged when no argument is left, matching browser console behavior and the existing formatConsoleArguments fix.

## Testing
Added a utils-test.js case covering exhausted %s, %d and %f specifiers. It fails on the old implementation and passes with the fix. Verified with yarn test --build --project devtools (63 passed); yarn prettier and yarn linc pass.

## Checklist
- [x] Bug reproduced before the fix
- [x] Root cause identified
- [x] Fix implemented
- [x] Tests passed
- [x] Final diff reviewed
