### PR TITLE
fix: defer Flight props freeze until references settle

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1031,6 +1031,59 @@ let initializingHandler: null | InitializationHandler = null;
 let initializingChunk: null | BlockedChunk<any> = null;
 let isInitializingDebugInfo: boolean = false;
 
+// A model can become renderable while another outlined reference still has a
+// write pending into the same props object. Keep the DEV freeze until the last
+// such write completes so fulfillReference never mutates frozen props.
+const pendingReferenceCounts: WeakMap<Object, number> = new WeakMap();
+const elementsWithPendingProps: WeakMap<Object, Array<any>> = new WeakMap();
+
+function trackPendingReference(parentObject: Object): void {
+  if (!__DEV__) {
+    return;
+  }
+  const count = pendingReferenceCounts.get(parentObject) || 0;
+  pendingReferenceCounts.set(parentObject, count + 1);
+}
+
+function freezeElementProps(element: any): void {
+  if (!__DEV__) {
+    return;
+  }
+  const props = element.props;
+  if ((pendingReferenceCounts.get(props) || 0) > 0) {
+    const elements = elementsWithPendingProps.get(props);
+    if (elements === undefined) {
+      elementsWithPendingProps.set(props, [element]);
+    } else {
+      elements.push(element);
+    }
+    return;
+  }
+  Object.freeze(props);
+}
+
+function resolvePendingReference(parentObject: Object): void {
+  if (!__DEV__) {
+    return;
+  }
+  const count = pendingReferenceCounts.get(parentObject);
+  if (count === undefined) {
+    return;
+  }
+  if (count > 1) {
+    pendingReferenceCounts.set(parentObject, count - 1);
+    return;
+  }
+  pendingReferenceCounts.delete(parentObject);
+  const elements = elementsWithPendingProps.get(parentObject);
+  if (elements !== undefined) {
+    elementsWithPendingProps.delete(parentObject);
+    for (let i = 0; i < elements.length; i++) {
+      freezeElementProps(elements[i]);
+    }
+  }
+}
+
 function initializeDebugChunk(
   response: Response,
   chunk: ResolvedModelChunk<any> | PendingChunk<any> | PendingWeakChunk<any>,
@@ -1395,7 +1448,7 @@ function initializeElement(
 
   // TODO: We should be freezing the element but currently, we might write into
   // _debugInfo later. We could move it into _store which remains mutable.
-  Object.freeze(element.props);
+  freezeElementProps(element);
 }
 
 function createElement(
@@ -1752,6 +1805,9 @@ function fulfillReference(
     if (key !== __PROTO__) {
       parentObject[key] = mappedValue;
     }
+    if (__DEV__) {
+      resolvePendingReference(parentObject);
+    }
 
     // If this is the root object for a model reference, where `handler.value`
     // is a stale `null`, the resolved value can be used directly.
@@ -1926,6 +1982,9 @@ function waitForReference<T>(
     path,
   };
   if (__DEV__) {
+    trackPendingReference(parentObject);
+  }
+  if (__DEV__) {
     reference.isDebug = isAwaitingDebugInfo;
   }
 
@@ -2006,6 +2065,9 @@ function loadServerReference<A: Iterable<any>, T>(
       errored: false,
     };
   }
+  if (__DEV__) {
+    trackPendingReference(parentObject);
+  }
 
   function fulfill(): void {
     let resolvedValue = requireModule(serverReference) as any;
@@ -2026,6 +2088,9 @@ function loadServerReference<A: Iterable<any>, T>(
 
     if (key !== __PROTO__) {
       parentObject[key] = resolvedValue;
+    }
+    if (__DEV__) {
+      resolvePendingReference(parentObject);
     }
 
     // If this is the root object for a model reference, where `handler.value`

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -421,6 +421,54 @@ describe('ReactFlightDOMBrowser', () => {
     expect(container.innerHTML).toBe('<div><span>12345</span>12345</div>');
   });
 
+  // @gate __DEV__
+  it('freezes element props after late deduped references resolve', async () => {
+    let resolveBlockedClientReference;
+    const Blocked = clientExports(
+      'resolved',
+      '41',
+      '/blocked.js',
+      new Promise(resolve => (resolveBlockedClientReference = resolve)),
+    );
+    const receivedProps = [];
+    const Client = clientExports(function Client(props) {
+      receivedProps.push(props);
+      return props.i18n.label;
+    });
+    const i18n = {label: 'shared', blocked: Blocked};
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(
+        <>
+          <Client i18n={i18n} />
+          <Client i18n={i18n} />
+        </>,
+        webpackMap,
+      ),
+    );
+
+    function ClientRoot({response}) {
+      return use(response);
+    }
+
+    const response = ReactServerDOMClient.createFromReadableStream(stream);
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(<ClientRoot response={response} />);
+    });
+    expect(container.innerHTML).toBe('');
+
+    await act(() => {
+      resolveBlockedClientReference();
+    });
+
+    expect(container.innerHTML).toBe('sharedshared');
+    expect(receivedProps).toHaveLength(2);
+    expect(receivedProps.every(Object.isFrozen)).toBe(true);
+  });
+
   it('should resolve deduped objects in nested children of blocked models', async () => {
     let resolveOuterClientComponentChunk;
     let resolveInnerClientComponentChunk;


### PR DESCRIPTION
## Summary

Fixes #37361.

The Flight client can initialize and freeze an element's props while an outlined reference still has a pending write into that same object. When the reference resolves, `fulfillReference()` then throws while assigning into frozen props.

This tracks outstanding writes per parent object in DEV. Element props are frozen immediately when there are no pending writes, or queued and frozen when the final write completes. Production behavior is unchanged, and the DEV mutation guard remains intact.

The regression passes one deduplicated prop object to two client elements, blocks a reference inside it, resolves that reference later, and verifies both rendering and the final frozen-props invariant.

## How did you test this change?

- Added `freezes element props after late deduped references resolve` to `ReactFlightDOMBrowser-test.js`.
- Ran `git diff --check`.
- The focused Jest run was not available locally because the dependency install could not reach the configured package registry; the new regression is included for CI.
