### PR TITLE
[DevTools] Handle missing renderer in getProfilingData

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/backend-test.js
+++ b/packages/react-devtools-shared/src/__tests__/backend-test.js
@@ -56,3 +56,17 @@ describe('connectToDevTools', () => {
     }
   });
 });
+
+describe('Agent.getProfilingData', () => {
+  it('warns without throwing when no renderer is registered for an id', () => {
+    const agent = global.agent;
+    const sendSpy = jest.spyOn(global.bridge, 'send');
+
+    expect(() => agent.getProfilingData({rendererID: 12345})).not.toThrow();
+
+    expect(global.consoleWarnMock).toHaveBeenCalledWith(
+      'Invalid renderer id "12345"',
+    );
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -555,9 +555,9 @@ export default class Agent extends EventEmitter<{
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
       console.warn(`Invalid renderer id "${rendererID}"`);
+    } else {
+      this._bridge.send('profilingData', renderer.getProfilingData());
     }
-
-    this._bridge.send('profilingData', renderer.getProfilingData());
   };
 
   getProfilingStatus: () => void = () => {


### PR DESCRIPTION
## Summary

Requesting profiling data with a renderer ID that is no longer registered warned `Invalid renderer id "..."` and then dereferenced the missing renderer anyway, throwing a TypeError out of the backend message handler while the Profiler UI kept waiting for data that never arrives. Skip the bridge send when the renderer is gone, matching how every other Agent method handles unknown renderer IDs. A new test also asserts nothing is sent on that path.

## How did you test this change?

```
yarn test-build-devtools packages/react-devtools-shared/src/__tests__/backend-test.js -t getProfilingData
```

- with the fix reverted: fails with `TypeError: Cannot read properties of undefined (reading 'getProfilingData')` at agent.js:560
- with the fix applied: passes; full file 2 passed, 2 total
- eslint clean; prettier clean; flow dom-node check: No errors!
