### PR TITLE
Allow Result combinators to change variants

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/Result.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/Result.ts
@@ -55,7 +55,7 @@ export interface Result<T, E> {
    * Arguments passed to {@link or} are eagerly evaluated; if you are passing the result of a
    * function call, it is recommended to use {@link orElse}, which is lazily evaluated.
    */
-  or(res: Result<T, E>): Result<T, E>;
+  or<F>(res: Result<T, F>): Result<T, F>;
   /*
    * Calls `fn` if the result is `Err`, otherwise returns the `Ok` value of self.
    *
@@ -111,15 +111,15 @@ class OkImpl<T> implements Result<T, never> {
     return fn(this.#val);
   }
 
-  andThen<U>(fn: (val: T) => Result<U, never>): Result<U, never> {
+  andThen<U, E>(fn: (val: T) => Result<U, E>): Result<U, E> {
     return fn(this.#val);
   }
 
-  and<U>(res: Result<U, never>): Result<U, never> {
+  and<U, E>(res: Result<U, E>): Result<U, E> {
     return res;
   }
 
-  or(_res: Result<T, never>): Result<T, never> {
+  or<E>(_res: Result<T, E>): Result<T, E> {
     return this;
   }
 
@@ -197,11 +197,11 @@ class ErrImpl<E> implements Result<never, E> {
     return this;
   }
 
-  or(res: Result<never, E>): Result<never, E> {
+  or<T, F>(res: Result<T, F>): Result<T, F> {
     return res;
   }
 
-  orElse<F>(fn: (val: E) => ErrImpl<F>): Result<never, F> {
+  orElse<T, F>(fn: (val: E) => Result<T, F>): Result<T, F> {
     return fn(this.#val);
   }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Result-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Result-test.ts
@@ -57,6 +57,7 @@ describe('Result', () => {
     expect(addMax10(10, 10).andThen(n => Ok(n * 2))).toEqual(
       Err('20 is too high'),
     );
+    expect(Ok(2).andThen(() => Err('failed'))).toEqual(Err('failed'));
   });
 
   test('.and', () => {
@@ -64,6 +65,7 @@ describe('Result', () => {
     expect(addMax10(10, 10).and(Ok(4))).toEqual(Err('20 is too high'));
     expect(addMax10(1, 1).and(Err('hehe'))).toEqual(Err('hehe'));
     expect(addMax10(10, 10).and(Err('hehe'))).toEqual(Err('20 is too high'));
+    expect(Ok(2).and(Err('failed'))).toEqual(Err('failed'));
   });
 
   test('.or', () => {
@@ -71,6 +73,7 @@ describe('Result', () => {
     expect(addMax10(10, 10).or(Ok(4))).toEqual(Ok(4));
     expect(addMax10(1, 1).or(Err('hehe'))).toEqual(Ok(2));
     expect(addMax10(10, 10).or(Err('hehe'))).toEqual(Err('hehe'));
+    expect(Err('failed').or(Ok(4))).toEqual(Ok(4));
   });
 
   test('.orElse', () => {
@@ -78,6 +81,7 @@ describe('Result', () => {
     expect(addMax10(10, 10).orElse(str => Err(str.toUpperCase()))).toEqual(
       Err('20 IS TOO HIGH'),
     );
+    expect(Err('failed').orElse(() => Ok(4))).toEqual(Ok(4));
   });
 
   test('.isOk', () => {


### PR DESCRIPTION
## Summary

- Generalize concrete `OkImpl` and `ErrImpl` combinator signatures to infer returned success/error variants.
- Let `Result.or` change the error type in line with Rust-style semantics.
- Cover direct `Ok`→`Err` and `Err`→`Ok` chains across `and`, `andThen`, `or`, and `orElse`.

## Breaking changes

None. Runtime behavior is unchanged; valid chains that previously failed TypeScript compilation now type-check.

## Verification

- Full typed Result suite: 16 tests passed, including 6 snapshots.
- Compiler source lint, Prettier, and `git diff --check` passed.
- The full compiler workspace build remains locally blocked before compilation because esbuild discovers an unrelated ancestor `/Users/Oskar/.pnp.cjs`; no full-build success is claimed.

Fixes #37435