### PR TITLE
Support null-prototype ReactDOM style objects

### DIFF
--- a/packages/react-dom-bindings/src/client/CSSPropertyOperations.js
+++ b/packages/react-dom-bindings/src/client/CSSPropertyOperations.js
@@ -11,6 +11,7 @@ import hyphenateStyleName from '../shared/hyphenateStyleName';
 import warnValidStyle from '../shared/warnValidStyle';
 import isUnitlessNumber from '../shared/isUnitlessNumber';
 import {checkCSSPropertyStringCoercion} from 'shared/CheckStringCoercion';
+import hasOwnProperty from 'shared/hasOwnProperty';
 import {trackHostMutation} from 'react-reconciler/src/ReactFiberMutationTracking';
 
 /**
@@ -28,7 +29,7 @@ export function createDangerousStringForStyles(styles) {
     let serialized = '';
     let delimiter = '';
     for (const styleName in styles) {
-      if (!styles.hasOwnProperty(styleName)) {
+      if (!hasOwnProperty.call(styles, styleName)) {
         continue;
       }
       const value = styles[styleName];
@@ -133,8 +134,8 @@ export function setValueForStyles(node, styles, prevStyles) {
 
     for (const styleName in prevStyles) {
       if (
-        prevStyles.hasOwnProperty(styleName) &&
-        (styles == null || !styles.hasOwnProperty(styleName))
+        hasOwnProperty.call(prevStyles, styleName) &&
+        (styles == null || !hasOwnProperty.call(styles, styleName))
       ) {
         // Clear style
         const isCustomProperty = styleName.indexOf('--') === 0;
@@ -150,14 +151,17 @@ export function setValueForStyles(node, styles, prevStyles) {
     }
     for (const styleName in styles) {
       const value = styles[styleName];
-      if (styles.hasOwnProperty(styleName) && prevStyles[styleName] !== value) {
+      if (
+        hasOwnProperty.call(styles, styleName) &&
+        prevStyles[styleName] !== value
+      ) {
         setValueForStyle(style, styleName, value);
         trackHostMutation();
       }
     }
   } else {
     for (const styleName in styles) {
-      if (styles.hasOwnProperty(styleName)) {
+      if (hasOwnProperty.call(styles, styleName)) {
         const value = styles[styleName];
         setValueForStyle(style, styleName, value);
       }
@@ -212,7 +216,10 @@ function validateShorthandPropertyCollisionInDev(prevStyles, nextStyles) {
     const expandedUpdates = {};
     if (prevStyles) {
       for (const key in prevStyles) {
-        if (prevStyles.hasOwnProperty(key) && !nextStyles.hasOwnProperty(key)) {
+        if (
+          hasOwnProperty.call(prevStyles, key) &&
+          !hasOwnProperty.call(nextStyles, key)
+        ) {
           const longhands = shorthandToLonghand[key] || [key];
           for (let i = 0; i < longhands.length; i++) {
             expandedUpdates[longhands[i]] = key;
@@ -222,7 +229,7 @@ function validateShorthandPropertyCollisionInDev(prevStyles, nextStyles) {
     }
     for (const key in nextStyles) {
       if (
-        nextStyles.hasOwnProperty(key) &&
+        hasOwnProperty.call(nextStyles, key) &&
         (!prevStyles || prevStyles[key] !== nextStyles[key])
       ) {
         const longhands = shorthandToLonghand[key] || [key];

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -1433,7 +1433,7 @@ export function unhideInstance(instance: Instance, props: Props): void {
     styleProp !== undefined &&
     // $FlowFixMe[invalid-compare]
     styleProp !== null &&
-    styleProp.hasOwnProperty('display')
+    hasOwnProperty.call(styleProp, 'display')
       ? styleProp.display
       : null;
   instance.style.display =
@@ -1572,9 +1572,9 @@ export function restoreViewTransitionName(
   const styleProp = props[STYLE];
   const viewTransitionName =
     styleProp != null
-      ? styleProp.hasOwnProperty('viewTransitionName')
+      ? hasOwnProperty.call(styleProp, 'viewTransitionName')
         ? styleProp.viewTransitionName
-        : styleProp.hasOwnProperty('view-transition-name')
+        : hasOwnProperty.call(styleProp, 'view-transition-name')
           ? styleProp['view-transition-name']
           : null
       : null;
@@ -1587,9 +1587,9 @@ export function restoreViewTransitionName(
         ('' + viewTransitionName).trim();
   const viewTransitionClass =
     styleProp != null
-      ? styleProp.hasOwnProperty('viewTransitionClass')
+      ? hasOwnProperty.call(styleProp, 'viewTransitionClass')
         ? styleProp.viewTransitionClass
-        : styleProp.hasOwnProperty('view-transition-class')
+        : hasOwnProperty.call(styleProp, 'view-transition-class')
           ? styleProp['view-transition-class']
           : null
       : null;
@@ -1612,12 +1612,12 @@ export function restoreViewTransitionName(
       if (margin != null) {
         style.margin = margin;
       } else {
-        const marginTop = styleProp.hasOwnProperty('marginTop')
+        const marginTop = hasOwnProperty.call(styleProp, 'marginTop')
           ? styleProp.marginTop
           : styleProp['margin-top'];
         style.marginTop =
           marginTop == null || typeof marginTop === 'boolean' ? '' : marginTop;
-        const marginBottom = styleProp.hasOwnProperty('marginBottom')
+        const marginBottom = hasOwnProperty.call(styleProp, 'marginBottom')
           ? styleProp.marginBottom
           : styleProp['margin-bottom'];
         style.marginBottom =

--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -84,6 +84,25 @@ describe('CSSPropertyOperations', () => {
     expect(/style=".*"/.test(container.innerHTML)).toBe(true);
   });
 
+  it('should support style objects without a prototype', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    const styles = Object.create(null);
+    styles.color = 'red';
+    await act(() => {
+      root.render(<div style={styles} />);
+    });
+    expect(container.firstChild.style.color).toBe('red');
+
+    const nextStyles = Object.create(null);
+    nextStyles.backgroundColor = 'blue';
+    await act(() => {
+      root.render(<div style={nextStyles} />);
+    });
+    expect(container.firstChild.style.color).toBe('');
+    expect(container.firstChild.style.backgroundColor).toBe('blue');
+  });
+
   it('should not set style attribute when no styles exist', () => {
     const styles = {
       backgroundColor: null,

--- a/packages/react-dom/src/__tests__/ReactDOMActivity-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMActivity-test.js
@@ -54,6 +54,30 @@ describe('ReactDOMActivity', () => {
     return <span prop={props.text}>{props.children}</span>;
   }
 
+  it('restores styles without a prototype when revealing an Activity', async () => {
+    const styles = Object.create(null);
+    styles.display = 'inline';
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(
+        <Activity mode="hidden">
+          <span style={styles}>Child</span>
+        </Activity>,
+      );
+    });
+    expect(container.firstChild.style.display).toBe('none');
+
+    await act(() => {
+      root.render(
+        <Activity mode="visible">
+          <span style={styles}>Child</span>
+        </Activity>,
+      );
+    });
+    expect(container.firstChild.style.display).toBe('inline');
+  });
+
   it(
     'hiding an Activity boundary also hides the direct children of any ' +
       'portals it contains, regardless of how deeply nested they are',


### PR DESCRIPTION
## Summary

- Use React's shared safe ownership helper throughout CSS style iteration and updates.
- Apply the same safe check when restoring Activity and view-transition styles.
- Add regressions for null-prototype style mount/update and Activity reveal.

## Breaking changes

None. Style records that previously crashed now follow the existing own-property behavior.

## Verification

- Full CSSPropertyOperations and ReactDOMActivity suites: 25 tests passed.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37423