### PR TITLE
Harden Fizz resource caches against prototype keys

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -310,6 +310,10 @@ export type ResumableState = {
   },
 };
 
+function createResourceMap<T>(): {[key: string]: T} {
+  return Object.create(null);
+}
+
 let currentlyFlushingRenderState: RenderState | null = null;
 
 const dataElementQuotedEnd = stringToPrecomputedChunk('"></template>');
@@ -503,15 +507,15 @@ export function createRenderState(
     onHeaders,
     headers,
     resets: {
-      font: {},
-      dns: {},
+      font: createResourceMap(),
+      dns: createResourceMap(),
       connect: {
-        default: {},
-        anonymous: {},
-        credentials: {},
+        default: createResourceMap(),
+        anonymous: createResourceMap(),
+        credentials: createResourceMap(),
       },
-      image: {},
-      style: {},
+      image: createResourceMap(),
+      style: createResourceMap(),
     },
 
     charsetChunks: [],
@@ -706,18 +710,18 @@ export function createResumableState(
     // @TODO add bootstrap script to implicit preloads
 
     // persistent
-    unknownResources: {},
-    dnsResources: {},
+    unknownResources: createResourceMap(),
+    dnsResources: createResourceMap(),
     connectResources: {
-      default: {},
-      anonymous: {},
-      credentials: {},
+      default: createResourceMap(),
+      anonymous: createResourceMap(),
+      credentials: createResourceMap(),
     },
-    imageResources: {},
-    styleResources: {},
-    scriptResources: {},
-    moduleUnknownResources: {},
-    moduleScriptResources: {},
+    imageResources: createResourceMap(),
+    styleResources: createResourceMap(),
+    scriptResources: createResourceMap(),
+    moduleUnknownResources: createResourceMap(),
+    moduleScriptResources: createResourceMap(),
   };
 }
 
@@ -730,16 +734,16 @@ export function resetResumableState(
   resumableState.nextFormID = 0;
   resumableState.hasBody = false;
   resumableState.hasHtml = false;
-  resumableState.unknownResources = {
-    font: renderState.resets.font,
-  };
+  const unknownResources = createResourceMap();
+  unknownResources.font = renderState.resets.font;
+  resumableState.unknownResources = unknownResources;
   resumableState.dnsResources = renderState.resets.dns;
   resumableState.connectResources = renderState.resets.connect;
   resumableState.imageResources = renderState.resets.image;
   resumableState.styleResources = renderState.resets.style;
-  resumableState.scriptResources = {};
-  resumableState.moduleUnknownResources = {};
-  resumableState.moduleScriptResources = {};
+  resumableState.scriptResources = createResourceMap();
+  resumableState.moduleUnknownResources = createResourceMap();
+  resumableState.moduleScriptResources = createResourceMap();
   resumableState.instructions = NothingSent; // Nothing was flushed so no instructions could've flushed.
 }
 
@@ -2990,7 +2994,7 @@ function pushLink(
     } else {
       // This stylesheet refers to a Resource and we create a new one if necessary
       let styleQueue = renderState.styles.get(precedence);
-      const hasKey = resumableState.styleResources.hasOwnProperty(key);
+      const hasKey = hasOwnProperty.call(resumableState.styleResources, key);
       const resourceState = hasKey
         ? resumableState.styleResources[key]
         : undefined;
@@ -3191,7 +3195,7 @@ function pushStyle(
 
   const key = getResourceKey(href);
   let styleQueue = renderState.styles.get(precedence);
-  const hasKey = resumableState.styleResources.hasOwnProperty(key);
+  const hasKey = hasOwnProperty.call(resumableState.styleResources, key);
   const resourceState = hasKey ? resumableState.styleResources[key] : undefined;
   if (resourceState !== EXISTS) {
     // We are going to create this resource now so it is marked as Exists
@@ -3439,7 +3443,7 @@ function pushImg(
         // $FlowFixMe[incompatible-type] - Flow should understand that this is a Resource if the condition was true
         renderState.highImagePreloads.add(resource);
       }
-    } else if (!resumableState.imageResources.hasOwnProperty(key)) {
+    } else if (!hasOwnProperty.call(resumableState.imageResources, key)) {
       // We must construct a new preload resource
       resumableState.imageResources[key] = PRELOAD_NO_CREDS;
       const crossOrigin = getCrossOriginString(props.crossOrigin);
@@ -3868,7 +3872,7 @@ function pushScript(
     preloads = renderState.preloads.scripts;
   }
 
-  const hasKey = resources.hasOwnProperty(key);
+  const hasKey = hasOwnProperty.call(resources, key);
   const resourceState = hasKey ? resources[key] : undefined;
   if (resourceState !== EXISTS) {
     // We are going to create this resource now so it is marked as Exists
@@ -6287,7 +6291,7 @@ function prefetchDNS(href: string) {
 
   if (typeof href === 'string' && href) {
     const key = getResourceKey(href);
-    if (!resumableState.dnsResources.hasOwnProperty(key)) {
+    if (!hasOwnProperty.call(resumableState.dnsResources, key)) {
       resumableState.dnsResources[key] = EXISTS;
 
       const headers = renderState.headers;
@@ -6346,7 +6350,7 @@ function preconnect(href: string, crossOrigin: ?CrossOriginEnum) {
           ? 'anonymous'
           : 'default';
     const key = getResourceKey(href);
-    if (!resumableState.connectResources[bucket].hasOwnProperty(key)) {
+    if (!hasOwnProperty.call(resumableState.connectResources[bucket], key)) {
       resumableState.connectResources[bucket][key] = EXISTS;
 
       const headers = renderState.headers;
@@ -6409,7 +6413,7 @@ function preload(href: string, as: string, options?: ?PreloadImplOptions) {
           fetchPriority = options.fetchPriority;
         }
         const key = getImageResourceKey(href, imageSrcSet, imageSizes);
-        if (resumableState.imageResources.hasOwnProperty(key)) {
+        if (hasOwnProperty.call(resumableState.imageResources, key)) {
           // we can return if we already have this resource
           return;
         }
@@ -6478,7 +6482,7 @@ function preload(href: string, as: string, options?: ?PreloadImplOptions) {
       }
       case 'style': {
         const key = getResourceKey(href);
-        if (resumableState.styleResources.hasOwnProperty(key)) {
+        if (hasOwnProperty.call(resumableState.styleResources, key)) {
           // we can return if we already have this resource
           return;
         }
@@ -6499,7 +6503,7 @@ function preload(href: string, as: string, options?: ?PreloadImplOptions) {
       }
       case 'script': {
         const key = getResourceKey(href);
-        if (resumableState.scriptResources.hasOwnProperty(key)) {
+        if (hasOwnProperty.call(resumableState.scriptResources, key)) {
           // we can return if we already have this resource
           return;
         }
@@ -6520,16 +6524,19 @@ function preload(href: string, as: string, options?: ?PreloadImplOptions) {
       }
       default: {
         const key = getResourceKey(href);
-        const hasAsType = resumableState.unknownResources.hasOwnProperty(as);
+        const hasAsType = hasOwnProperty.call(
+          resumableState.unknownResources,
+          as,
+        );
         let resources;
         if (hasAsType) {
           resources = resumableState.unknownResources[as];
-          if (resources.hasOwnProperty(key)) {
+          if (hasOwnProperty.call(resources, key)) {
             // we can return if we already have this resource
             return;
           }
         } else {
-          resources = {} as ResumableState['unknownResources']['asType'];
+          resources = createResourceMap();
           resumableState.unknownResources[as] = resources;
         }
         resources[key] = PRELOAD_NO_CREDS;
@@ -6612,7 +6619,7 @@ function preloadModule(
     let resource;
     switch (as) {
       case 'script': {
-        if (resumableState.moduleScriptResources.hasOwnProperty(key)) {
+        if (hasOwnProperty.call(resumableState.moduleScriptResources, key)) {
           // we can return if we already have this resource
           return;
         }
@@ -6627,17 +6634,19 @@ function preloadModule(
         break;
       }
       default: {
-        const hasAsType =
-          resumableState.moduleUnknownResources.hasOwnProperty(as);
+        const hasAsType = hasOwnProperty.call(
+          resumableState.moduleUnknownResources,
+          as,
+        );
         let resources;
         if (hasAsType) {
           resources = resumableState.moduleUnknownResources[as];
-          if (resources.hasOwnProperty(key)) {
+          if (hasOwnProperty.call(resources, key)) {
             // we can return if we already have this resource
             return;
           }
         } else {
-          resources = {} as ResumableState['moduleUnknownResources']['asType'];
+          resources = createResourceMap();
           resumableState.moduleUnknownResources[as] = resources;
         }
         resource = [] as Resource;
@@ -6683,7 +6692,7 @@ function preinitStyle(
     const key = getResourceKey(href);
 
     let styleQueue = renderState.styles.get(precedence);
-    const hasKey = resumableState.styleResources.hasOwnProperty(key);
+    const hasKey = hasOwnProperty.call(resumableState.styleResources, key);
     const resourceState = hasKey
       ? resumableState.styleResources[key]
       : undefined;
@@ -6766,7 +6775,7 @@ function preinitScript(src: string, options?: ?PreinitScriptOptions): void {
   if (src) {
     const key = getResourceKey(src);
 
-    const hasKey = resumableState.scriptResources.hasOwnProperty(key);
+    const hasKey = hasOwnProperty.call(resumableState.scriptResources, key);
     const resourceState = hasKey
       ? resumableState.scriptResources[key]
       : undefined;
@@ -6828,7 +6837,10 @@ function preinitModuleScript(
   const renderState = getRenderState(request);
   if (src) {
     const key = getResourceKey(src);
-    const hasKey = resumableState.moduleScriptResources.hasOwnProperty(key);
+    const hasKey = hasOwnProperty.call(
+      resumableState.moduleScriptResources,
+      key,
+    );
     const resourceState = hasKey
       ? resumableState.moduleScriptResources[key]
       : undefined;
@@ -6887,8 +6899,8 @@ function preloadBootstrapScriptOrModule(
 
   if (__DEV__) {
     if (
-      resumableState.scriptResources.hasOwnProperty(key) ||
-      resumableState.moduleScriptResources.hasOwnProperty(key)
+      hasOwnProperty.call(resumableState.scriptResources, key) ||
+      hasOwnProperty.call(resumableState.moduleScriptResources, key)
     ) {
       // This is coded as a React error because it should be impossible for a userspace preload to preempt this call
       // If a userspace preload can preempt it then this assumption is broken and we need to reconsider this strategy
@@ -6920,7 +6932,7 @@ function internalPreinitScript(
   chunks: Array<Chunk | PrecomputedChunk>,
 ): void {
   const key = getResourceKey(src);
-  if (!resumableState.scriptResources.hasOwnProperty(key)) {
+  if (!hasOwnProperty.call(resumableState.scriptResources, key)) {
     const resource: Resource = chunks;
     resumableState.scriptResources[key] = EXISTS;
     renderState.scripts.add(resource);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -4586,6 +4586,26 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  it('supports resource URLs that collide with object prototype keys', async () => {
+    function App() {
+      ReactDOM.prefetchDNS('hasOwnProperty');
+      ReactDOM.prefetchDNS('other');
+      ReactDOM.prefetchDNS('__proto__');
+      ReactDOM.prefetchDNS('__proto__');
+      return <div>hello</div>;
+    }
+
+    await act(() => {
+      renderToPipeableStream(<App />).pipe(writable);
+    });
+
+    expect(
+      Array.from(document.querySelectorAll('link[rel="dns-prefetch"]')).map(
+        link => link.getAttribute('href'),
+      ),
+    ).toEqual(['hasOwnProperty', 'other', '__proto__']);
+  });
+
   it('provides headers after initial work if onHeaders option used', async () => {
     let headers = null;
     function onHeaders(x) {


### PR DESCRIPTION
## Summary

- Store request-local Fizz resource indexes in null-prototype dictionaries.
- Use React's shared safe ownership helper for every resource lookup.
- Cover DNS, connect, image, style, script, module, and unknown resource caches.
- Add a regression for `hasOwnProperty` and `__proto__` URLs, including deduplication.

## Breaking changes

None. Arbitrary resource strings that previously crashed or bypassed deduplication now behave as ordinary keys.

## Verification

- Full ReactDOMFizzServer suite: 184 tests passed, including 2 snapshots.
- ReactDOMFloat suite: 142 tests passed, 1 skipped.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37431