### PR TITLE
[not for merge] Demonstrate sizebot comparing against the base revision instead of the merge-base

### DIFF
--- a/scripts/sizebot/compare-sizes.js
+++ b/scripts/sizebot/compare-sizes.js
@@ -17,6 +17,9 @@
 // user-facing. `render-comment.js` turns this JSON into the pull request comment
 // from a trusted checkout. See `.github/workflows/runtime_sizebot_comment.yml`
 // for why the two halves are separate.
+//
+// This comment exists to give the demonstration pull request a non-empty
+// diff. It should be removed when the demonstration closes.
 
 const {promisify} = require('util');
 const glob = promisify(require('glob'));


### PR DESCRIPTION

Do not merge. This pull request contains an empty commit on top of `675a29c3`, the parent of the size-changing commit `dc631ef5` ([Flight] Outline and dedupe repeated strings, #37147). It exists to demonstrate the problem that #37355 fixes.

Sizebot compares the head build against the build of `pull_request.base.sha`, the current tip of `main`, rather than against the merge-base.
>  Downloading artifacts from GitHub for commit bd6ea412c6732b3b946a2827fcaac3a1c

-- https://github.com/react/react/actions/runs/32729325563/job/97438366280?pr=37356#step:8:2
meanwhile 
> $ gh api repos/react/react/compare/bd6ea412c6732b3b946a2827fcaac3a1c...95516c9fdd38c24133422a1a29545b9595281453 | jq .merge_base_commit.sha
> 675a29c3e9869d0706dc5ed08779ae04186bd44f
