### PR TITLE
[DevTools] Guard overrideSuspenseMilestone against unknown renderer ids

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/backend-test.js
+++ b/packages/react-devtools-shared/src/__tests__/backend-test.js
@@ -56,3 +56,19 @@ describe('connectToDevTools', () => {
     }
   });
 });
+
+describe('Agent.overrideSuspenseMilestone', () => {
+  it('warns without throwing when no renderer is registered for an id', () => {
+    const agent = global.agent;
+    const sendSpy = jest.spyOn(global.bridge, 'send');
+
+    expect(() =>
+      agent.overrideSuspenseMilestone({rendererID: 12345, suspendedSet: []}),
+    ).not.toThrow();
+
+    expect(global.consoleWarnMock).toHaveBeenCalledWith(
+      'Invalid renderer id "12345"',
+    );
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -790,7 +790,9 @@ export default class Agent extends EventEmitter<{
     const renderer = this._rendererInterfaces[
       rendererID as any
     ] as any as RendererInterface;
-    if (renderer.supportsTogglingSuspense) {
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}"`);
+    } else if (renderer.supportsTogglingSuspense) {
       renderer.overrideSuspenseMilestone(suspendedSet);
     }
   };


### PR DESCRIPTION
## Summary

`Agent.overrideSuspenseMilestone` indexed `_rendererInterfaces` directly, so a stale renderer ID from the front-end threw `Cannot read properties of undefined (reading 'supportsTogglingSuspense')` inside the Bridge's synchronous listener dispatch, which can also break later queued messages in the same tick. Warn and bail out instead, matching the other override handlers on this class.

## How did you test this change?

```
yarn test-build-devtools packages/react-devtools-shared/src/__tests__/backend-test.js -t overrideSuspenseMilestone
```

- with the fix reverted: fails with `TypeError: Cannot read properties of undefined (reading 'supportsTogglingSuspense')` at agent.js:793
- with the fix applied: passes; full file 2 passed, 2 total
- eslint clean; prettier clean; flow dom-node check: No errors!
