### PR TITLE
fix: preserve act queue when re-entered during flush

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -195,6 +195,54 @@ function runActTests(render, unmount, rerender) {
       });
 
       // @gate __DEV__
+      it('keeps flushing when act is re-entered during the outer flush', () => {
+        let updateFromListener;
+
+        function App() {
+          const [open, setOpen] = React.useState(false);
+          const [fromEffect, setFromEffect] = React.useState(0);
+          const [fromListener, setFromListener] = React.useState(0);
+          updateFromListener = setFromListener;
+
+          React.useEffect(() => {
+            if (open) {
+              document.dispatchEvent(new Event('committed'));
+              setFromEffect(value => value + 1);
+            }
+          }, [open]);
+
+          return (
+            <button onClick={() => setOpen(true)}>
+              {`${open}:${fromEffect}:${fromListener}`}
+            </button>
+          );
+        }
+
+        act(() => {
+          render(<App />, container);
+        });
+
+        const handleCommitted = () => {
+          act(() => {
+            updateFromListener(value => value + 1);
+          });
+        };
+        document.addEventListener('committed', handleCommitted);
+
+        try {
+          act(() => {
+            container
+              .querySelector('button')
+              .dispatchEvent(new MouseEvent('click', {bubbles: true}));
+          });
+        } finally {
+          document.removeEventListener('committed', handleCommitted);
+        }
+
+        expect(container.textContent).toBe('true:1:1');
+      });
+
+      // @gate __DEV__
       it('warns if a setState is called outside of act(...)', () => {
         let setValue = null;
         function App() {

--- a/packages/react/src/ReactAct.js
+++ b/packages/react/src/ReactAct.js
@@ -137,8 +137,8 @@ export function act<T>(callback: () => T | Thenable<T>): Thenable<T> {
           thenable.then(
             returnValue => {
               popActScope(prevActQueue, prevActScopeDepth);
-              if (prevActScopeDepth === 0) {
-                // We're exiting the outermost `act` scope. Flush the queue.
+              if (prevActQueue === null) {
+                // This call created the queue. Flush it before yielding.
                 try {
                   flushActQueue(queue);
                   queueMacrotask(() =>
@@ -182,8 +182,8 @@ export function act<T>(callback: () => T | Thenable<T>): Thenable<T> {
       // The callback is not an async function. Exit the current
       // scope immediately.
       popActScope(prevActQueue, prevActScopeDepth);
-      if (prevActScopeDepth === 0) {
-        // We're exiting the outermost `act` scope. Flush the queue.
+      if (prevActQueue === null) {
+        // This call created the queue. Flush it before yielding.
         flushActQueue(queue);
 
         // If the queue is not empty, it implies that we intentionally yielded
@@ -234,8 +234,8 @@ export function act<T>(callback: () => T | Thenable<T>): Thenable<T> {
       return {
         then(resolve: T => mixed, reject: mixed => mixed) {
           didAwaitActCall = true;
-          if (prevActScopeDepth === 0) {
-            // If the `act` call is awaited, restore the queue we were
+          if (prevActQueue === null) {
+            // If the `act` call created the queue and is awaited, restore it
             // using before (see long comment above) so we can flush it.
             ReactSharedInternals.actQueue = queue;
             queueMacrotask(() =>


### PR DESCRIPTION
## Summary

Fixes #37374.

Re-entering `act()` while an outer queue is flushing can create a new queue even though the global scope depth still reflects the surrounding call. The exit paths used scope depth to decide whether to flush and restore that queue, so the re-entrant work could be left behind.

This uses the previous queue as the ownership signal: a call with no previous queue created the queue and is responsible for flushing it. The regression test dispatches an event from an effect, re-enters `act()` in the listener, and verifies both the listener and effect updates are flushed.

## How did you test this change?

- Added `keeps flushing when act is re-entered during the outer flush` to `ReactTestUtilsAct-test.js`.
- Ran `git diff --check`.
- The focused Jest run was not available locally because the dependency install could not reach the configured package registry; the new regression is included for CI.
