### PR TITLE
[jsx] Warn when accessing an empty key prop

### DIFF
--- a/packages/react/src/__tests__/ReactCreateElement-test.js
+++ b/packages/react/src/__tests__/ReactCreateElement-test.js
@@ -92,6 +92,17 @@ describe('ReactCreateElement', () => {
     ]);
   });
 
+  it('should warn when an empty `key` is being accessed', () => {
+    const element = React.createElement('div', {key: ''});
+    void element.props.key;
+    assertConsoleErrorDev([
+      'div: `key` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://react.dev/link/special-props)',
+    ]);
+  });
+
   it('allows a string to be passed as the type', () => {
     const element = React.createElement('div');
     expect(element.type).toBe('div');

--- a/packages/react/src/__tests__/ReactJSXRuntime-test.js
+++ b/packages/react/src/__tests__/ReactJSXRuntime-test.js
@@ -243,6 +243,17 @@ describe('ReactJSXRuntime', () => {
     ]);
   });
 
+  it('should warn when an empty `key` is being accessed', () => {
+    const element = JSXRuntime.jsx('div', {}, '');
+    void element.props.key;
+    assertConsoleErrorDev([
+      'div: `key` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://react.dev/link/special-props)',
+    ]);
+  });
+
   it('should warn when unkeyed children are passed to jsx', async () => {
     const container = document.createElement('div');
 

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -591,7 +591,7 @@ function jsxDEVImpl(
       }
     }
 
-    if (key) {
+    if (key !== null) {
       const displayName =
         typeof type === 'function'
           ? type.displayName || type.name || 'Unknown'
@@ -710,7 +710,7 @@ export function createElement(type, config, children) {
     }
   }
   if (__DEV__) {
-    if (key) {
+    if (key !== null) {
       const displayName =
         typeof type === 'function'
           ? type.displayName || type.name || 'Unknown'


### PR DESCRIPTION
## Summary


Fixes #37433

Install React's development-only special-prop warning getter for empty keys (`''`).



## Verification

- Added test
