### PR TITLE
[DOM] Register error event when hydrating <embed>

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -3167,7 +3167,6 @@ export function hydrateProperties(
       break;
     case 'iframe':
     case 'object':
-    case 'embed':
       // We listen to this event in case to ensure emulated bubble
       // listeners still fire for the load event.
       listenToNonDelegatedEvent('load', domElement);
@@ -3185,6 +3184,7 @@ export function hydrateProperties(
       // listeners still fire for the error event.
       listenToNonDelegatedEvent('error', domElement);
       break;
+    case 'embed':
     case 'img':
     case 'image':
     case 'link':

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -633,6 +633,43 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
+  it('should dispatch load and error on a hydrated embed', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    try {
+      const ref = React.createRef();
+      const handleLoad = jest.fn();
+      const handleError = jest.fn();
+      const tree = (
+        <div>
+          <embed ref={ref} onLoad={handleLoad} onError={handleError} />
+        </div>
+      );
+      container.innerHTML = ReactDOMServer.renderToString(tree);
+      await act(() => {
+        ReactDOMClient.hydrateRoot(container, tree);
+      });
+      await act(() => {
+        ref.current.dispatchEvent(
+          new ProgressEvent('load', {
+            bubbles: false,
+          }),
+        );
+        ref.current.dispatchEvent(
+          new Event('error', {
+            bubbles: false,
+          }),
+        );
+      });
+
+      expect(handleLoad).toHaveBeenCalledTimes(1);
+      expect(handleError).toHaveBeenCalledTimes(1);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
   // Unlike browsers, we delegate media events.
   // (This doesn't make a lot of sense but it would be a breaking change not to.)
   it('should delegate media events even without a direct listener', async () => {


### PR DESCRIPTION
## Summary

`onError` on a hydrated `<embed>` never fires. The same element rendered with `createRoot` fires it, and `onLoad` works in both modes.

## Root cause

`error` and `load` don't bubble, so React only receives them through a per-element `listenToNonDelegatedEvent` call. #26501 made `setInitialProperties` register both `error` and `load` for `<embed>` (grouped with `source`/`link`, `ReactDOMComponent.js:1417`), but `hydrateProperties` still had the pre-#26501 grouping with `iframe`/`object`, which registers only `load` (`ReactDOMComponent.js:3168`). So a hydrated `<embed>` has no `error` listener and `onError` (and any ancestor's emulated-bubble `onError`) never dispatches.

## Fix

Move `case 'embed'` in `hydrateProperties` into the group that registers both `error` and `load`, matching the mount path.

Not changed here: the mount path also registers `load` for `<source>` while hydration registers only `error`. That difference dates to the same refactor; it can be aligned the same way if desired, but it's a separate surface so I left it out of this diff.

## How did you test this change?

Added a test that server-renders an `<embed>` with `onLoad`/`onError`, hydrates it, and dispatches both events. On `main` it fails:

```
expect(handleError).toHaveBeenCalledTimes(1)
Expected number of calls: 1
Received number of calls: 0
```

With the fix it passes. Also ran:

- `yarn test packages/react-dom/src/__tests__/ReactDOMEventListener-test.js` — 24 passed (also with `--prod` and `--release-channel=www-classic`)
- `yarn test` on ReactDOMEventPropagation, ReactServerRenderingHydration, ReactDOMHydrationDiff, ReactBrowserEventEmitter, ReactDOMServerIntegrationElements, ReactDOMServerPartialHydration — all passing except one pre-existing `[GATED, SHOULD FAIL]` failure in ReactDOMServerPartialHydration that reproduces identically on `main`
- `yarn flow dom-node`, `yarn linc`, `yarn prettier-check` — clean
