### PR TITLE
[DOM] Unobserve fragment IntersectionObserver targets after exit

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3399,6 +3399,7 @@ FragmentInstance.prototype.unobserveUsing = function (
       unobserveChild,
       observer,
     );
+    unobservePendingChildren(this, observer);
   }
 };
 function unobserveChild(
@@ -3414,6 +3415,92 @@ function unobserveChild(
   const instance = getInstanceFromHostFiber<Instance>(child);
   observer.unobserve(instance);
   return false;
+}
+
+type PendingIntersectionUnobserve = {
+  fragmentInstance: FragmentInstanceType,
+  observer: IntersectionObserver,
+  instance: Instance,
+};
+
+let pendingIntersectionUnobserves: Array<PendingIntersectionUnobserve> = [];
+let intersectionUnobserveScheduled: boolean = false;
+
+function isIntersectionObserver(
+  observer: IntersectionObserver | ResizeObserver,
+): boolean {
+  // IntersectionObserver has rootMargin; ResizeObserver does not. Avoid
+  // instanceof so jsdom mocks and cross-realm observers still match.
+  return typeof (observer as any).rootMargin === 'string';
+}
+
+// A later commit can reinsert the same node before the post-paint unobserve
+// runs (Activity hidden → visible). Cancel so the flush does not drop it.
+function cancelPendingIntersectionUnobserve(
+  fragmentInstance: FragmentInstanceType,
+  observer: IntersectionObserver | ResizeObserver,
+  instance: Instance,
+): void {
+  let writeIdx = 0;
+  for (let i = 0; i < pendingIntersectionUnobserves.length; i++) {
+    const pending = pendingIntersectionUnobserves[i];
+    if (
+      pending.fragmentInstance !== fragmentInstance ||
+      pending.observer !== observer ||
+      pending.instance !== instance
+    ) {
+      pendingIntersectionUnobserves[writeIdx++] = pending;
+    }
+  }
+  pendingIntersectionUnobserves.length = writeIdx;
+}
+
+// unobserveUsing() only walks the children that are still mounted, so release
+// the deleted ones that are waiting for their exit record.
+function unobservePendingChildren(
+  fragmentInstance: FragmentInstanceType,
+  observer: IntersectionObserver | ResizeObserver,
+): void {
+  let writeIdx = 0;
+  for (let i = 0; i < pendingIntersectionUnobserves.length; i++) {
+    const pending = pendingIntersectionUnobserves[i];
+    if (
+      pending.fragmentInstance === fragmentInstance &&
+      pending.observer === observer
+    ) {
+      observer.unobserve(pending.instance);
+    } else {
+      pendingIntersectionUnobserves[writeIdx++] = pending;
+    }
+  }
+  pendingIntersectionUnobserves.length = writeIdx;
+}
+
+function schedulePendingIntersectionUnobserve(
+  fragmentInstance: FragmentInstanceType,
+  observer: IntersectionObserver,
+  instance: Instance,
+): void {
+  pendingIntersectionUnobserves.push({
+    fragmentInstance,
+    observer,
+    instance,
+  });
+  if (!intersectionUnobserveScheduled) {
+    intersectionUnobserveScheduled = true;
+    // Unobserving in this commit would cancel the record IntersectionObserver
+    // delivers for the now disconnected target. Wait until after paint so the
+    // exit fires first, then drop the observer's strong ref to the node.
+    requestPostPaintCallback(() => {
+      intersectionUnobserveScheduled = false;
+      const pending = pendingIntersectionUnobserves;
+      pendingIntersectionUnobserves = [];
+      for (let i = 0; i < pending.length; i++) {
+        const item = pending[i];
+        item.observer.unobserve(item.instance);
+      }
+    });
+  }
 }
 // $FlowFixMe[prop-missing]
 FragmentInstance.prototype.getClientRects = function (
@@ -3797,10 +3884,14 @@ export function commitNewChildToFragmentInstance(
     return;
   }
   const instance: InstanceWithFragmentHandles = childInstance as any;
-  if (fragmentInstance._observers !== null) {
-    fragmentInstance._observers.forEach(observer => {
+  const observers = fragmentInstance._observers;
+  if (observers !== null) {
+    const observerList = Array.from(observers);
+    for (let i = 0; i < observerList.length; i++) {
+      const observer = observerList[i];
+      cancelPendingIntersectionUnobserve(fragmentInstance, observer, instance);
       observer.observe(instance);
-    });
+    }
   }
   if (enableFragmentRefsInstanceHandles) {
     addFragmentHandleToInstance(instance, fragmentInstance);
@@ -3826,6 +3917,24 @@ export function deleteChildFromFragmentInstance(
     return;
   }
   const instance: InstanceWithFragmentHandles = childInstance as any;
+  const observers = fragmentInstance._observers;
+  if (observers !== null) {
+    const observerList = Array.from(observers);
+    for (let i = 0; i < observerList.length; i++) {
+      const observer = observerList[i];
+      if (isIntersectionObserver(observer)) {
+        // Stay observed until the next IntersectionObserver delivery so a
+        // disconnected target still gets an isIntersecting: false record.
+        schedulePendingIntersectionUnobserve(
+          fragmentInstance,
+          observer as any as IntersectionObserver,
+          instance,
+        );
+      } else {
+        observer.unobserve(instance);
+      }
+    }
+  }
   if (enableFragmentRefsInstanceHandles) {
     if (instance.reactFragments != null) {
       instance.reactFragments.delete(fragmentInstance);

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3886,12 +3886,10 @@ export function commitNewChildToFragmentInstance(
   const instance: InstanceWithFragmentHandles = childInstance as any;
   const observers = fragmentInstance._observers;
   if (observers !== null) {
-    const observerList = Array.from(observers);
-    for (let i = 0; i < observerList.length; i++) {
-      const observer = observerList[i];
+    observers.forEach(observer => {
       cancelPendingIntersectionUnobserve(fragmentInstance, observer, instance);
       observer.observe(instance);
-    }
+    });
   }
   if (enableFragmentRefsInstanceHandles) {
     addFragmentHandleToInstance(instance, fragmentInstance);
@@ -3919,9 +3917,7 @@ export function deleteChildFromFragmentInstance(
   const instance: InstanceWithFragmentHandles = childInstance as any;
   const observers = fragmentInstance._observers;
   if (observers !== null) {
-    const observerList = Array.from(observers);
-    for (let i = 0; i < observerList.length; i++) {
-      const observer = observerList[i];
+    observers.forEach(observer => {
       if (isIntersectionObserver(observer)) {
         // Stay observed until the next IntersectionObserver delivery so a
         // disconnected target still gets an isIntersecting: false record.
@@ -3933,7 +3929,7 @@ export function deleteChildFromFragmentInstance(
       } else {
         observer.unobserve(instance);
       }
-    }
+    });
   }
   if (enableFragmentRefsInstanceHandles) {
     if (instance.reactFragments != null) {

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1782,13 +1782,10 @@ describe('FragmentRefs', () => {
       // Install before requiring React so host config captures this rAF
       // (requestPostPaintCallback / delayed observer unobserve).
       rafCallbacks = [];
-      global.requestAnimationFrame = cb => {
+      jest.spyOn(global, 'requestAnimationFrame').mockImplementation(cb => {
         rafCallbacks.push(cb);
         return rafCallbacks.length;
-      };
-      if (typeof window === 'object') {
-        window.requestAnimationFrame = global.requestAnimationFrame;
-      }
+      });
       loadModules();
       intersectionObserverMock = mockIntersectionObserver();
 

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -25,31 +25,35 @@ let mockRangeClientRects;
 let assertConsoleErrorDev;
 let assertConsoleWarnDev;
 let assertLog;
+let rafCallbacks;
 
 function Wrapper({children}) {
   return children;
 }
 
+function loadModules() {
+  React = require('react');
+  Fragment = React.Fragment;
+  Activity = React.Activity;
+  ReactDOMClient = require('react-dom/client');
+  ReactDOM = require('react-dom');
+  createPortal = ReactDOM.createPortal;
+  act = require('internal-test-utils').act;
+  Scheduler = require('scheduler');
+  const IntersectionMocks = require('./utils/IntersectionMocks');
+  mockIntersectionObserver = IntersectionMocks.mockIntersectionObserver;
+  simulateIntersection = IntersectionMocks.simulateIntersection;
+  setClientRects = IntersectionMocks.setClientRects;
+  mockRangeClientRects = IntersectionMocks.mockRangeClientRects;
+  assertConsoleErrorDev = require('internal-test-utils').assertConsoleErrorDev;
+  assertConsoleWarnDev = require('internal-test-utils').assertConsoleWarnDev;
+  assertLog = require('internal-test-utils').assertLog;
+}
+
 describe('FragmentRefs', () => {
   beforeEach(() => {
     jest.resetModules();
-    React = require('react');
-    Fragment = React.Fragment;
-    Activity = React.Activity;
-    ReactDOMClient = require('react-dom/client');
-    ReactDOM = require('react-dom');
-    createPortal = ReactDOM.createPortal;
-    act = require('internal-test-utils').act;
-    Scheduler = require('scheduler');
-    const IntersectionMocks = require('./utils/IntersectionMocks');
-    mockIntersectionObserver = IntersectionMocks.mockIntersectionObserver;
-    simulateIntersection = IntersectionMocks.simulateIntersection;
-    setClientRects = IntersectionMocks.setClientRects;
-    mockRangeClientRects = IntersectionMocks.mockRangeClientRects;
-    assertConsoleErrorDev =
-      require('internal-test-utils').assertConsoleErrorDev;
-    assertConsoleWarnDev = require('internal-test-utils').assertConsoleWarnDev;
-    assertLog = require('internal-test-utils').assertLog;
+    loadModules();
 
     container = document.createElement('div');
     document.body.innerHTML = '';
@@ -1754,8 +1758,43 @@ describe('FragmentRefs', () => {
   });
 
   describe('observers', () => {
+    let intersectionObserverMock;
+
+    function observedIds() {
+      return intersectionObserverMock.observedTargets.map(node => node.id);
+    }
+
+    function flushPostPaintCallbacks() {
+      const first = rafCallbacks.slice();
+      rafCallbacks.length = 0;
+      for (let i = 0; i < first.length; i++) {
+        first[i](0);
+      }
+      const second = rafCallbacks.slice();
+      rafCallbacks.length = 0;
+      for (let i = 0; i < second.length; i++) {
+        second[i](0);
+      }
+    }
+
     beforeEach(() => {
-      mockIntersectionObserver();
+      jest.resetModules();
+      // Install before requiring React so host config captures this rAF
+      // (requestPostPaintCallback / delayed observer unobserve).
+      rafCallbacks = [];
+      global.requestAnimationFrame = cb => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      };
+      if (typeof window === 'object') {
+        window.requestAnimationFrame = global.requestAnimationFrame;
+      }
+      loadModules();
+      intersectionObserverMock = mockIntersectionObserver();
+
+      container = document.createElement('div');
+      document.body.innerHTML = '';
+      document.body.appendChild(container);
     });
 
     // @gate enableFragmentRefs
@@ -1817,6 +1856,190 @@ describe('FragmentRefs', () => {
       await act(() => root.render(null));
       simulateAllChildrenIntersecting();
       expect(logs).toEqual([]);
+    });
+
+    // @gate enableFragmentRefs
+    it('keeps a removed child observed until after the intersection exit, then unobserves it', async () => {
+      const logs = [];
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          logs.push({id: entry.target.id, ratio: entry.intersectionRatio});
+        });
+      });
+      const fragmentRef = React.createRef();
+      function Test({showB}) {
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(observer);
+        }, []);
+        return (
+          <div id="parent">
+            <React.Fragment ref={fragmentRef}>
+              <div id="childA">A</div>
+              {showB && <div id="childB">B</div>}
+            </React.Fragment>
+          </div>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test showB={true} />));
+      const childA = container.querySelector('#childA');
+      const childB = container.querySelector('#childB');
+      expect(observedIds()).toEqual(['childA', 'childB']);
+
+      await act(() => root.render(<Test showB={false} />));
+      // Still observed so IntersectionObserver can deliver isIntersecting: false.
+      expect(observedIds()).toEqual(['childA', 'childB']);
+      expect(childB.isConnected).toBe(false);
+
+      simulateIntersection(
+        [childA, {y: 0, x: 0, width: 1, height: 1}, 1],
+        [childB, {y: 0, x: 0, width: 0, height: 0}, 0],
+      );
+      expect(logs).toEqual([
+        {id: 'childA', ratio: 1},
+        {id: 'childB', ratio: 0},
+      ]);
+
+      flushPostPaintCallbacks();
+      expect(observedIds()).toEqual(['childA']);
+    });
+
+    // @gate enableFragmentRefs
+    it('unobserveUsing() releases deleted children that were waiting for an exit record', async () => {
+      const observer = new IntersectionObserver(() => {});
+      const fragmentRef = React.createRef();
+      function Test({showB}) {
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(observer);
+        }, []);
+        return (
+          <React.Fragment ref={fragmentRef}>
+            <div id="childA">A</div>
+            {showB && <div id="childB">B</div>}
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test showB={true} />));
+
+      await act(() => root.render(<Test showB={false} />));
+      expect(observedIds()).toEqual(['childA', 'childB']);
+
+      fragmentRef.current.unobserveUsing(observer);
+      expect(observedIds()).toEqual([]);
+    });
+
+    // @gate enableFragmentRefs
+    it('unobserves ResizeObserver targets as soon as a child is deleted', async () => {
+      const observedTargets = [];
+      const resizeObserver = {
+        observe(target) {
+          observedTargets.push(target);
+        },
+        unobserve(target) {
+          const index = observedTargets.indexOf(target);
+          if (index >= 0) {
+            observedTargets.splice(index, 1);
+          }
+        },
+      };
+      const fragmentRef = React.createRef();
+      function Test({showB}) {
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(resizeObserver);
+        }, []);
+        return (
+          <React.Fragment ref={fragmentRef}>
+            <div id="childA">A</div>
+            {showB && <div id="childB">B</div>}
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test showB={true} />));
+      expect(observedTargets.map(node => node.id)).toEqual([
+        'childA',
+        'childB',
+      ]);
+
+      await act(() => root.render(<Test showB={false} />));
+      expect(observedTargets.map(node => node.id)).toEqual(['childA']);
+    });
+
+    // @gate enableFragmentRefs
+    it('unobserves a replaced child after post-paint and keeps the new child observed', async () => {
+      const observer = new IntersectionObserver(() => {});
+      const fragmentRef = React.createRef();
+      const childRef = React.createRef();
+      function Test({showChild}) {
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(observer);
+        }, []);
+        return (
+          <React.Fragment ref={fragmentRef}>
+            {showChild && <div id="child" ref={childRef} />}
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test showChild={true} />));
+      const firstChild = childRef.current;
+      expect(observedIds()).toEqual(['child']);
+
+      await act(() => root.render(<Test showChild={false} />));
+      expect(observedIds()).toEqual(['child']);
+      expect(intersectionObserverMock.observedTargets[0]).toBe(firstChild);
+
+      await act(() => root.render(<Test showChild={true} />));
+      const secondChild = childRef.current;
+      expect(secondChild).not.toBe(firstChild);
+      expect(intersectionObserverMock.observedTargets.length).toBe(2);
+      expect(intersectionObserverMock.observedTargets[0]).toBe(firstChild);
+      expect(intersectionObserverMock.observedTargets[1]).toBe(secondChild);
+
+      flushPostPaintCallbacks();
+      expect(intersectionObserverMock.observedTargets.length).toBe(1);
+      expect(intersectionObserverMock.observedTargets[0]).toBe(secondChild);
+    });
+
+    // @gate enableFragmentRefs
+    it('keeps a child observed if Activity shows it again before the delayed unobserve', async () => {
+      const observer = new IntersectionObserver(() => {});
+      const fragmentRef = React.createRef();
+      function Test({mode}) {
+        React.useEffect(() => {
+          fragmentRef.current.observeUsing(observer);
+        }, []);
+        return (
+          <React.Fragment ref={fragmentRef}>
+            <Activity mode={mode}>
+              <div id="child" />
+            </Activity>
+          </React.Fragment>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<Test mode="visible" />));
+      const child = container.querySelector('#child');
+      expect(observedIds()).toEqual(['child']);
+
+      await act(() => root.render(<Test mode="hidden" />));
+      // Same node, still observed so the exit record can fire.
+      expect(container.querySelector('#child')).toBe(child);
+      expect(observedIds()).toEqual(['child']);
+
+      // A second commit before post-paint reinserts the same instance.
+      await act(() => root.render(<Test mode="visible" />));
+      expect(container.querySelector('#child')).toBe(child);
+      expect(observedIds()).toEqual(['child']);
+
+      flushPostPaintCallbacks();
+      expect(observedIds()).toEqual(['child']);
     });
 
     // @gate enableFragmentRefs

--- a/packages/react-dom/src/__tests__/utils/IntersectionMocks.js
+++ b/packages/react-dom/src/__tests__/utils/IntersectionMocks.js
@@ -19,6 +19,9 @@ export function mockIntersectionObserver() {
 
   class IntersectionObserver {
     constructor() {
+      this.root = null;
+      this.rootMargin = '0px';
+      this.thresholds = [0];
       intersectionObserverMock.callback = arguments[0];
     }
 
@@ -28,7 +31,10 @@ export function mockIntersectionObserver() {
     }
 
     observe(target) {
-      intersectionObserverMock.observedTargets.push(target);
+      // Match the spec: observing an already-observed target is a no-op.
+      if (intersectionObserverMock.observedTargets.indexOf(target) === -1) {
+        intersectionObserverMock.observedTargets.push(target);
+      }
     }
 
     unobserve(target) {


### PR DESCRIPTION
Fragment IntersectionObserver targets used to stay observed after a child was removed so the exit record (isIntersecting: false) could still fire, but that left the observer holding detached nodes. We now unobserve ResizeObserver targets immediately, and delay IntersectionObserver unobserve until after paint so the exit still lands, then drop the strong ref.

If the same node is reinserted before that flush, we cancel the pending unobserve so a later cleanup does not detach a child that’s still visible.

Closes https://github.com/react/react/pull/37452/
Closes https://github.com/react/react/pull/37302
Fixes https://github.com/react/react/issues/37451