### PR TITLE
[compiler] Load babel-jest from the workspace root in the Jest e2e transform

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/scripts/jest/makeTransform.ts
+++ b/compiler/packages/babel-plugin-react-compiler/scripts/jest/makeTransform.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import babelJest from 'babel-jest';
 import {
   validateEnvironmentConfig,
   EnvironmentConfig,
 } from 'babel-plugin-react-compiler';
 import {execSync} from 'child_process';
+import {createRequire} from 'module';
 
 import type {NodePath, Visitor} from '@babel/traverse';
 import type {CallExpression} from '@babel/types';
@@ -27,6 +27,16 @@ const forgetOptions: EnvironmentConfig = validateEnvironmentConfig({
   enableAssumeHooksFollowRulesOfReact: true,
 });
 const debugMode = process.env['DEBUG_FORGET_COMPILER'] != null;
+
+/*
+ * This package's `resolutions` pin @babel/core to the minimum supported
+ * version so that tests exercise the compiler against it. The transform's
+ * preset stack requires a modern @babel/core though, so babel-jest is loaded
+ * from the workspace root, which is outside the scope of that pin.
+ */
+const babelJest: (typeof import('babel-jest'))['default'] = createRequire(
+  `${__dirname}/../../../../package.json`,
+)('babel-jest').default;
 
 const compilerCacheKey = execSync(
   'yarn --silent --cwd ../.. hash packages/babel-plugin-react-compiler/dist',
@@ -96,13 +106,9 @@ module.exports = (useForget: boolean) => {
           ],
         },
       ],
-      targets: {
-        esmodules: true,
-      },
     } as any);
     /*
-     * typecast needed as DefinitelyTyped does not have updated Babel configs types yet
-     * (missing passPerPreset and targets).
+     * typecast needed as the Babel config types do not include passPerPreset.
      */
   }
 


### PR DESCRIPTION
## Summary

The compiler package's `resolutions` pin `@babel/core` to 7.2.0 so tests exercise the compiler against the minimum supported Babel version. babel-jest 30 loads the full Babel config during `getCacheKey`, and when babel-jest resolves inside this package's scope it gets the pinned 7.2.0, which rejects the transform's options because the pinned version does not know the `targets` option. `makeTransform.ts` now loads babel-jest through a `require` created from the workspace root, so the transform runs against the modern hoisted `@babel/core` like the rest of the workspace.

The inert `targets: {esmodules: true}` option is also dropped, since none of the presets in this stack (`@babel/preset-typescript`, `@babel/preset-react`, `@babel/plugin-transform-modules-commonjs`, and the inline plugin presets) consume it.

This prepares for the Jest 30 upgrade stacked on top.

## How did you test this change?

`yarn workspace babel-plugin-react-compiler jest` passes on this branch (Jest 29) and with the Jest 30 upgrade stacked on top: 15 suites, 43 tests.