### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/runtime_build_and_test.yml
+++ b/.github/workflows/runtime_build_and_test.yml
@@ -284,7 +284,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 11.0.22


### PR DESCRIPTION
## Summary

Upgrade the workflow reference from actions/setup-java v4 to v6.0.0 so CI uses the current major release.

## How did you test this change?

Reviewed the workflow-only diff and verified no setup-java reference older than v6 remains in active workflow YAML.