### PR TITLE
Support null-prototype React ref objects

### DIFF
--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -170,6 +170,23 @@ describe('ref swapping', () => {
       });
     }).rejects.toThrow('Expected ref to be a function');
   });
+
+  it('supports object refs without a prototype', async () => {
+    const ref = Object.create(null);
+    ref.current = null;
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(<div ref={ref} />);
+    });
+    expect(ref.current).toBe(container.firstChild);
+
+    await act(() => {
+      root.unmount();
+    });
+    expect(ref.current).toBe(null);
+  });
 });
 
 describe('root level refs', () => {
@@ -497,6 +514,23 @@ describe('useImerativeHandle refs', () => {
       root.render(<ImperativeHandleComponent name="Alice" ref={ref} />);
     });
     expect(ref.current.greet()).toBe('Hello Alice');
+    await act(() => {
+      root.render(null);
+    });
+    expect(ref.current).toBe(null);
+  });
+
+  it('should work with object style refs without a prototype', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    const ref = Object.create(null);
+    ref.current = null;
+
+    await act(() => {
+      root.render(<ImperativeHandleComponent name="Alice" ref={ref} />);
+    });
+    expect(ref.current.greet()).toBe('Hello Alice');
+
     await act(() => {
       root.render(null);
     });

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -66,6 +66,7 @@ import {
   Passive as HookPassive,
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork';
+import hasOwnProperty from 'shared/hasOwnProperty';
 import {
   markComponentPassiveEffectMountStarted,
   markComponentPassiveEffectMountStopped,
@@ -808,7 +809,7 @@ function commitAttachRef(finishedWork: Fiber) {
         // phase (markRef).
         if (typeof ref === 'string') {
           console.error('String refs are no longer supported.');
-        } else if (!ref.hasOwnProperty('current')) {
+        } else if (!hasOwnProperty.call(ref, 'current')) {
           console.error(
             'Unexpected ref object provided for %s. ' +
               'Use either a ref-setter function or React.createRef().',

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -35,6 +35,7 @@ import {
   getCurrentUpdatePriority,
 } from './ReactFiberConfig';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import hasOwnProperty from 'shared/hasOwnProperty';
 import {
   enableSchedulingProfiler,
   enableTransitionTracing,
@@ -2833,7 +2834,7 @@ function imperativeHandleEffect<T>(
   } else if (ref !== null && ref !== undefined) {
     const refObject = ref;
     if (__DEV__) {
-      if (!refObject.hasOwnProperty('current')) {
+      if (!hasOwnProperty.call(refObject, 'current')) {
         console.error(
           'Expected useImperativeHandle() first argument to either be a ' +
             'ref callback or React.createRef() object. Instead received: %s.',


### PR DESCRIPTION
## Summary

- Use React's shared safe ownership helper when validating object refs.
- Support null-prototype `{current}` refs in both ordinary ref attachment and `useImperativeHandle`.
- Add regressions for mount, cleanup, and imperative-handle cleanup.

## Breaking changes

None. Structurally valid object refs that previously crashed in development now follow the existing ref behavior.

## Verification

- Full ReactDOM ref suites: 106 tests passed.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37425