### PR TITLE
Preserve negative zero through compiler optimizations

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
@@ -196,7 +196,7 @@ function evaluatePhi(phi: Phi, constants: Constants): Constant | null {
         });
 
         // different constant values, can't constant propogate
-        if (operandValue.value !== value.value) {
+        if (!Object.is(operandValue.value, value.value)) {
           return null;
         }
         break;

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -2368,7 +2368,7 @@ function codegenValue(
   value: boolean | number | string | null | undefined,
 ): t.Expression {
   if (typeof value === 'number') {
-    if (value < 0) {
+    if (value < 0 || Object.is(value, -0)) {
       /**
        * Babel's code generator produces invalid JS for negative numbers when
        * run with { compact: true }.

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-preserves-negative-zero-phi.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-preserves-negative-zero-phi.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+function SignedZero({negative}) {
+  'use memo';
+  let value;
+  if (negative) {
+    value = -0;
+  } else {
+    value = 0;
+  }
+  return 1 / value < 0 ? 'negative' : 'positive';
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: SignedZero,
+  params: [{negative: false}],
+  sequentialRenders: [{negative: false}, {negative: true}],
+};
+
+```
+
+## Code
+
+```javascript
+function SignedZero(t0) {
+  "use memo";
+  const { negative } = t0;
+
+  let value;
+  if (negative) {
+    value = -0;
+  } else {
+    value = 0;
+  }
+
+  return 1 / value < 0 ? "negative" : "positive";
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: SignedZero,
+  params: [{ negative: false }],
+  sequentialRenders: [{ negative: false }, { negative: true }],
+};
+
+```
+      
+### Eval output
+(kind: ok) "positive"
+"negative"

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-preserves-negative-zero-phi.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-preserves-negative-zero-phi.js
@@ -1,0 +1,16 @@
+function SignedZero({negative}) {
+  'use memo';
+  let value;
+  if (negative) {
+    value = -0;
+  } else {
+    value = 0;
+  }
+  return 1 / value < 0 ? 'negative' : 'positive';
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: SignedZero,
+  params: [{negative: false}],
+  sequentialRenders: [{negative: false}, {negative: true}],
+};


### PR DESCRIPTION
## Summary

- Compare primitive phi constants with `Object.is` so `0` and `-0` remain distinct.
- Emit negative zero through the compiler numeric-literal code path.
- Add an evaluated fixture alternating a memoized phi between both signed-zero values.

## Breaking changes

None. This preserves JavaScript numeric semantics.

## Verification

- Isolated rebuilt compiler fixture and snapshot passed.
- Full compiler ESLint, root Prettier check, and `git diff --check` passed.

Fixes #37447