### PR TITLE
[Flight] Validate that declared string row lengths are not impossibly large

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -5425,7 +5425,7 @@ export function processStringChunk(
         // we are looking for but we can assume that the raw string will be its own
         // chunk. We add extra validation that the length is at least within the
         // possible byte range it could possibly be to catch mistakes.
-        if (rowLength < chunk.length || chunk.length > rowLength * 3) {
+        if (rowLength < chunk.length || rowLength > chunk.length * 3) {
           throw new Error(
             'String chunks need to be passed in their original shape. ' +
               'Not split into smaller string chunks. ' +

--- a/packages/react-client/src/__tests__/ReactFlightStringChunks-test.js
+++ b/packages/react-client/src/__tests__/ReactFlightStringChunks-test.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+'use strict';
+
+describe('processStringChunk', () => {
+  let createResponse;
+  let createStreamState;
+  let processStringChunk;
+  let getRoot;
+  let close;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const ReactFlightClient = require('react-client/flight');
+    const client = ReactFlightClient({
+      createStringDecoder() {
+        return new TextEncoder();
+      },
+      readPartialStringChunk(decoder, buffer) {
+        return decoder.decode(buffer, {stream: true});
+      },
+      readFinalStringChunk(decoder, buffer) {
+        return decoder.decode(buffer);
+      },
+      resolveClientReference(bundlerConfig, idx) {
+        return idx;
+      },
+      prepareDestinationForModule(moduleLoading, metadata) {},
+      preloadModule(idx) {},
+      requireModule(idx) {
+        return {};
+      },
+      bindToConsole(methodName, args) {
+        return Function.prototype.bind.apply(
+          console[methodName],
+          [console].concat(args),
+        );
+      },
+      checkEvalAvailabilityOnceDev() {},
+    });
+    createResponse = client.createResponse;
+    createStreamState = client.createStreamState;
+    processStringChunk = client.processStringChunk;
+    getRoot = client.getRoot;
+    close = client.close;
+  });
+
+  function createTestResponse() {
+    return createResponse(
+      null, // bundlerConfig
+      null, // serverReferenceConfig
+      null, // moduleLoading
+      null, // callServer
+      null, // encodeFormAction
+      null, // nonce
+      null, // temporaryReferences
+      false, // allowPartialStream
+    );
+  }
+
+  it('resolves a large string row with a matching declared byte length', async () => {
+    const response = createTestResponse();
+    const streamState = createStreamState(response, null);
+
+    processStringChunk(response, streamState, '0:T6,');
+    processStringChunk(response, streamState, 'abcdef');
+    close(response);
+
+    expect(await getRoot(response)).toBe('abcdef');
+  });
+
+  it('rejects a large string row with an impossibly large declared byte length', () => {
+    const response = createTestResponse();
+    const streamState = createStreamState(response, null);
+
+    processStringChunk(response, streamState, '0:T1000,');
+    expect(() => {
+      // A one code unit string cannot be 4096 UTF-8 bytes.
+      processStringChunk(response, streamState, 'x');
+    }).toThrow('String chunks need to be passed in their original shape.');
+  });
+
+  it('rejects a large string row with an impossibly small declared byte length', () => {
+    const response = createTestResponse();
+    const streamState = createStreamState(response, null);
+
+    processStringChunk(response, streamState, '0:T1,');
+    expect(() => {
+      // A three code unit string is at least three UTF-8 bytes.
+      processStringChunk(response, streamState, 'abc');
+    }).toThrow('String chunks need to be passed in their original shape.');
+  });
+});


### PR DESCRIPTION
## Summary
`processStringChunk` validated large string rows with `rowLength < chunk.length || chunk.length > rowLength * 3`. The second condition is implied by the first, so a declared byte length that no string of the given code unit count could have (e.g. `0:T1000,` followed by a one character chunk) was accepted silently instead of throwing the wiring error the comment describes. The comparison now runs in the other direction: `rowLength > chunk.length * 3`.

## Testing
Added `ReactFlightStringChunks-test.js`, which feeds length-prefixed string rows directly to the Flight client. The oversized declaration case failed before the fix and all three cases (matching, impossibly large, impossibly small) pass after. Full `react-client` suite passes apart from one pre-existing Windows-only failure on `main`; lint and prettier pass.

## Checklist
- [x] Bug reproduced before fix
- [x] Root cause identified
- [x] Fix implemented
- [x] Tests passed
- [x] Final diff reviewed

Fixes #37156
