### PR TITLE
Avoid quadratic compiler queue traversal

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -463,8 +463,9 @@ export function compileProgram(
   // outputMode takes precedence if specified
   const outputMode: CompilerOutputMode =
     pass.opts.outputMode ?? (pass.opts.noEmit ? 'lint' : 'client');
-  while (queue.length !== 0) {
-    const current = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const current = queue[queueIndex++];
     const compiled = processFn(
       current.fn,
       current.fnType,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -651,8 +651,9 @@ function _shrink(func: HIR): void {
 
   const queue = [func.entry];
   const reachable = new Set<BlockId>();
-  while (queue.length !== 0) {
-    const blockId = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const blockId = queue[queueIndex++];
     if (reachable.has(blockId)) {
       continue;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/ControlDominators.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/ControlDominators.ts
@@ -95,8 +95,9 @@ function postDominatorsOf(
   const result = new Set<BlockId>();
   const visited = new Set<BlockId>();
   const queue = [targetId];
-  while (queue.length) {
-    const currentId = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const currentId = queue[queueIndex++];
     if (visited.has(currentId)) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Replace `Array.shift()` dequeue loops with cursor indexes in program compilation, HIR reachability, and post-dominator traversal.
- Preserve FIFO order and append-during-traversal behavior while avoiding repeated array moves.

## Breaking changes

None. Traversal order and results are unchanged.

## Verification

- Compiler source lint, Prettier, and `git diff --check` passed.
- The full compiler workspace build is locally blocked before compilation because esbuild discovers an unrelated ancestor `/Users/Oskar/.pnp.cjs`; no build success is claimed.

Fixes #37414
