### PR TITLE
Stop compiler suppressions at matching enable comments

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
@@ -116,9 +116,12 @@ export function findProgramSuppressions(
       disableNextLinePattern != null &&
       disableNextLinePattern.test(comment.value)
     ) {
-      disableComment = comment;
-      enableComment = comment;
-      source = 'Eslint';
+      suppressionRanges.push({
+        disableComment: comment,
+        enableComment: comment,
+        source: 'Eslint',
+      });
+      continue;
     }
 
     if (
@@ -126,34 +129,47 @@ export function findProgramSuppressions(
       disableComment == null &&
       flowSuppressionPattern.test(comment.value)
     ) {
-      disableComment = comment;
-      enableComment = comment;
-      source = 'Flow';
-    }
-
-    if (disablePattern != null && disablePattern.test(comment.value)) {
-      disableComment = comment;
-      source = 'Eslint';
+      suppressionRanges.push({
+        disableComment: comment,
+        enableComment: comment,
+        source: 'Flow',
+      });
+      continue;
     }
 
     if (
+      disableComment === null &&
+      disablePattern != null &&
+      disablePattern.test(comment.value)
+    ) {
+      disableComment = comment;
+      source = 'Eslint';
+      continue;
+    }
+
+    if (
+      disableComment !== null &&
       enablePattern != null &&
       enablePattern.test(comment.value) &&
       source === 'Eslint'
     ) {
       enableComment = comment;
-    }
-
-    if (disableComment != null && source != null) {
       suppressionRanges.push({
-        disableComment: disableComment,
-        enableComment: enableComment,
-        source,
+        disableComment,
+        enableComment,
+        source: 'Eslint',
       });
       disableComment = null;
       enableComment = null;
       source = null;
     }
+  }
+  if (disableComment !== null && source !== null) {
+    suppressionRanges.push({
+      disableComment,
+      enableComment: null,
+      source,
+    });
   }
   return suppressionRanges;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Suppression-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Suppression-test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {parse} from '@babel/parser';
+import traverse, {NodePath} from '@babel/traverse';
+import * as t from '@babel/types';
+
+import {
+  filterSuppressionsThatAffectFunction,
+  findProgramSuppressions,
+} from '../Entrypoint/Suppression';
+
+describe('ESLint suppressions', () => {
+  it('stops a block suppression at its matching enable comment', () => {
+    const ast = parse(`
+      /* eslint-disable react-hooks/rules-of-hooks */
+      function Suppressed() {}
+      /* eslint-enable react-hooks/rules-of-hooks */
+      function Enabled() {}
+    `);
+    const functions: Array<NodePath<t.Function>> = [];
+    traverse(ast, {
+      FunctionDeclaration(path) {
+        functions.push(path);
+      },
+    });
+
+    const suppressions = findProgramSuppressions(
+      ast.comments ?? [],
+      ['react-hooks/rules-of-hooks'],
+      false,
+    );
+
+    expect(suppressions).toHaveLength(1);
+    expect(suppressions[0].enableComment?.value).toContain('eslint-enable');
+    expect(
+      filterSuppressionsThatAffectFunction(suppressions, functions[0]),
+    ).toHaveLength(1);
+    expect(
+      filterSuppressionsThatAffectFunction(suppressions, functions[1]),
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep block ESLint suppressions open until their matching enable comment.
- Emit next-line and Flow suppressions immediately as single-comment ranges.
- Preserve an unclosed disable block as an end-of-file range.
- Add a regression proving a function after `eslint-enable` is not suppressed.

## Breaking changes

None. Compiler suppression scope now follows the ESLint block boundaries it detects.

## Verification

- Focused suppression regression: 1 test passed.
- Compiler source lint, Prettier, and `git diff --check` passed.
- The full compiler workspace build is locally blocked before compilation because esbuild discovers an unrelated ancestor `/Users/Oskar/.pnp.cjs`; no build success is claimed.

Fixes #37416
