### PR TITLE
[Fizz] Avoid duplicate props copy

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -2588,7 +2588,7 @@ export function resolveClassComponentProps(
     // We may have already copied the props object above to remove ref. If so,
     // we can modify that. Otherwise, copy the props object with Object.assign.
     if (newProps === baseProps) {
-      newProps = assign({}, newProps, baseProps);
+      newProps = assign({}, newProps);
     }
     // Taken from old JSX runtime, where this used to live.
     for (const propName in defaultProps) {


### PR DESCRIPTION
## Summary

- Copy Fizz class component props from their single source once before applying `defaultProps`.
- Remove a redundant full property enumeration when `newProps` and `baseProps` are the same object.
- Match the equivalent client reconciler form without changing the resulting props.

## Breaking changes

None. The duplicate assignment wrote each key to the same value.

## Verification

- Full ReactDOMFizzServer suite: 183 tests passed, including 2 snapshots.
- Server integration suite: 27 tests passed.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37429