### PR TITLE
Check the smallest set first during compiler intersections

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/utils.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/utils.ts
@@ -109,9 +109,20 @@ export function Set_intersect<T>(sets: Array<ReadonlySet<T>>): Set<T> {
     return new Set(sets[0]);
   }
   const result: Set<T> = new Set();
-  const first = sets[0];
-  outer: for (const e of first) {
+  let smallestIndex = 1;
+  for (let i = 2; i < sets.length; i++) {
+    if (sets[i].size < sets[smallestIndex].size) {
+      smallestIndex = i;
+    }
+  }
+  outer: for (const e of sets[0]) {
+    if (!sets[smallestIndex].has(e)) {
+      continue;
+    }
     for (let i = 1; i < sets.length; i++) {
+      if (i === smallestIndex) {
+        continue;
+      }
       if (!sets[i].has(e)) {
         continue outer;
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Utils-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Utils-test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Set_intersect} from '../Utils/utils';
+
+describe('Set_intersect', () => {
+  test('checks the smallest set first while preserving input order', () => {
+    const first = new Set([
+      2,
+      1,
+      ...Array.from({length: 100}, (_, i) => i + 3),
+    ]);
+    const large = new Set(first);
+    const small = new Set([1, 2]);
+    const largeHas = jest.spyOn(large, 'has');
+    const smallHas = jest.spyOn(small, 'has');
+
+    expect(Set_intersect([first, large, small])).toEqual(new Set([2, 1]));
+    expect(smallHas).toHaveBeenCalledTimes(first.size);
+    expect(largeHas).toHaveBeenCalledTimes(small.size);
+  });
+});


### PR DESCRIPTION
## Summary

- Find the smallest set after the first compiler-intersection input.
- Check that set before the other remaining inputs so non-members short-circuit cheaply.
- Preserve exact first-input iteration and result insertion order.
- Add a regression that verifies both ordering and reduced large-set membership checks.

## Breaking changes

None. Intersection values and insertion order are unchanged.

## Verification

- Focused typed Jest regression passed.
- Full compiler ESLint, root Prettier check, and `git diff --check` passed.
- The full compiler workspace retains the previously recorded ancestor-`.pnp.cjs` blocker, so no full-build success is claimed.

Fixes #37437