### PR TITLE
[react] Warn instead of crashing when lazy() resolves to null

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -291,6 +291,46 @@ describe('ReactLazy', () => {
     expect(root).not.toMatchRenderedOutput('Hi');
   });
 
+  it('warns if promise resolves to null', async () => {
+    const LazyText = lazy(async () => null);
+
+    const root = ReactTestRenderer.create(null, {
+      unstable_isConcurrent: true,
+    });
+
+    function App() {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi" />
+        </Suspense>
+      );
+    }
+
+    let error;
+    try {
+      await act(() => {
+        root.update(<App />);
+      });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    assertLog(['Loading...']);
+    assertConsoleErrorDev([
+      'lazy: Expected the result of a dynamic import() call. ' +
+        'Instead received: null\n\n' +
+        'Your code should look like: \n  ' +
+        "const MyComponent = lazy(() => import('./MyComponent'))\n" +
+        '    in App (at **)',
+      'lazy: Expected the result of a dynamic import() call. ' +
+        'Instead received: null\n\n' +
+        'Your code should look like: \n  ' +
+        "const MyComponent = lazy(() => import('./MyComponent'))\n" +
+        '    in App (at **)',
+    ]);
+  });
+
   it('throws if promise rejects', async () => {
     const networkError = new Error('Bad network');
     const LazyText = lazy(async () => {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -202,10 +202,7 @@ function lazyInitializer<T>(payload: Payload<T>): T {
             'Did you accidentally put curly braces around the import?',
           moduleObject,
         );
-      }
-    }
-    if (__DEV__) {
-      if (!('default' in moduleObject)) {
+      } else if (moduleObject == null || !('default' in moduleObject)) {
         console.error(
           'lazy: Expected the result of a dynamic imp' +
             'ort() call. ' +


### PR DESCRIPTION
## Summary

`lazy(() => Promise.resolve(null))` crashed inside the DEV diagnostic that exists to explain the problem: the missing-default-export check used the `in` operator, which throws "Cannot use 'in' operator to search for 'default' in null" before any guidance printed. Merge the two sibling `__DEV__` checks so a null payload takes the same warn path as other non-module objects, after which the inevitable error from reading `.default` fires as before. Production behavior is unchanged since both guards are dev-only.

## How did you test this change?

New test `warns if promise resolves to null` in `packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js`, mirroring the adjacent arbitrary-promise test:

```
yarn test packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
```

- with the fix reverted: fails, `assertConsoleErrorDev` received 0 warnings, expected 2
- with the fix applied: 42 passed, 42 total
- SuspenseList and StrictMode suites: 75 passed, 75 total
- `--prod` and `--variant=www` lanes pass (the diagnostic compiles out in prod)
- eslint clean; `flow dom-node`: No errors!
