### PR TITLE
Render buffered iterable SuspenseList rows in Fizz

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -4083,6 +4083,23 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
+  // @gate enableSuspenseList
+  it('supports iterable rows in an ordered SuspenseList', async () => {
+    const rows = new Set([<span key="a">A</span>, <span key="b">B</span>]);
+
+    await act(() => {
+      const {pipe} = renderToPipeableStream(
+        <SuspenseList revealOrder="forwards">{rows}</SuspenseList>,
+      );
+      pipe(writable);
+    });
+
+    expect(getVisibleChildren(container)).toEqual([
+      <span>A</span>,
+      <span>B</span>,
+    ]);
+  });
+
   // @gate enableAsyncIterableChildren
   it('supports async generator component', async () => {
     async function* App() {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -2278,7 +2278,7 @@ function renderSuspenseList(
             rows.push(step.value);
             step = iterator.next();
           } while (!step.done);
-          renderSuspenseListRows(request, task, keyPath, children, revealOrder);
+          renderSuspenseListRows(request, task, keyPath, rows, revealOrder);
         }
         return;
       }


### PR DESCRIPTION
## Summary

- Render the array of rows buffered from synchronous iterables in ordered Fizz `SuspenseList` paths.
- Add a server-rendering regression covering ordered `Set` children.

## Breaking changes

None. This restores iterable behavior to match ordered array children.

## Verification

- `ReactDOMFizzServer` suite: 224 tests and 17 snapshots passed.
- Changed-source linc, Prettier, and `git diff --check` passed.

Fixes #37443