### PR TITLE
Close React.Children iterators on mapping errors

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -308,14 +308,24 @@ function mapIntoArray(
       // $FlowFixMe[incompatible-use] `iteratorFn` might return null according to typing.
       while (!(step = iterator.next()).done) {
         child = step.value;
-        nextName = nextNamePrefix + getElementKey(child, ii++);
-        subtreeCount += mapIntoArray(
-          child,
-          array,
-          escapedPrefix,
-          nextName,
-          callback,
-        );
+        try {
+          nextName = nextNamePrefix + getElementKey(child, ii++);
+          subtreeCount += mapIntoArray(
+            child,
+            array,
+            escapedPrefix,
+            nextName,
+            callback,
+          );
+        } catch (error) {
+          const iteratorReturn = iterator.return;
+          if (typeof iteratorReturn === 'function') {
+            try {
+              iteratorReturn.call(iterator);
+            } catch (x) {}
+          }
+          throw error;
+        }
       }
     } else if (type === 'object') {
       if (typeof (children as any).then === 'function') {

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -318,12 +318,12 @@ function mapIntoArray(
             callback,
           );
         } catch (error) {
-          const iteratorReturn = iterator.return;
-          if (typeof iteratorReturn === 'function') {
-            try {
+          try {
+            const iteratorReturn = iterator.return;
+            if (typeof iteratorReturn === 'function') {
               iteratorReturn.call(iterator);
-            } catch (x) {}
-          }
+            }
+          } catch (x) {}
           throw error;
         }
       }

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -411,6 +411,28 @@ describe('ReactChildren', () => {
     ]);
   });
 
+  it('closes an iterator when mapping throws', () => {
+    const close = jest.fn();
+    const children = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return {value: <div />, done: false};
+          },
+          return: close,
+        };
+      },
+    };
+    const error = new Error('stop mapping');
+
+    expect(() => {
+      React.Children.map(children, () => {
+        throw error;
+      });
+    }).toThrow(error);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it('should not enumerate enumerable numbers (#4776)', () => {
     /*eslint-disable no-extend-native */
     Number.prototype['@@iterator'] = function () {

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -433,6 +433,31 @@ describe('ReactChildren', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves mapping errors when reading the iterator return method throws', () => {
+    const error = new Error('stop mapping');
+    const children = {
+      [Symbol.iterator]() {
+        const iterator = {
+          next() {
+            return {value: <div />, done: false};
+          },
+        };
+        Object.defineProperty(iterator, 'return', {
+          get() {
+            throw new Error('failed to read return');
+          },
+        });
+        return iterator;
+      },
+    };
+
+    expect(() => {
+      React.Children.map(children, () => {
+        throw error;
+      });
+    }).toThrow(error);
+  });
+
   it('should not enumerate enumerable numbers (#4776)', () => {
     /*eslint-disable no-extend-native */
     Number.prototype['@@iterator'] = function () {


### PR DESCRIPTION
## Summary

- Close manually consumed child iterators when key processing or recursive mapping throws.
- Invoke an iterator's optional `return()` exactly once while preserving the original mapping error.
- Add a regression that verifies cleanup and error identity.

## Breaking changes

None. This adds the expected iterator cleanup on an already failing path.

## Verification

- Full ReactChildren suite: 43 tests passed.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37427