### PR TITLE
[DOM] Copy `source` onto the synthetic toggle event

### DIFF
--- a/packages/react-dom-bindings/src/events/SyntheticEvent.js
+++ b/packages/react-dom-bindings/src/events/SyntheticEvent.js
@@ -609,6 +609,7 @@ const ToggleEventInterface: EventInterfaceType = {
   ...EventInterface,
   newState: 0,
   oldState: 0,
+  source: 0,
 };
 export const SyntheticToggleEvent: $FlowFixMe =
   createSyntheticEvent(ToggleEventInterface);

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -15,6 +15,7 @@ class ToggleEvent extends Event {
     super(type, eventInit);
     this.newState = eventInit.newState;
     this.oldState = eventInit.oldState;
+    this.source = eventInit.source;
   }
 }
 
@@ -622,5 +623,40 @@ describe('SimpleEventPlugin', function () {
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const event = onSubmit.mock.calls[0][0];
     expect(event.submitter).toBe(submitter);
+  });
+
+  it('includes the source in toggle events', async function () {
+    container = document.createElement('div');
+
+    const onToggle = jest.fn();
+    const root = ReactDOMClient.createRoot(container);
+    await act(() => {
+      root.render(
+        <>
+          <button popoverTarget="popover">Toggle popover</button>
+          <div id="popover" popover="" onToggle={onToggle}>
+            popover content
+          </div>
+        </>,
+      );
+    });
+
+    const source = container.querySelector('button');
+    const target = container.querySelector('#popover');
+    await act(() => {
+      target.dispatchEvent(
+        new ToggleEvent('toggle', {
+          bubbles: false,
+          cancelable: true,
+          oldState: 'closed',
+          newState: 'open',
+          source: source,
+        }),
+      );
+    });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    const event = onToggle.mock.calls[0][0];
+    expect(event.source).toBe(source);
   });
 });


### PR DESCRIPTION
## Summary

`ToggleEvent` carries a `source` property pointing at the control that opened or closed a popover, but `ToggleEventInterface` only lists `newState` and `oldState`, so the synthetic event never copies it. An `onToggle` handler reads `event.source` as `undefined` even when the native event has it.

Adding `source` to the interface copies it off the native event the same way `newState` and `oldState` are copied.

Fixes #37387

## How did you test this change?

Added a test to the SimpleEventPlugin suite that dispatches a `ToggleEvent` with a `source` and asserts the synthetic event exposes it. It fails on main and passes with the fix. Also ran `yarn test packages/react-dom/src/events`, `yarn lint`, `yarn prettier-check`, and `yarn flow dom-node`.
