### PR TITLE
Fix ReactDOM prop ownership checks

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -64,6 +64,7 @@ import {validateProperties as validateUnknownProperties} from '../shared/ReactDO
 import sanitizeURL from '../shared/sanitizeURL';
 
 import noop from 'shared/noop';
+import hasOwnProperty from 'shared/hasOwnProperty';
 
 import {trackHostMutation} from 'react-reconciler/src/ReactFiberMutationTracking';
 
@@ -1142,7 +1143,7 @@ export function setInitialProperties(
       let hasSrc = false;
       let hasSrcSet = false;
       for (const propKey in props) {
-        if (!props.hasOwnProperty(propKey)) {
+        if (!hasOwnProperty.call(props, propKey)) {
           continue;
         }
         const propValue = props[propKey];
@@ -1193,7 +1194,7 @@ export function setInitialProperties(
       let checked = null;
       let defaultChecked = null;
       for (const propKey in props) {
-        if (!props.hasOwnProperty(propKey)) {
+        if (!hasOwnProperty.call(props, propKey)) {
           continue;
         }
         const propValue = props[propKey];
@@ -1266,7 +1267,7 @@ export function setInitialProperties(
       let defaultValue = null;
       let multiple = null;
       for (const propKey in props) {
-        if (!props.hasOwnProperty(propKey)) {
+        if (!hasOwnProperty.call(props, propKey)) {
           continue;
         }
         const propValue = props[propKey];
@@ -1310,7 +1311,7 @@ export function setInitialProperties(
       let defaultValue = null;
       let children = null;
       for (const propKey in props) {
-        if (!props.hasOwnProperty(propKey)) {
+        if (!hasOwnProperty.call(props, propKey)) {
           continue;
         }
         const propValue = props[propKey];
@@ -1355,7 +1356,7 @@ export function setInitialProperties(
     case 'option': {
       validateOptionProps(domElement, props);
       for (const propKey in props) {
-        if (!props.hasOwnProperty(propKey)) {
+        if (!hasOwnProperty.call(props, propKey)) {
           continue;
         }
         const propValue = props[propKey];
@@ -1435,7 +1436,7 @@ export function setInitialProperties(
     case 'menuitem': {
       // Void elements
       for (const propKey in props) {
-        if (!props.hasOwnProperty(propKey)) {
+        if (!hasOwnProperty.call(props, propKey)) {
           continue;
         }
         const propValue = props[propKey];
@@ -1462,7 +1463,7 @@ export function setInitialProperties(
     default: {
       if (isCustomElement(tag, props)) {
         for (const propKey in props) {
-          if (!props.hasOwnProperty(propKey)) {
+          if (!hasOwnProperty.call(props, propKey)) {
             continue;
           }
           const propValue = props[propKey];
@@ -1484,7 +1485,7 @@ export function setInitialProperties(
   }
 
   for (const propKey in props) {
-    if (!props.hasOwnProperty(propKey)) {
+    if (!hasOwnProperty.call(props, propKey)) {
       continue;
     }
     const propValue = props[propKey];
@@ -1509,7 +1510,7 @@ export function clearSingletonProperties(
   // body, so they always use this generic path.
   for (const propKey in props) {
     const propValue = props[propKey];
-    if (props.hasOwnProperty(propKey) && propValue != null) {
+    if (hasOwnProperty.call(props, propKey) && propValue != null) {
       setProp(domElement, tag, propKey, null, emptyProps, propValue);
     }
   }
@@ -1547,7 +1548,7 @@ export function updateProperties(
       let defaultChecked = null;
       for (const propKey in lastProps) {
         const lastProp = lastProps[propKey];
-        if (lastProps.hasOwnProperty(propKey) && lastProp != null) {
+        if (hasOwnProperty.call(lastProps, propKey) && lastProp != null) {
           switch (propKey) {
             case 'checked': {
               break;
@@ -1562,7 +1563,7 @@ export function updateProperties(
             // defaultChecked and defaultValue are ignored by setProp
             // Fallthrough
             default: {
-              if (!nextProps.hasOwnProperty(propKey))
+              if (!hasOwnProperty.call(nextProps, propKey))
                 setProp(domElement, tag, propKey, null, nextProps, lastProp);
             }
           }
@@ -1572,7 +1573,7 @@ export function updateProperties(
         const nextProp = nextProps[propKey];
         const lastProp = lastProps[propKey];
         if (
-          nextProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(nextProps, propKey) &&
           (nextProp != null || lastProp != null)
         ) {
           switch (propKey) {
@@ -1705,7 +1706,7 @@ export function updateProperties(
       let wasMultiple = null;
       for (const propKey in lastProps) {
         const lastProp = lastProps[propKey];
-        if (lastProps.hasOwnProperty(propKey) && lastProp != null) {
+        if (hasOwnProperty.call(lastProps, propKey) && lastProp != null) {
           switch (propKey) {
             case 'value': {
               // This is handled by updateWrapper below.
@@ -1718,7 +1719,7 @@ export function updateProperties(
             }
             // Fallthrough
             default: {
-              if (!nextProps.hasOwnProperty(propKey)) {
+              if (!hasOwnProperty.call(nextProps, propKey)) {
                 setProp(domElement, tag, propKey, null, nextProps, lastProp);
               }
             }
@@ -1729,7 +1730,7 @@ export function updateProperties(
         const nextProp = nextProps[propKey];
         const lastProp = lastProps[propKey];
         if (
-          nextProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(nextProps, propKey) &&
           (nextProp != null || lastProp != null)
         ) {
           switch (propKey) {
@@ -1781,9 +1782,9 @@ export function updateProperties(
       for (const propKey in lastProps) {
         const lastProp = lastProps[propKey];
         if (
-          lastProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(lastProps, propKey) &&
           lastProp != null &&
-          !nextProps.hasOwnProperty(propKey)
+          !hasOwnProperty.call(nextProps, propKey)
         ) {
           switch (propKey) {
             case 'value': {
@@ -1805,7 +1806,7 @@ export function updateProperties(
         const nextProp = nextProps[propKey];
         const lastProp = lastProps[propKey];
         if (
-          nextProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(nextProps, propKey) &&
           (nextProp != null || lastProp != null)
         ) {
           switch (propKey) {
@@ -1858,9 +1859,9 @@ export function updateProperties(
       for (const propKey in lastProps) {
         const lastProp = lastProps[propKey];
         if (
-          lastProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(lastProps, propKey) &&
           lastProp != null &&
-          !nextProps.hasOwnProperty(propKey)
+          !hasOwnProperty.call(nextProps, propKey)
         ) {
           switch (propKey) {
             case 'selected': {
@@ -1878,7 +1879,7 @@ export function updateProperties(
         const nextProp = nextProps[propKey];
         const lastProp = lastProps[propKey];
         if (
-          nextProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(nextProps, propKey) &&
           nextProp !== lastProp &&
           (nextProp != null || lastProp != null)
         ) {
@@ -1921,9 +1922,9 @@ export function updateProperties(
       for (const propKey in lastProps) {
         const lastProp = lastProps[propKey];
         if (
-          lastProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(lastProps, propKey) &&
           lastProp != null &&
-          !nextProps.hasOwnProperty(propKey)
+          !hasOwnProperty.call(nextProps, propKey)
         ) {
           setProp(domElement, tag, propKey, null, nextProps, lastProp);
         }
@@ -1932,7 +1933,7 @@ export function updateProperties(
         const nextProp = nextProps[propKey];
         const lastProp = lastProps[propKey];
         if (
-          nextProps.hasOwnProperty(propKey) &&
+          hasOwnProperty.call(nextProps, propKey) &&
           nextProp !== lastProp &&
           (nextProp != null || lastProp != null)
         ) {
@@ -1962,9 +1963,9 @@ export function updateProperties(
         for (const propKey in lastProps) {
           const lastProp = lastProps[propKey];
           if (
-            lastProps.hasOwnProperty(propKey) &&
+            hasOwnProperty.call(lastProps, propKey) &&
             lastProp !== undefined &&
-            !nextProps.hasOwnProperty(propKey)
+            !hasOwnProperty.call(nextProps, propKey)
           ) {
             setPropOnCustomElement(
               domElement,
@@ -1980,7 +1981,7 @@ export function updateProperties(
           const nextProp = nextProps[propKey];
           const lastProp = lastProps[propKey];
           if (
-            nextProps.hasOwnProperty(propKey) &&
+            hasOwnProperty.call(nextProps, propKey) &&
             nextProp !== lastProp &&
             (nextProp !== undefined || lastProp !== undefined)
           ) {
@@ -2002,9 +2003,9 @@ export function updateProperties(
   for (const propKey in lastProps) {
     const lastProp = lastProps[propKey];
     if (
-      lastProps.hasOwnProperty(propKey) &&
+      hasOwnProperty.call(lastProps, propKey) &&
       lastProp != null &&
-      !nextProps.hasOwnProperty(propKey)
+      !hasOwnProperty.call(nextProps, propKey)
     ) {
       setProp(domElement, tag, propKey, null, nextProps, lastProp);
     }
@@ -2013,7 +2014,7 @@ export function updateProperties(
     const nextProp = nextProps[propKey];
     const lastProp = lastProps[propKey];
     if (
-      nextProps.hasOwnProperty(propKey) &&
+      hasOwnProperty.call(nextProps, propKey) &&
       nextProp !== lastProp &&
       (nextProp != null || lastProp != null)
     ) {
@@ -2490,7 +2491,7 @@ function diffHydratedCustomComponent(
   serverDifferences: {[propName: string]: mixed},
 ) {
   for (const propKey in props) {
-    if (!props.hasOwnProperty(propKey)) {
+    if (!hasOwnProperty.call(props, propKey)) {
       continue;
     }
     const value = props[propKey];
@@ -2623,7 +2624,7 @@ function diffHydratedGenericElement(
   serverDifferences: {[propName: string]: mixed},
 ) {
   for (const propKey in props) {
-    if (!props.hasOwnProperty(propKey)) {
+    if (!hasOwnProperty.call(props, propKey)) {
       continue;
     }
     const value = props[propKey];

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -830,6 +830,20 @@ describe('ReactDOMComponent', () => {
       expect(node.getAttribute('bar')).toBe('buzz');
     });
 
+    it('should support a custom hasOwnProperty prop', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(<some-custom-element hasOwnProperty="first" />);
+      });
+      expect(container.firstChild.hasOwnProperty).toBe('first');
+
+      await act(() => {
+        root.render(<some-custom-element hasOwnProperty="second" />);
+      });
+      expect(container.firstChild.hasOwnProperty).toBe('second');
+    });
+
     it('should not apply React-specific aliases to custom elements', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -243,6 +243,20 @@ describe('ReactDOMServerHydration', () => {
 
   describe('attribute mismatch', () => {
     // @gate __DEV__
+    it('describes props named hasOwnProperty', () => {
+      function Mismatch({isClient}) {
+        return (
+          <some-custom-element
+            hasOwnProperty={isClient ? 'client' : 'server'}
+          />
+        );
+      }
+      expect(testMismatch(Mismatch)).toEqual([
+        expect.stringContaining('hasOwnProperty="client"'),
+      ]);
+    });
+
+    // @gate __DEV__
     it('warns when client and server render different attributes', () => {
       function Mismatch({isClient}) {
         return (

--- a/packages/react-reconciler/src/ReactFiberHydrationDiffs.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationDiffs.js
@@ -29,6 +29,7 @@ import {enableSrcObject} from 'shared/ReactFeatureFlags';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 import assign from 'shared/assign';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
+import hasOwnProperty from 'shared/hasOwnProperty';
 
 import isArray from 'shared/isArray';
 
@@ -206,7 +207,7 @@ function describeValue(value: mixed, maxLength: number): string {
         let properties = '';
         maxLength -= 2;
         for (let propName in value) {
-          if (!value.hasOwnProperty(propName)) {
+          if (!hasOwnProperty.call(value, propName)) {
             continue;
           }
           const jsonPropName = JSON.stringify(propName);
@@ -268,7 +269,7 @@ function describeCollapsedElement(
   let content = '';
 
   for (const propName in props) {
-    if (!props.hasOwnProperty(propName)) {
+    if (!hasOwnProperty.call(props, propName)) {
       continue;
     }
     if (propName === 'children') {
@@ -303,7 +304,7 @@ function describeExpandedElement(
   const properties = [];
 
   for (const propName in props) {
-    if (!props.hasOwnProperty(propName)) {
+    if (!hasOwnProperty.call(props, propName)) {
       continue;
     }
     if (propName === 'children') {
@@ -346,14 +347,14 @@ function describePropertiesDiff(
   let properties = '';
   const remainingServerProperties = assign({}, serverObject);
   for (const propName in clientObject) {
-    if (!clientObject.hasOwnProperty(propName)) {
+    if (!hasOwnProperty.call(clientObject, propName)) {
       continue;
     }
     delete remainingServerProperties[propName];
     const maxLength = maxRowLength - indent * 2 - propName.length - 2;
     const clientValue = clientObject[propName];
     const clientPropValue = describeValue(clientValue, maxLength);
-    if (serverObject.hasOwnProperty(propName)) {
+    if (hasOwnProperty.call(serverObject, propName)) {
       const serverValue = serverObject[propName];
       const serverPropValue = describeValue(serverValue, maxLength);
       properties += added(indent) + propName + ': ' + clientPropValue + '\n';
@@ -363,7 +364,7 @@ function describePropertiesDiff(
     }
   }
   for (const propName in remainingServerProperties) {
-    if (!remainingServerProperties.hasOwnProperty(propName)) {
+    if (!hasOwnProperty.call(remainingServerProperties, propName)) {
       continue;
     }
     const maxLength = maxRowLength - indent * 2 - propName.length - 2;
@@ -386,7 +387,7 @@ function describeElementDiff(
   const serverPropNames: Map<string, string> = new Map();
 
   for (const propName in serverProps) {
-    if (!serverProps.hasOwnProperty(propName)) {
+    if (!hasOwnProperty.call(serverProps, propName)) {
       continue;
     }
     serverPropNames.set(propName.toLowerCase(), propName);
@@ -396,7 +397,7 @@ function describeElementDiff(
     content += describeExpandedElement(type, clientProps, indentation(indent));
   } else {
     for (const propName in clientProps) {
-      if (!clientProps.hasOwnProperty(propName)) {
+      if (!hasOwnProperty.call(clientProps, propName)) {
         continue;
       }
       if (propName === 'children') {


### PR DESCRIPTION
## Summary

- Use React's shared unbound `hasOwnProperty` helper for DOM prop iteration and hydration diagnostics.
- Support props objects that shadow `hasOwnProperty` or do not inherit from `Object.prototype`.
- Add regressions for custom-element mount/update and hydration diagnostics with a `hasOwnProperty` prop.

## Breaking changes

None. Previously crashing or incomplete prop paths now use the normal ownership checks.

## Verification

- Full ReactDOMComponent and ReactDOMHydrationDiff suites: 206 tests passed, including 37 snapshots.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37415