### PR TITLE
Traverse compiler stacks iteratively

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/Stack.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/Stack.ts
@@ -60,18 +60,39 @@ class Node<T> implements StackInterface<T> {
   }
 
   find(fn: (value: T) => boolean): boolean {
-    return fn(this.#value) ? true : this.#next.find(fn);
+    if (fn(this.#value)) {
+      return true;
+    }
+    let current = this.#next;
+    while (current instanceof Node) {
+      if (fn(current.#value)) {
+        return true;
+      }
+      current = current.#next;
+    }
+    return false;
   }
 
   contains(value: T): boolean {
-    return (
-      value === this.#value ||
-      (this.#next !== null && this.#next.contains(value))
-    );
+    if (value === this.#value) {
+      return true;
+    }
+    let current = this.#next;
+    while (current instanceof Node) {
+      if (value === current.#value) {
+        return true;
+      }
+      current = current.#next;
+    }
+    return false;
   }
   each(fn: (value: T) => void): void {
     fn(this.#value);
-    this.#next.each(fn);
+    let current = this.#next;
+    while (current instanceof Node) {
+      fn(current.#value);
+      current = current.#next;
+    }
   }
 
   get value(): T {
@@ -79,7 +100,13 @@ class Node<T> implements StackInterface<T> {
   }
 
   print(fn: (node: T) => string): string {
-    return fn(this.#value) + this.#next.print(fn);
+    const output = [fn(this.#value)];
+    let current = this.#next;
+    while (current instanceof Node) {
+      output.push(fn(current.#value));
+      current = current.#next;
+    }
+    return output.join('');
   }
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Stack-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Stack-test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {empty, Stack} from '../Utils/Stack';
+
+describe('Stack', () => {
+  test('visits values from the top of the stack down', () => {
+    const stack = empty<number>().push(1).push(2).push(3);
+    const values: Array<number> = [];
+
+    stack.each(value => values.push(value));
+
+    expect(values).toEqual([3, 2, 1]);
+    expect(stack.print(String)).toBe('321');
+  });
+
+  test('traverses deeply nested stacks without overflowing', () => {
+    let stack: Stack<number> = empty();
+    for (let i = 0; i < 20_000; i++) {
+      stack = stack.push(i);
+    }
+
+    expect(stack.find(value => value === 0)).toBe(true);
+    expect(stack.contains(0)).toBe(true);
+
+    let count = 0;
+    let first = null;
+    let last = null;
+    stack.each(value => {
+      first ??= value;
+      last = value;
+      count++;
+    });
+    expect(count).toBe(20_000);
+    expect(first).toBe(19_999);
+    expect(last).toBe(0);
+    expect(stack.print(() => '.')).toHaveLength(20_000);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace recursive compiler Stack traversals with iterative linked-node walks.
- Preserve top-to-bottom visitation and print order.
- Add order and 20,000-node overflow regressions covering all four traversal helpers.

## Breaking changes

None. Return values and traversal order are unchanged.

## Verification

- Focused typed Jest suite: 2 tests passed.
- Full compiler ESLint, root Prettier check, and `git diff --check` passed.

Fixes #37445