### PR TITLE
Revert "[rust-compiler] Bail out on nested TypeScript `this` parameters"

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -2589,12 +2589,8 @@ fn lower_block_statement(
     block: &react_compiler_ast::statements::BlockStatement,
     parent_scope: Option<react_compiler_ast::scope::ScopeId>,
 ) -> Result<(), CompilerError> {
-    Ok(lower_block_statement_inner(
-        builder,
-        block,
-        None,
-        parent_scope,
-    )?)
+    let _ = lower_block_statement_inner(builder, block, None, parent_scope);
+    Ok(())
 }
 
 fn lower_block_statement_with_scope(
@@ -2602,12 +2598,8 @@ fn lower_block_statement_with_scope(
     block: &react_compiler_ast::statements::BlockStatement,
     scope_override: react_compiler_ast::scope::ScopeId,
 ) -> Result<(), CompilerError> {
-    Ok(lower_block_statement_inner(
-        builder,
-        block,
-        Some(scope_override),
-        None,
-    )?)
+    let _ = lower_block_statement_inner(builder, block, Some(scope_override), None);
+    Ok(())
 }
 
 fn lower_block_statement_inner(


### PR DESCRIPTION
Reverts react/react#37232