### PR TITLE
Fix React Refresh stale root scheduling

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -274,6 +274,7 @@ export function performReactRefresh(): RefreshUpdate | null {
       }
       if (!failedRoots.has(root)) {
         // No longer failed.
+        return;
       }
       if (rootElements === null) {
         return;
@@ -301,6 +302,7 @@ export function performReactRefresh(): RefreshUpdate | null {
       }
       if (!mountedRoots.has(root)) {
         // No longer mounted.
+        return;
       }
       try {
         helpers.scheduleRefresh(root, update);

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -3949,6 +3949,102 @@ describe('ReactFresh', () => {
     }
   });
 
+  it('skips roots that leave a refresh snapshot while another root is scheduled', () => {
+    if (__DEV__) {
+      const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      const scheduledRoots = [];
+      const refreshedRoots = [];
+      const rootA = {
+        current: {
+          alternate: null,
+          memoizedState: {element: 'A'},
+        },
+      };
+      const rootB = {
+        current: {
+          alternate: null,
+          memoizedState: {element: 'B'},
+        },
+      };
+
+      const rendererID = hook.inject({
+        scheduleRoot(fakeRoot) {
+          scheduledRoots.push(fakeRoot);
+          if (fakeRoot === rootA) {
+            rootB.current = {
+              alternate: rootB.current,
+              memoizedState: {element: 'B'},
+            };
+            hook.onCommitFiberRoot(rendererID, rootB, null, false);
+          }
+        },
+        scheduleRefresh(fakeRoot) {
+          refreshedRoots.push(fakeRoot);
+          if (fakeRoot === rootA) {
+            hook.onScheduleFiberRoot(rendererID, rootB, null);
+            rootB.current = {
+              alternate: rootB.current,
+              memoizedState: {element: null},
+            };
+            hook.onCommitFiberRoot(rendererID, rootB, null, false);
+          }
+        },
+        setRefreshHandler() {},
+      });
+
+      hook.onScheduleFiberRoot(rendererID, rootA, 'A');
+      hook.onCommitFiberRoot(rendererID, rootA, null, false);
+      hook.onScheduleFiberRoot(rendererID, rootB, 'B');
+      hook.onCommitFiberRoot(rendererID, rootB, null, false);
+
+      rootA.current = {
+        alternate: rootA.current,
+        memoizedState: {element: null},
+      };
+      hook.onCommitFiberRoot(rendererID, rootA, null, true);
+      rootB.current = {
+        alternate: rootB.current,
+        memoizedState: {element: null},
+      };
+      hook.onCommitFiberRoot(rendererID, rootB, null, true);
+
+      const ComponentV1 = () => {};
+      const ComponentV2 = () => {};
+      $RefreshReg$(ComponentV1, 'Component');
+      $RefreshReg$(ComponentV2, 'Component');
+      ReactFreshRuntime.performReactRefresh();
+
+      expect(scheduledRoots).toEqual([rootA]);
+
+      hook.onScheduleFiberRoot(rendererID, rootB, null);
+      rootB.current = {
+        alternate: rootB.current,
+        memoizedState: {element: null},
+      };
+      hook.onCommitFiberRoot(rendererID, rootB, null, false);
+      hook.onScheduleFiberRoot(rendererID, rootA, null);
+
+      rootA.current = {
+        alternate: null,
+        memoizedState: {element: 'A'},
+      };
+      rootB.current = {
+        alternate: null,
+        memoizedState: {element: 'B'},
+      };
+      hook.onScheduleFiberRoot(rendererID, rootA, 'A');
+      hook.onCommitFiberRoot(rendererID, rootA, null, false);
+      hook.onScheduleFiberRoot(rendererID, rootB, 'B');
+      hook.onCommitFiberRoot(rendererID, rootB, null, false);
+
+      const ComponentV3 = () => {};
+      $RefreshReg$(ComponentV3, 'Component');
+      ReactFreshRuntime.performReactRefresh();
+
+      expect(refreshedRoots).toEqual([rootA]);
+    }
+  });
+
   it('remounts classes on every edit', async () => {
     if (__DEV__) {
       const HelloV1 = await render(() => {


### PR DESCRIPTION
## Summary

- Stop scheduling failed roots that recovered after the refresh snapshot was captured.
- Stop refreshing mounted roots that were intentionally unmounted during the same refresh pass.
- Add regressions covering both snapshot-mutation paths.

## Breaking changes

None. Roots that no longer belong to the relevant live set are now skipped as the existing guards and comments intend.

## Verification

- Full ReactFresh suite: 68 tests passed.
- Changed-source `yarn linc` and `git diff --check` passed.

Fixes #37409
