### PR TITLE
[react-devtools] Fix multi-rect decoding in suspense add debug logging

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -13,7 +13,11 @@ import {
   isPlainObject,
   printOperationsArray,
 } from 'react-devtools-shared/src/utils';
-import {TREE_OPERATION_APPLIED_ACTIVITY_SLICE_CHANGE} from 'react-devtools-shared/src/constants';
+import {
+  SUSPENSE_TREE_OPERATION_ADD,
+  TREE_OPERATION_APPLIED_ACTIVITY_SLICE_CHANGE,
+  TREE_OPERATION_REMOVE,
+} from 'react-devtools-shared/src/constants';
 import {stackToComponentLocations} from 'react-devtools-shared/src/devtools/utils';
 import {
   formatConsoleArguments,
@@ -567,6 +571,44 @@ function f() { }
         'Applied activity slice change to 42',
       );
       expect(log.mock.calls[0][0]).toContain('Reset applied activity slice');
+    });
+
+    it('should log every rect of an added suspense node', () => {
+      const name = 'Suspense';
+      const operations = [
+        1, // rendererID
+        1, // rootID
+        1 + name.length,
+        name.length,
+        ...name.split('').map(char => char.charCodeAt(0)),
+        SUSPENSE_TREE_OPERATION_ADD,
+        3, // fiberID
+        2, // parentID
+        1, // nameStringID -> "Suspense"
+        1, // isSuspended
+        2, // numRects
+        11,
+        22,
+        33,
+        44,
+        111,
+        222,
+        333,
+        444,
+
+        TREE_OPERATION_REMOVE,
+        1, // removeLength
+        5,
+      ];
+
+      printOperationsArray(operations);
+
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0][0]).toBe(
+        'operations for renderer:1 and root:1\n' +
+          '  Add suspense node 3 (Suspense,rects={[(11, 22, 33, 44), (111, 222, 333, 444)]}) under 2 suspended 1\n' +
+          '  Remove node 5',
+      );
     });
   });
 });

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -346,11 +346,10 @@ export function printOperationsArray(operations: Array<number>) {
         } else {
           rects = '[';
           for (let rectIndex = 0; rectIndex < numRects; rectIndex++) {
-            const offset = i + rectIndex * 4;
-            const x = operations[offset + 0];
-            const y = operations[offset + 1];
-            const width = operations[offset + 2];
-            const height = operations[offset + 3];
+            const x = operations[i];
+            const y = operations[i + 1];
+            const width = operations[i + 2];
+            const height = operations[i + 3];
 
             if (rectIndex > 0) {
               rects += ', ';


### PR DESCRIPTION
## Summary

The `__DEBUG__` suspense-add printer in `printOperationsArray` computed each rect offset as `i + rectIndex*4` while also advancing `i` by 4 per rect, so with more than one client rect every rect after the first was decoded from the wrong slots and printed garbage values or `undefined`. Read via `i` directly, matching the adjacent RESIZE case and the Store decoder. Parse position was never wrong, so only the logged text changes; the sole production caller is inside `__DEBUG__` in the legacy backend renderer.

## How did you test this change?

```
yarn test --build --project devtools packages/react-devtools-shared/src/__tests__/utils-test.js -t "should log every rect"
```

- before: second rect decoded as `(2, 1, 5, undefined)` from the next operation's bytes
- after: `(111, 222, 333, 444)` as encoded
- full file: 56 passed, 56 total
- eslint clean; prettier clean; flow dom-node check: No errors!
