### PR TITLE
Forward complete calls through compiler gating wrappers

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
@@ -28,8 +28,8 @@ import {ExternalFunction} from '..';
  * function Foo_optimized() {}      <- inserted
  * function Foo_unoptimized() {}    <- renamed from Foo
  * function Foo() {                 <- inserted function, which can be hoisted by JS engines
- *   if (gating_result) return Foo_optimized();
- *   else return Foo_unoptimized();
+ *   if (gating_result) return Foo_optimized.apply(this, arguments);
+ *   else return Foo_unoptimized.apply(this, arguments);
  * }
  * ```
  */
@@ -79,17 +79,19 @@ function insertAdditionalFunctionDeclaration(
    * Step 2: insert new function declaration
    */
   const newParams: Array<t.Identifier | t.RestElement> = [];
-  const genNewArgs: Array<() => t.Identifier | t.SpreadElement> = [];
   for (let i = 0; i < originalFnParams.length; i++) {
     const argName = `arg${i}`;
     if (originalFnParams[i].type === 'RestElement') {
       newParams.push(t.restElement(t.identifier(argName)));
-      genNewArgs.push(() => t.spreadElement(t.identifier(argName)));
     } else {
       newParams.push(t.identifier(argName));
-      genNewArgs.push(() => t.identifier(argName));
     }
   }
+  const forwardCall = (callee: t.Identifier): t.CallExpression =>
+    t.callExpression(t.memberExpression(callee, t.identifier('apply')), [
+      t.thisExpression(),
+      t.identifier('arguments'),
+    ]);
   // insertAfter called in reverse order of how nodes should appear in program
   fnPath.insertAfter(
     t.functionDeclaration(
@@ -98,18 +100,8 @@ function insertAdditionalFunctionDeclaration(
       t.blockStatement([
         t.ifStatement(
           gatingCondition,
-          t.returnStatement(
-            t.callExpression(
-              compiled.id,
-              genNewArgs.map(fn => fn()),
-            ),
-          ),
-          t.returnStatement(
-            t.callExpression(
-              unoptimizedFnName,
-              genNewArgs.map(fn => fn()),
-            ),
-          ),
+          t.returnStatement(forwardCall(compiled.id)),
+          t.returnStatement(forwardCall(unoptimizedFnName)),
         ),
       ]),
     ),

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/component-syntax-ref-gating.flow.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/component-syntax-ref-gating.flow.expect.md
@@ -46,8 +46,9 @@ function Foo_withRef_unoptimized(
   return <Stringify ref={ref} />;
 }
 function Foo_withRef(arg0, arg1) {
-  if (isForgetEnabled_Fixtures_result) return Foo_withRef_optimized(arg0, arg1);
-  else return Foo_withRef_unoptimized(arg0, arg1);
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_withRef_optimized.apply(this, arguments);
+  else return Foo_withRef_unoptimized.apply(this, arguments);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-forwards-call.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-forwards-call.expect.md
@@ -1,0 +1,71 @@
+
+## Input
+
+```javascript
+// @gating
+
+const FooBeforeDeclaration = Foo;
+
+function callFoo() {
+  'use no memo';
+  return FooBeforeDeclaration('first', 'second');
+}
+
+function Foo(first) {
+  'use memo';
+  return [first, arguments[1], arguments.length];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: callFoo,
+  params: [],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating
+
+const FooBeforeDeclaration = Foo;
+
+function callFoo() {
+  "use no memo";
+  return FooBeforeDeclaration("first", "second");
+}
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
+
+function Foo_optimized(first) {
+  "use memo";
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== first) {
+    t0 = [first, arguments[1], arguments.length];
+    $[0] = first;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+function Foo_unoptimized(first) {
+  "use memo";
+  return [first, arguments[1], arguments.length];
+}
+function Foo(arg0) {
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_optimized.apply(this, arguments);
+  else return Foo_unoptimized.apply(this, arguments);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: callFoo,
+  params: [],
+};
+
+```
+      
+### Eval output
+(kind: ok) ["first","second",2]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-forwards-call.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-forwards-call.js
@@ -1,0 +1,18 @@
+// @gating
+
+const FooBeforeDeclaration = Foo;
+
+function callFoo() {
+  'use no memo';
+  return FooBeforeDeclaration('first', 'second');
+}
+
+function Foo(first) {
+  'use memo';
+  return [first, arguments[1], arguments.length];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: callFoo,
+  params: [],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-ref.expect.md
@@ -45,8 +45,9 @@ function Foo_withRef_unoptimized(props, ref) {
   return <Stringify ref={ref} {...props} />;
 }
 function Foo_withRef(arg0, arg1) {
-  if (isForgetEnabled_Fixtures_result) return Foo_withRef_optimized(arg0, arg1);
-  else return Foo_withRef_unoptimized(arg0, arg1);
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_withRef_optimized.apply(this, arguments);
+  else return Foo_withRef_unoptimized.apply(this, arguments);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl.expect.md
@@ -49,8 +49,9 @@ function Foo_unoptimized({ prop1, prop2 }) {
   return <Stringify prop1={prop1} prop2={prop2} />;
 }
 function Foo(arg0) {
-  if (isForgetEnabled_Fixtures_result) return Foo_optimized(arg0);
-  else return Foo_unoptimized(arg0);
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_optimized.apply(this, arguments);
+  else return Foo_unoptimized.apply(this, arguments);
 }
 
 export const FIXTURE_ENTRYPOINT = {


### PR DESCRIPTION
## Summary

- Dispatch gated optimized/unoptimized implementations with `.apply(this, arguments)`.
- Preserve extra runtime arguments and ordinary call context while retaining generated formal parameters and function `.length`.
- Add an evaluated use-before-declaration fixture that reproduces and fixes the semantic divergence.
- Refresh existing gating fixture output.

## Breaking changes

None. Generated gated output now preserves the source function's complete call semantics.

## Verification

- Isolated non-PnP compiler plugin `tsup` build passed.
- All gating fixtures: 31 passed.
- Full compiler ESLint, root Prettier check, and `git diff --check` passed.

Fixes #37439