### PR TITLE
fix(eslint-plugin-react-hooks): ignore nested properties in TypeScript typeof queries

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -8041,6 +8041,42 @@ const testsTypescript = {
     },
     {
       code: normalizeIndent`
+        function MyComponent() {
+          const [foo, setFoo] = React.useState<{ bar: number }>({ bar: 42 });
+
+          React.useEffect(() => {
+            const square = (x: typeof foo.bar) => x * x;
+            setFoo((previous) => ({ ...previous, bar: square(previous.bar) }));
+          }, []);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const obj = { nested: { deep: { value: 1 } } };
+
+          React.useEffect(() => {
+            const val: typeof obj.nested.deep.value = 10;
+            console.log(val);
+          }, []);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function App() {
+          const foo = {x: {y: 1}};
+          React.useEffect(() => {
+            const bar = {y: 2};
+            const baz = bar as typeof foo.x;
+            console.log(baz);
+          }, []);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
         function App(props) {
           React.useEffect(() => {
             console.log(props.test);

--- a/packages/eslint-plugin-react-hooks/jest.config.js
+++ b/packages/eslint-plugin-react-hooks/jest.config.js
@@ -8,5 +8,7 @@ module.exports = {
   moduleNameMapper: {
     '^babel-plugin-react-compiler$':
       '<rootDir>/../../compiler/packages/babel-plugin-react-compiler/dist/index.js',
+    '^babel-plugin-react-compiler/(.*)$':
+      '<rootDir>/../../compiler/packages/babel-plugin-react-compiler/$1',
   },
 };

--- a/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
+++ b/packages/eslint-plugin-react-hooks/src/rules/ExhaustiveDeps.ts
@@ -548,10 +548,7 @@ const rule = {
             });
           }
 
-          if (
-            dependencyNode.parent?.type === 'TSTypeQuery' ||
-            dependencyNode.parent?.type === 'TSTypeReference'
-          ) {
+          if (isInsideTypeQuery(dependencyNode)) {
             continue;
           }
 
@@ -2133,6 +2130,38 @@ function getUnknownDependenciesMessage(reactiveHookName: string): string {
     `React Hook ${reactiveHookName} received a function whose dependencies ` +
     `are unknown. Pass an inline function instead.`
   );
+}
+
+function isInsideTypeQuery(node: Node): boolean {
+  let current: Node | null | undefined = node;
+  while (current != null) {
+    const parent: Node | null | undefined = current.parent;
+    if (parent == null) {
+      break;
+    }
+    if (
+      parent.type === 'TSTypeQuery' ||
+      parent.type === 'TSTypeReference' ||
+      // @ts-expect-error Flow-specific AST node type
+      parent.type === 'TypeofTypeAnnotation' ||
+      // @ts-expect-error Flow-specific AST node type
+      parent.type === 'GenericTypeAnnotation'
+    ) {
+      return true;
+    }
+    if (
+      parent.type === 'TSQualifiedName' ||
+      // @ts-expect-error Flow-specific AST node type
+      parent.type === 'QualifiedTypeIdentifier' ||
+      parent.type === 'MemberExpression' ||
+      parent.type === 'OptionalMemberExpression'
+    ) {
+      current = parent;
+    } else {
+      break;
+    }
+  }
+  return false;
 }
 
 export default rule;


### PR DESCRIPTION
## Summary
Fixes #27335

In TypeScript and Flow, accessing nested properties within a type query (e.g. `typeof foo.bar` or `typeof obj.nested.value`) creates intermediate `TSQualifiedName` or `MemberExpression` AST nodes, causing `exhaustive-deps` to incorrectly require the root identifier as a reactive dependency. This PR adds `isInsideTypeQuery()` to traverse qualified names up to enclosing type query declarations, ignoring compile-time type accesses while preserving runtime `typeof` checks.