### PR TITLE
Expose renderers from the React Refresh fallback hook

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -447,10 +447,15 @@ export function injectIntoGlobalHook(globalObject: any): void {
       // Note that in this case it's important that renderer code runs *after* this method call.
       // Otherwise, the renderer will think that there is no global hook, and won't do the injection.
       let nextID = 0;
+      const renderers = new Map();
       globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook = {
-        renderers: new Map(),
+        renderers,
         supportsFiber: true,
-        inject: injected => nextID++,
+        inject: injected => {
+          const id = nextID++;
+          renderers.set(id, injected);
+          return id;
+        },
         onScheduleFiberRoot: (
           id: number,
           root: FiberRoot,

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -4566,6 +4566,48 @@ describe('ReactFresh', () => {
     };
   }
 
+  it('exposes renderers injected into the synthetic DevTools hook', () => {
+    if (__DEV__) {
+      delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      jest.resetModules();
+      const firstRuntime = require('react-refresh/runtime');
+      firstRuntime.injectIntoGlobalHook(global);
+
+      const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      const renderer = {
+        scheduleRefresh: jest.fn(),
+        scheduleRoot: jest.fn(),
+        setRefreshHandler: jest.fn(),
+      };
+      const rendererID = hook.inject(renderer);
+
+      expect(hook.renderers.get(rendererID)).toBe(renderer);
+
+      jest.resetModules();
+      const secondRuntime = require('react-refresh/runtime');
+      secondRuntime.injectIntoGlobalHook(global);
+
+      const fakeRoot = {
+        current: {
+          alternate: null,
+          memoizedState: {element: 'mounted'},
+        },
+      };
+      hook.onCommitFiberRoot(rendererID, fakeRoot, null, false);
+
+      const ComponentV1 = () => {};
+      const ComponentV2 = () => {};
+      secondRuntime.register(ComponentV1, 'Component');
+      secondRuntime.register(ComponentV2, 'Component');
+      secondRuntime.performReactRefresh();
+
+      expect(renderer.scheduleRefresh).toHaveBeenCalledWith(
+        fakeRoot,
+        expect.any(Object),
+      );
+    }
+  });
+
   // This simulates the scenario in https://github.com/facebook/react/issues/17626
   it('can inject the runtime after the renderer executes', async () => {
     if (__DEV__) {


### PR DESCRIPTION
## Summary

- Store injected renderers in the fallback DevTools hook's public `renderers` map.
- Let a subsequently loaded React Refresh runtime discover already injected renderer helpers.
- Add a regression that reloads the runtime and verifies refresh scheduling continues.

## Breaking changes

None. The synthetic hook now implements the renderer registry it already exposes.

## Verification

- Full ReactFresh suite: 68 tests passed.
- Changed-source `yarn linc` and `git diff --check` passed.

Fixes #37410
