### PR TITLE
[compiler] Fix postfix member updates emitting the incremented value

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -2648,6 +2648,15 @@ function lowerExpression(
 
         // Store the previous value to a temporary
         const previousValuePlace = lowerValueToTemporary(builder, value);
+        if (!expr.node.prefix) {
+          /*
+           * The original value is observed after the update, so it must remain
+           * valid across the store below. Promote the temporary so that codegen
+           * emits a named variable instead of re-emitting the load at the use
+           * site, which would occur after the store and observe the new value.
+           */
+          promoteTemporary(previousValuePlace.identifier);
+        }
         // Store the new value to a temporary
         const updatedValue = lowerValueToTemporary(builder, {
           kind: 'BinaryExpression',

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/e2e/update-expressions.e2e.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/e2e/update-expressions.e2e.js
@@ -47,3 +47,30 @@ test('use-state', async () => {
     </DocumentFragment>
   `);
 });
+
+// Postfix updates of properties must observe the value prior to the update,
+// even when the update occurs inside an outlined function.
+function MemberPostfixUpdate(props) {
+  'use memo';
+  const results = [];
+  const counter = {value: props.initial};
+  props.inputs.forEach(input => {
+    const previous = counter.value++;
+    results.push(previous + input);
+  });
+  return <span>{results.join(',')}</span>;
+}
+
+test('member-postfix-update', async () => {
+  const {asFragment} = render(
+    <MemberPostfixUpdate initial={0} inputs={[10]} />
+  );
+  // The first iteration observes the initial value, not the incremented one.
+  expect(asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      <span>
+        10
+      </span>
+    </DocumentFragment>
+  `);
+});

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.expect.md
@@ -5,22 +5,12 @@
 import {useRef, useEffect} from 'react';
 
 /**
- * The postfix increment operator should return the value before incrementing.
+ * The postfix increment operator returns the value before incrementing.
  * ```js
  * const id = count.current; // 0
  * count.current = count.current + 1; // 1
  * return id;
  * ```
- * The bug is that we currently increment the value before the expression is evaluated.
- * This bug does not trigger when the incremented value is a plain primitive.
- *
- * Found differences in evaluator results
- * Non-forget (expected):
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 0','count = 1']
- * Forget:
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 1','count = 1']
  */
 function useFoo() {
   const count = useRef(0);
@@ -54,22 +44,12 @@ import { c as _c } from "react/compiler-runtime";
 import { useRef, useEffect } from "react";
 
 /**
- * The postfix increment operator should return the value before incrementing.
+ * The postfix increment operator returns the value before incrementing.
  * ```js
  * const id = count.current; // 0
  * count.current = count.current + 1; // 1
  * return id;
  * ```
- * The bug is that we currently increment the value before the expression is evaluated.
- * This bug does not trigger when the incremented value is a plain primitive.
- *
- * Found differences in evaluator results
- * Non-forget (expected):
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 0','count = 1']
- * Forget:
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 1','count = 1']
  */
 function useFoo() {
   const $ = _c(5);
@@ -77,8 +57,9 @@ function useFoo() {
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = () => {
-      count.current = count.current + 1;
-      const id = count.current;
+      const t1 = count.current;
+      count.current = t1 + 1;
+      const id = t1;
       return id;
     };
     $[0] = t0;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bug-ref-prefix-postfix-operator.js
@@ -1,22 +1,12 @@
 import {useRef, useEffect} from 'react';
 
 /**
- * The postfix increment operator should return the value before incrementing.
+ * The postfix increment operator returns the value before incrementing.
  * ```js
  * const id = count.current; // 0
  * count.current = count.current + 1; // 1
  * return id;
  * ```
- * The bug is that we currently increment the value before the expression is evaluated.
- * This bug does not trigger when the incremented value is a plain primitive.
- *
- * Found differences in evaluator results
- * Non-forget (expected):
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 0','count = 1']
- * Forget:
- * (kind: ok) {"count":{"current":0},"updateCountPostfix":"[[ function params=0 ]]","updateCountPrefix":"[[ function params=0 ]]"}
- * logs: ['id = 1','count = 1']
  */
 function useFoo() {
   const count = useRef(0);


### PR DESCRIPTION
## Summary
A postfix update of a property (`agg.count++`) compiled to code that assigned the incremented value, because the temporary holding the previous value was left unpromoted and codegen re-emitted the load at its use site, which is after the store. Outlined functions do not get PromoteUsedTemporaries, so the previous value temporary is now promoted eagerly when lowering the update in BuildHIR, matching the diagnosis in #35205.

## Testing
Reproduced with a component incrementing a property inside a callback: pre-fix output assigned before reading, post-fix output captures the previous value first. The existing bug-ref-prefix-postfix-operator fixture now passes with matching evaluator logs and was regenerated; added an e2e case asserting the observed value in update-expressions.e2e.js. ESLint and prettier pass.

## Checklist
- [x] Bug reproduced before fix
- [x] Root cause identified
- [x] Fix implemented
- [x] Tests passed
- [x] Final diff reviewed

Fixes #35205
