### PR TITLE
[Fizz] Construct the render lifetime controller only when it is needed

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzStaticBrowser-test.js
@@ -1584,6 +1584,32 @@ describe('ReactDOMFizzStaticBrowser', () => {
       expect(lifetimes[0].aborted).toBe(true);
     });
 
+    it('constructs no abort controller when no signal is passed', async () => {
+      // The render lifetime exists only to bound the caller's abort listener,
+      // so a render that is given no signal has nothing to bound and should not
+      // pay for a controller. It also means such a render never requires
+      // AbortController to exist or to work.
+      const RealAbortController = globalThis.AbortController;
+      let constructed = 0;
+      globalThis.AbortController = class extends RealAbortController {
+        constructor() {
+          super();
+          constructed++;
+        }
+      };
+
+      try {
+        const stream = await serverAct(() =>
+          ReactDOMFizzServer.renderToReadableStream(<div>hello world</div>),
+        );
+        await readContent(stream);
+      } finally {
+        globalThis.AbortController = RealAbortController;
+      }
+
+      expect(constructed).toBe(0);
+    });
+
     it('attaches no listener when the signal is already aborted', async () => {
       const controller = new AbortController();
       controller.abort();

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -435,7 +435,9 @@ export opaque type Request = {
   onFatalError: (error: mixed) => void,
   // Aborted once the render ends, whether it completed, failed fatally or was
   // aborted. Bounds the lifetime of anything that must not outlive the render.
-  renderLifetimeController: AbortController,
+  // Null until attachAbortSignal creates it, so a render that is given no
+  // signal constructs no controller.
+  renderLifetimeController: null | AbortController,
   // Form state that was the result of an MPA submission, if it was provided.
   formState: null | ReactFormState<any, any>,
   // DEV-only, warning dedupe
@@ -589,7 +591,7 @@ function RequestInstance(
   this.onShellReady = onShellReady === undefined ? noop : onShellReady;
   this.onShellError = onShellError === undefined ? noop : onShellError;
   this.onFatalError = onFatalError === undefined ? noop : onFatalError;
-  this.renderLifetimeController = new AbortController();
+  this.renderLifetimeController = null;
   this.formState = formState === undefined ? null : formState;
   if (__DEV__) {
     this.didWarnForKey = null;
@@ -1455,7 +1457,7 @@ function fatalError(
     }
     onFatalError(error);
   }
-  request.renderLifetimeController.abort(RENDER_ENDED);
+  endRenderLifetime(request);
   if (request.destination !== null) {
     request.status = CLOSED;
     closeWithError(request.destination, error);
@@ -6352,7 +6354,7 @@ function flushCompletedQueues(
         }
       }
       // We're done.
-      request.renderLifetimeController.abort(RENDER_ENDED);
+      endRenderLifetime(request);
       request.status = CLOSED;
       close(destination);
       // We need to stop flowing now because we do not want any async contexts which might call
@@ -6516,6 +6518,13 @@ function finishAbort(request: Request, abortableTasks: Set<Task>): void {
   }
 }
 
+function endRenderLifetime(request: Request): void {
+  const renderLifetimeController = request.renderLifetimeController;
+  if (renderLifetimeController !== null) {
+    renderLifetimeController.abort(RENDER_ENDED);
+  }
+}
+
 // Aborts the request when the caller's signal aborts. The render lifetime
 // bounds the listener, so the runtime removes the listener as soon as the
 // render ends. From that point on abort() returns early, so the listener has
@@ -6533,12 +6542,14 @@ export function attachAbortSignal(request: Request, signal: AbortSignal): void {
     abort(request, signal.reason);
     return;
   }
+  const renderLifetimeController = new AbortController();
+  request.renderLifetimeController = renderLifetimeController;
   signal.addEventListener(
     'abort',
     () => {
       abort(request, signal.reason);
     },
-    {signal: request.renderLifetimeController.signal},
+    {signal: renderLifetimeController.signal},
   );
 }
 
@@ -6552,7 +6563,7 @@ export function abort(request: Request, reason: mixed): void {
     // can be aborted. in practice this makes abort callable at most once per render.
     return;
   }
-  request.renderLifetimeController.abort(RENDER_ENDED);
+  endRenderLifetime(request);
   const isRecoverableReason =
     typeof reason === 'object' &&
     reason !== null &&


### PR DESCRIPTION
This follows #37315, which added the render lifetime controller to bound the abort listener that `attachAbortSignal` attaches to a caller's signal. `RequestInstance` constructed one for every request, so a render that is given no signal allocated a controller, aborted it on completion, and nothing ever observed either.

The controller is now created in `attachAbortSignal`, and the three places that end the lifetime go through `endRenderLifetime`, which does nothing when there is no controller. Callers that pass a signal are unaffected. Callers that do not no longer allocate one, and `signal` is optional in every browser, edge and static entry point, while `renderToPipeableStream` and `resumeToPipeableStream` accept no signal at all.

They also no longer reach `AbortController` at all, which matters more than the allocation. Fizz had no runtime dependency on it before #37315, and an unconditional one reaches environments that provide the API through a polyfill. An incomplete polyfill can then fail a render that never asked for abort support.

The new test asserts that no controller is constructed when no signal is passed. It fails with the eager construction restored, since nothing else in the suite would notice a regression to it.