### PR TITLE
[ci] Download build artifacts in the background during job setup

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -377,6 +377,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      # The build download runs in the background while Node is set up and
+      # node_modules is restored. The `wait` step below synchronizes on it.
+      # It must start after checkout, whose git clean would wipe `build/`.
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -388,18 +401,12 @@ jobs:
             **/node_modules
           key: runtime-and-compiler-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock', 'compiler/yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
       - run: yarn --cwd compiler install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - name: Display structure of build
         run: ls -R build
       - run: node --version
@@ -422,6 +429,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -433,16 +450,10 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - name: Display structure of build
         run: ls -R build
       - run: node --version
@@ -460,6 +471,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -471,16 +492,10 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       # Only used to log weight variance; the new measurement is what gets
       # saved, so removed bundles drop out instead of accumulating.
       - name: Restore previous build shard weights
@@ -547,6 +562,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -558,16 +583,10 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - name: Display structure of build
         run: ls -R build
       - name: Search build artifacts for unminified errors
@@ -583,6 +602,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -594,16 +623,10 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - name: Display structure of build
         run: ls -R build
       - run: yarn check-release-dependencies
@@ -616,6 +639,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -626,16 +659,10 @@ jobs:
           path: |
             **/node_modules
           key: fixtures_dom-node_modules-v6-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock', 'fixtures/dom/yarn.lock') }}
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn --cwd fixtures/dom install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - name: Display structure of build
         run: ls -R build
       - name: Run DOM fixture tests
@@ -655,6 +682,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -668,8 +705,6 @@ jobs:
           path: |
             **/node_modules
           key: fixtures_flight-node_modules-v6-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock', 'fixtures/flight/yarn.lock') }}
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
       - run: yarn --cwd fixtures/flight install --frozen-lockfile
@@ -687,12 +722,8 @@ jobs:
         if: steps.cache_playwright_browsers.outputs.cache-hit != 'true'
         working-directory: fixtures/flight
         run: npx playwright install --with-deps chromium
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - name: Display structure of build
         run: ls -R build
       - name: Run tests
@@ -727,6 +758,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -738,16 +779,10 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
+      - name: Wait for archived build
+        wait: download_build
       - run: ./scripts/ci/pack_and_store_devtools_artifacts.sh ${{ matrix.browser }}
         env:
           RELEASE_CHANNEL: experimental
@@ -821,6 +856,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -832,22 +877,16 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
       - name: Restore Playwright Chromium
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-v6-${{ runner.arch }}-${{ runner.os }}-${{ needs.runtime_playwright_chromium_cache.outputs.playwright_version }}
           fail-on-cache-miss: true
+      - name: Wait for archived build
+        wait: download_build
       - run: ./scripts/ci/run_devtools_e2e_tests.js
         env:
           RELEASE_CHANNEL: experimental
@@ -866,6 +905,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Ensure clean build directory
+        run: rm -rf build
+      - name: Restore archived build
+        id: download_build
+        uses: actions/download-artifact@v4
+        background: true
+        with:
+          pattern: _build_*
+          path: build
+          merge-multiple: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -877,16 +926,8 @@ jobs:
             **/node_modules
           key: runtime-node_modules-v10-${{ runner.arch }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           # Don't use restore-keys here. Otherwise the cache grows indefinitely.
-      - name: Ensure clean build directory
-        run: rm -rf build
       - run: yarn install --frozen-lockfile
         if: steps.node_modules.outputs.cache-hit != 'true'
-      - name: Restore archived build
-        uses: actions/download-artifact@v4
-        with:
-          pattern: _build_*
-          path: build
-          merge-multiple: true
       - name: Restore Playwright Chromium
         uses: actions/cache/restore@v4
         with:
@@ -898,6 +939,8 @@ jobs:
         run: |
           echo "executable_path=$(node -e 'process.stdout.write(require("playwright").chromium.executablePath())')" >> "$GITHUB_OUTPUT"
           "$(node -e 'process.stdout.write(require("playwright").chromium.executablePath())')" --version
+      - name: Wait for archived build
+        wait: download_build
       - name: Run React DevTools CDT MCP e2e tests
         run: yarn --cwd packages/react-devtools-cdt-mcp test:e2e:ci
         env:


### PR DESCRIPTION
Every downstream job in `runtime_build_and_test.yml` restored the 50 `_build_*` artifacts with `actions/download-artifact` only after setup-node, the node_modules cache restore, and any installs had completed, even though the download is independent of all of them. 

This change marks the download as a [background step](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsbackground) started immediately after checkout, and adds an explicit `wait: download_build` before the first step that reads `build/`.

The download starts after checkout because `actions/checkout` runs `git clean`, which would wipe a previously downloaded `build/` directory. The `sizebot` job is unchanged because its base-build download also writes `./build` and would collide with a concurrent artifact restore.

This only shaves of a few seconds from wall time. It's more about establishing precedent.
