### PR TITLE
React Compiler: move compiled function bodies into AST instead of cloning

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/program.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/program.rs
@@ -2581,7 +2581,7 @@ fn build_compiled_expression_matching_kind(
 /// Apply compiled functions back to the AST by replacing original function nodes
 /// with their compiled versions, inserting outlined functions, and adding imports.
 fn apply_compiled_functions(
-    compiled_fns: &[CompiledFnForReplacement],
+    compiled_fns: Vec<CompiledFnForReplacement>,
     program: &mut Program,
     context: &mut ProgramContext,
 ) {
@@ -2594,7 +2594,7 @@ fn apply_compiled_functions(
 
     // If gating is enabled, determine which functions are referenced before declaration
     let referenced_before_decl = if has_gating {
-        get_functions_referenced_before_declaration(program, compiled_fns)
+        get_functions_referenced_before_declaration(program, &compiled_fns)
     } else {
         FxHashSet::default()
     };
@@ -2629,15 +2629,23 @@ fn apply_compiled_functions(
     //   (matching TS pushContainer behavior)
     let mut outlined_decls: Vec<(Option<u32>, OriginalFnKind, FunctionDeclaration)> = Vec::new(); // (node_id, kind, decl)
 
+    // Computed before the loop below consumes `compiled_fns`.
+    let needs_memo_import = compiled_fns
+        .iter()
+        .any(|cf| cf.codegen_fn.memo_slots_used > 0);
+
     // Replace each compiled function in the AST
-    for (idx, compiled) in compiled_fns.iter().enumerate() {
+    for (idx, mut compiled) in compiled_fns.into_iter().enumerate() {
+        let fn_node_id = compiled.fn_node_id;
+        let original_kind = compiled.original_kind;
+
         // Collect outlined functions for this compiled function
-        for outlined in &compiled.codegen_fn.outlined {
+        for outlined in std::mem::take(&mut compiled.codegen_fn.outlined) {
             let outlined_decl = FunctionDeclaration {
                 base: BaseNode::typed("FunctionDeclaration"),
-                id: outlined.func.id.clone(),
-                params: outlined.func.params.clone(),
-                body: outlined.func.body.clone(),
+                id: outlined.func.id,
+                params: outlined.func.params,
+                body: outlined.func.body,
                 generator: outlined.func.generator,
                 is_async: outlined.func.is_async,
                 declare: None,
@@ -2647,23 +2655,22 @@ fn apply_compiled_functions(
                 component_declaration: false,
                 hook_declaration: false,
             };
-            outlined_decls.push((compiled.fn_node_id, compiled.original_kind, outlined_decl));
+            outlined_decls.push((fn_node_id, original_kind, outlined_decl));
         }
 
         if let Some(ref gating_config) = compiled.gating {
-            let is_ref_before_decl = compiled
-                .fn_node_id
-                .map_or(false, |nid| referenced_before_decl.contains(&nid));
+            let is_ref_before_decl =
+                fn_node_id.map_or(false, |nid| referenced_before_decl.contains(&nid));
 
-            if is_ref_before_decl && compiled.original_kind == OriginalFnKind::FunctionDeclaration {
+            if is_ref_before_decl && original_kind == OriginalFnKind::FunctionDeclaration {
                 // Use the hoisted function declaration gating pattern
-                apply_gated_function_hoisted(program, compiled, gating_config, context);
+                apply_gated_function_hoisted(program, &compiled, gating_config, context);
             } else {
                 // Use the conditional expression gating pattern
                 let original_expr = original_expressions[idx].clone();
                 apply_gated_function_conditional(
                     program,
-                    compiled,
+                    &compiled,
                     gating_config,
                     original_expr,
                     context,
@@ -2671,8 +2678,11 @@ fn apply_compiled_functions(
             }
         } else {
             // No gating: replace the function directly (original behavior)
-            if let Some(node_id) = compiled.fn_node_id {
-                let mut visitor = ReplaceFnVisitor { node_id, compiled };
+            if let Some(node_id) = fn_node_id {
+                let mut visitor = ReplaceFnVisitor {
+                    node_id,
+                    compiled: Some(compiled.codegen_fn),
+                };
                 walk_program_mut(&mut visitor, program);
             }
         }
@@ -2704,9 +2714,6 @@ fn apply_compiled_functions(
     }
 
     // Register the memo cache import and rename useMemoCache references.
-    let needs_memo_import = compiled_fns
-        .iter()
-        .any(|cf| cf.codegen_fn.memo_slots_used > 0);
     if needs_memo_import {
         let import_spec = context.add_memo_cache_import();
         let local_name = import_spec.name;
@@ -3613,20 +3620,32 @@ fn expr_has_fn_with_node_id(expr: &Expression, node_id: u32) -> bool {
 }
 
 /// Visitor that replaces a compiled function in the AST by matching `base.node_id`.
-struct ReplaceFnVisitor<'a> {
+struct ReplaceFnVisitor {
     node_id: u32,
-    compiled: &'a CompiledFnForReplacement,
+    /// Owned so the compiled body can be moved into the AST rather than deep
+    /// cloned. Exactly one arm below fires, because each returns `Stop` once it
+    /// matches `node_id`.
+    compiled: Option<CodegenFunction>,
 }
 
-impl MutVisitor for ReplaceFnVisitor<'_> {
+impl ReplaceFnVisitor {
+    fn take(&mut self) -> CodegenFunction {
+        self.compiled
+            .take()
+            .expect("ReplaceFnVisitor matched more than once; node ids must be unique")
+    }
+}
+
+impl MutVisitor for ReplaceFnVisitor {
     fn visit_statement(&mut self, stmt: &mut Statement) -> VisitResult {
         match stmt {
             Statement::FunctionDeclaration(f) if f.base.node_id == Some(self.node_id) => {
-                f.id = self.compiled.codegen_fn.id.clone();
-                f.params = self.compiled.codegen_fn.params.clone();
-                f.body = self.compiled.codegen_fn.body.clone();
-                f.generator = self.compiled.codegen_fn.generator;
-                f.is_async = self.compiled.codegen_fn.is_async;
+                let compiled = self.take();
+                f.id = compiled.id;
+                f.params = compiled.params;
+                f.body = compiled.body;
+                f.generator = compiled.generator;
+                f.is_async = compiled.is_async;
                 f.return_type = None;
                 f.type_parameters = None;
                 f.predicate = None;
@@ -3636,11 +3655,12 @@ impl MutVisitor for ReplaceFnVisitor<'_> {
             Statement::ExportDefaultDeclaration(export) => {
                 if let ExportDefaultDecl::FunctionDeclaration(f) = export.declaration.as_mut() {
                     if f.base.node_id == Some(self.node_id) {
-                        f.id = self.compiled.codegen_fn.id.clone();
-                        f.params = self.compiled.codegen_fn.params.clone();
-                        f.body = self.compiled.codegen_fn.body.clone();
-                        f.generator = self.compiled.codegen_fn.generator;
-                        f.is_async = self.compiled.codegen_fn.is_async;
+                        let compiled = self.take();
+                        f.id = compiled.id;
+                        f.params = compiled.params;
+                        f.body = compiled.body;
+                        f.generator = compiled.generator;
+                        f.is_async = compiled.is_async;
                         f.return_type = None;
                         f.type_parameters = None;
                         f.predicate = None;
@@ -3653,11 +3673,12 @@ impl MutVisitor for ReplaceFnVisitor<'_> {
                 if let Some(ref mut decl) = export.declaration {
                     if let Declaration::FunctionDeclaration(f) = decl.as_mut() {
                         if f.base.node_id == Some(self.node_id) {
-                            f.id = self.compiled.codegen_fn.id.clone();
-                            f.params = self.compiled.codegen_fn.params.clone();
-                            f.body = self.compiled.codegen_fn.body.clone();
-                            f.generator = self.compiled.codegen_fn.generator;
-                            f.is_async = self.compiled.codegen_fn.is_async;
+                            let compiled = self.take();
+                            f.id = compiled.id;
+                            f.params = compiled.params;
+                            f.body = compiled.body;
+                            f.generator = compiled.generator;
+                            f.is_async = compiled.is_async;
                             f.return_type = None;
                             f.type_parameters = None;
                             f.predicate = None;
@@ -3675,22 +3696,22 @@ impl MutVisitor for ReplaceFnVisitor<'_> {
     fn visit_expression(&mut self, expr: &mut Expression) -> VisitResult {
         match expr {
             Expression::FunctionExpression(f) if f.base.node_id == Some(self.node_id) => {
-                f.id = self.compiled.codegen_fn.id.clone();
-                f.params = self.compiled.codegen_fn.params.clone();
-                f.body = self.compiled.codegen_fn.body.clone();
-                f.generator = self.compiled.codegen_fn.generator;
-                f.is_async = self.compiled.codegen_fn.is_async;
+                let compiled = self.take();
+                f.id = compiled.id;
+                f.params = compiled.params;
+                f.body = compiled.body;
+                f.generator = compiled.generator;
+                f.is_async = compiled.is_async;
                 f.return_type = None;
                 f.type_parameters = None;
                 VisitResult::Stop
             }
             Expression::ArrowFunctionExpression(f) if f.base.node_id == Some(self.node_id) => {
-                f.params = self.compiled.codegen_fn.params.clone();
-                f.body = Box::new(ArrowFunctionBody::BlockStatement(
-                    self.compiled.codegen_fn.body.clone(),
-                ));
-                f.generator = self.compiled.codegen_fn.generator;
-                f.is_async = self.compiled.codegen_fn.is_async;
+                let compiled = self.take();
+                f.params = compiled.params;
+                f.body = Box::new(ArrowFunctionBody::BlockStatement(compiled.body));
+                f.generator = compiled.generator;
+                f.is_async = compiled.is_async;
                 f.expression = Some(false);
                 f.return_type = None;
                 f.type_parameters = None;
@@ -4018,7 +4039,7 @@ pub fn compile_program(mut file: File, scope: ScopeInfo, options: PluginOptions)
     }
 
     // Now we can mutate file.program
-    apply_compiled_functions(&replacements, &mut file.program, &mut context);
+    apply_compiled_functions(replacements, &mut file.program, &mut context);
 
     let timing_entries = context.timing.into_entries();
 


### PR DESCRIPTION
tl;dr reduces memory churn by 7.8%, allocations by 4.1%, wall time by ~4%

## Summary

When compiled functions are written back to the AST, `apply_compiled_functions` took a reference to a slice, and deep-cloned each compiled body out of it. In theTS version this step assigns references through Babel paths, which are essentially free. The Rust port translated that as `.clone()` for safety, deep-copying the entire codegen output for every compiled function.

Nothing needs these bodies after they are inserted, and the caller already owns the vector. So this takes `compiled_fns` by value and moves the data into the AST instead:

* `ReplaceFnVisitor` holds an `Option<CodegenFunction>` and moves it to whatever arm matches
* Outlined function declarations move their id+params+body out of `codegen_fn.outlined` rather than cloning them
* `needs_memo_import` is computed before the loop that consumes the vector. Only the computation moved; the block that registers the import stays where it was, so ordering and identifier numbering don't change.

This doesn't fully eliminate clones, just ones where it's easy to do a move instead.

## How did you test this change?

All compiler fixtures pass with byte-identical output
