### PR TITLE
Avoid mutating disjoint set union inputs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
@@ -18,7 +18,7 @@ export default class DisjointSet<T> {
    * set.
    */
   union(items: Array<T>): void {
-    const first = items.shift();
+    const first = items[0];
     CompilerError.invariant(first != null, {
       reason: 'Expected set to be non-empty',
       loc: GeneratedSource,
@@ -34,7 +34,8 @@ export default class DisjointSet<T> {
       this.#entries.set(first, first);
     }
     // update remaining items (which may already be part of other sets)
-    for (const item of items) {
+    for (let i = 1; i < items.length; i++) {
+      const item = items[i];
       let itemParent = this.#entries.get(item);
       if (itemParent == null) {
         // new item, no existing set to update

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/DisjointSet-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/DisjointSet-test.ts
@@ -57,6 +57,16 @@ describe('DisjointSet', () => {
     expect(identifiers.size).toBe(2);
   });
 
+  it('.union - does not modify the input array', () => {
+    const identifiers = new DisjointSet<TestIdentifier>();
+    const [x, y] = makeIdentifiers('x', 'y');
+    const input = [x, y];
+
+    identifiers.union(input);
+
+    expect(input).toEqual([x, y]);
+  });
+
   it('.buildSets - returns non-overlapping sets', () => {
     const identifiers = new DisjointSet<TestIdentifier>();
     const [a, b, c, x, y, z] = makeIdentifiers('a', 'b', 'c', 'x', 'y', 'z');


### PR DESCRIPTION
## Summary

- Read the union representative without removing it from the caller-owned array.
- Traverse remaining entries from index one, avoiding the initial O(n) `shift()`.
- Add a regression proving the supplied array remains unchanged.

## Breaking changes

None. `union()` keeps its existing set result and no longer mutates its input as a side effect.

## Verification

- Focused DisjointSet suite: 6 tests passed.
- Compiler source lint, Prettier, and `git diff --check` passed.
- The full compiler workspace build is locally blocked before compilation because esbuild discovers an unrelated ancestor `/Users/Oskar/.pnp.cjs`; no build success is claimed.

Fixes #37417
