### PR TITLE
Close child iterators when reconciliation throws

### DIFF
--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -228,6 +228,38 @@ describe('ReactChildReconciler', () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it('preserves reconciliation errors when reading iterator return throws', async () => {
+    const returnGetter = jest.fn(() => {
+      throw new Error('failed to read return');
+    });
+    const iterable = {
+      [Symbol.iterator]() {
+        let didYield = false;
+        const iterator = {
+          next() {
+            if (didYield) {
+              return {done: true};
+            }
+            didYield = true;
+            return {done: false, value: {invalid: true}};
+          },
+        };
+        Object.defineProperty(iterator, 'return', {get: returnGetter});
+        return iterator;
+      },
+    };
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await expect(
+      act(() => {
+        root.render(<div>{iterable}</div>);
+      }),
+    ).rejects.toThrow('Objects are not valid as a React child');
+
+    expect(returnGetter).toHaveBeenCalled();
+  });
+
   // @gate enableAsyncIterableChildren
   it('closes an async iterator when reconciling one of its children throws', async () => {
     const fulfilledThenable = value => ({

--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -198,4 +198,71 @@ describe('ReactChildReconciler', () => {
         '    in GrandParent (at **)',
     ]);
   });
+
+  it('closes an iterator when reconciling one of its children throws', async () => {
+    const close = jest.fn(() => ({done: true}));
+    const iterable = {
+      [Symbol.iterator]() {
+        let didYield = false;
+        return {
+          next() {
+            if (didYield) {
+              return {done: true};
+            }
+            didYield = true;
+            return {done: false, value: {invalid: true}};
+          },
+          return: close,
+        };
+      },
+    };
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await expect(
+      act(() => {
+        root.render(<div>{iterable}</div>);
+      }),
+    ).rejects.toThrow('Objects are not valid as a React child');
+
+    expect(close).toHaveBeenCalled();
+  });
+
+  // @gate enableAsyncIterableChildren
+  it('closes an async iterator when reconciling one of its children throws', async () => {
+    const fulfilledThenable = value => ({
+      status: 'fulfilled',
+      value,
+      then() {},
+    });
+    const closes = [];
+    const iterable = {
+      [Symbol.asyncIterator]() {
+        const close = jest.fn(() => fulfilledThenable({done: true}));
+        closes.push(close);
+        return {
+          next: () =>
+            fulfilledThenable({done: false, value: {invalidAsync: true}}),
+          return: close,
+        };
+      },
+    };
+
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+    await expect(
+      act(() => {
+        root.render(<div>{iterable}</div>);
+      }),
+    ).rejects.toThrow(
+      'Objects are not valid as a React child (found: object with keys {invalidAsync})',
+    );
+
+    // React retries the failed root once. Each underlying iterator must still
+    // be closed exactly once rather than once by each adapter layer.
+    expect(closes).toHaveLength(2);
+    closes.forEach(close => {
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1514,13 +1514,13 @@ function createChildReconciler(
         lanes,
       );
     } catch (error) {
-      const iteratorReturn = (newChildren as any).return;
-      if (typeof iteratorReturn === 'function') {
-        try {
+      try {
+        const iteratorReturn = (newChildren as any).return;
+        if (typeof iteratorReturn === 'function') {
           iteratorReturn.call(newChildren);
-        } catch {
-          // Preserve the reconciliation error, matching IteratorClose semantics.
         }
+      } catch {
+        // Preserve the reconciliation error, matching IteratorClose semantics.
       }
       throw error;
     }

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1480,6 +1480,12 @@ function createChildReconciler(
       next(): IteratorResult<mixed, void> {
         return unwrapThenable(newChildren.next());
       },
+      return(): IteratorResult<mixed, void> {
+        const iteratorReturn = (newChildren as any).return;
+        return typeof iteratorReturn === 'function'
+          ? unwrapThenable(iteratorReturn.call(newChildren))
+          : {done: true, value: undefined};
+      },
     } as any;
 
     return reconcileChildrenIterator(
@@ -1500,6 +1506,32 @@ function createChildReconciler(
       throw new Error('An iterable object provided no iterator.');
     }
 
+    try {
+      return reconcileChildrenIteratorImpl(
+        returnFiber,
+        currentFirstChild,
+        newChildren,
+        lanes,
+      );
+    } catch (error) {
+      const iteratorReturn = (newChildren as any).return;
+      if (typeof iteratorReturn === 'function') {
+        try {
+          iteratorReturn.call(newChildren);
+        } catch {
+          // Preserve the reconciliation error, matching IteratorClose semantics.
+        }
+      }
+      throw error;
+    }
+  }
+
+  function reconcileChildrenIteratorImpl(
+    returnFiber: Fiber,
+    currentFirstChild: Fiber | null,
+    newChildren: Iterator<mixed>,
+    lanes: Lanes,
+  ): Fiber | null {
     let resultingFirstChild: Fiber | null = null;
     let previousNewFiber: Fiber | null = null;
 


### PR DESCRIPTION
## Summary

- Close manually consumed child iterators when child creation/update throws.
- Preserve the original reconciliation error if iterator cleanup also fails.
- Forward `return()` through the async-iterable adapter.
- Add synchronous and gated asynchronous regressions, including retry ownership.

## Breaking changes

None. This adds expected iterator cleanup on an already failing reconciliation path.

## Verification

- Focused ReactChildReconciler suite: 7 tests passed.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37441