### PR TITLE
Match compiler suppression rules exactly

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
@@ -90,7 +90,9 @@ export function findProgramSuppressions(
   let disablePattern: RegExp | null = null;
   let enablePattern: RegExp | null = null;
   if (ruleNames != null && ruleNames.length !== 0) {
-    const rulePattern = `(${ruleNames.join('|')})`;
+    const rulePattern = `(${ruleNames
+      .map(ruleName => ruleName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      .join('|')})(?=[\\s,]|$)`;
     disableNextLinePattern = new RegExp(
       `eslint-disable-next-line ${rulePattern}`,
     );

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/SuppressionRules-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/SuppressionRules-test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {parse} from '@babel/parser';
+
+import {findProgramSuppressions} from '../Entrypoint/Suppression';
+
+describe('ESLint suppression rule matching', () => {
+  function findSuppressions(comment: string, ruleName: string) {
+    const ast = parse(`// ${comment}\n`);
+    return findProgramSuppressions(ast.comments ?? [], [ruleName], false);
+  }
+
+  it('does not match a longer rule name with the configured rule as a prefix', () => {
+    expect(
+      findSuppressions(
+        'eslint-disable-next-line react-hooks/rules-of-hooks-extra',
+        'react-hooks/rules-of-hooks',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('treats regular expression characters in rule names literally', () => {
+    expect(
+      findSuppressions(
+        'eslint-disable-next-line my-plugin/reactXrule',
+        'my-plugin/react.rule',
+      ),
+    ).toHaveLength(0);
+    expect(
+      findSuppressions(
+        'eslint-disable-next-line my-plugin/react.rule',
+        'my-plugin/react.rule',
+      ),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Escape configured ESLint rule names before building suppression patterns.
- Require a rule-list separator or comment end after each match.
- Add regressions for prefix collisions and regular-expression punctuation.

## Breaking changes

None. Only exact configured rule names now create compiler suppression ranges.

## Verification

- Focused suppression-rule suite: 2 tests passed.
- Compiler source lint, Prettier, and `git diff --check` passed.
- The full compiler workspace build is locally blocked before compilation because esbuild discovers an unrelated ancestor `/Users/Oskar/.pnp.cjs`; no build success is claimed.

Fixes #37413
