### PR TITLE
Fix aborted Fragment event listener registration

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3034,6 +3034,10 @@ FragmentInstance.prototype.addEventListener = function (
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): void {
+  const signal = getListenerSignal(optionsOrUseCapture);
+  if (signal != null && signal.aborted) {
+    return;
+  }
   if (this._eventListeners === null) {
     this._eventListeners = [];
   }
@@ -3042,8 +3046,24 @@ FragmentInstance.prototype.addEventListener = function (
   // Element.addEventListener will only apply uniquely new event listeners by default. Since we
   // need to collect the listeners to apply to appended children, we track them ourselves and use
   // custom equality check for the options.
-  const isNewEventListener =
-    indexOfEventListener(listeners, type, listener, optionsOrUseCapture) === -1;
+  const existingIndex = indexOfEventListener(
+    listeners,
+    type,
+    listener,
+    optionsOrUseCapture,
+  );
+  let isNewEventListener = existingIndex === -1;
+  if (existingIndex !== -1) {
+    const existingSignal = getListenerSignal(
+      listeners[existingIndex].optionsOrUseCapture,
+    );
+    if (existingSignal != null && existingSignal.aborted) {
+      // The signal has already removed this listener from every host child.
+      // Discard the stale record so the listener can be added again.
+      listeners.splice(existingIndex, 1);
+      isNewEventListener = true;
+    }
+  }
   if (isNewEventListener) {
     const fragmentInstance = this;
     let attachedListener = listener;
@@ -3131,6 +3151,11 @@ function removeEventListenerFromChild(
   const instance = getInstanceFromHostFiber<Instance | TextInstance>(child);
   instance.removeEventListener(type, listener, optionsOrUseCapture);
   return false;
+}
+function getListenerSignal(
+  opts: ?EventListenerOptionsOrUseCapture,
+): void | AbortSignal {
+  return opts != null && typeof opts !== 'boolean' ? opts.signal : undefined;
 }
 function isOnceOption(opts: ?EventListenerOptionsOrUseCapture): boolean {
   return opts != null && typeof opts !== 'boolean' && opts.once === true;

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -874,6 +874,71 @@ describe('FragmentRefs', () => {
       });
 
       // @gate enableFragmentRefs
+      it('can re-add a listener after its signal aborts', async () => {
+        const fragmentRef = React.createRef();
+        const childRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+        const controller = new AbortController();
+        const logs = [];
+
+        function listener() {
+          logs.push('click');
+        }
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <div ref={childRef}>child</div>
+            </Fragment>,
+          );
+        });
+
+        fragmentRef.current.addEventListener('click', listener, {
+          signal: controller.signal,
+        });
+        childRef.current.click();
+        expect(logs).toEqual(['click']);
+
+        controller.abort();
+        childRef.current.click();
+        expect(logs).toEqual(['click']);
+
+        fragmentRef.current.addEventListener('click', listener);
+        childRef.current.click();
+        expect(logs).toEqual(['click', 'click']);
+      });
+
+      // @gate enableFragmentRefs
+      it('does not track a listener with an already aborted signal', async () => {
+        const fragmentRef = React.createRef();
+        const childRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+        const controller = new AbortController();
+        const logs = [];
+
+        function listener() {
+          logs.push('click');
+        }
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <div ref={childRef}>child</div>
+            </Fragment>,
+          );
+        });
+
+        controller.abort();
+        fragmentRef.current.addEventListener('click', listener, {
+          signal: controller.signal,
+        });
+        fragmentRef.current.addEventListener('click', listener);
+
+        childRef.current.click();
+        expect(logs).toEqual(['click']);
+      });
+
+      // @gate enableFragmentRefs
       it('adds and removes event listeners from children with multiple fragments', async () => {
         const fragmentRef = React.createRef();
         const nestedFragmentRef = React.createRef();


### PR DESCRIPTION
## Summary

- Ignore Fragment listener registrations whose signal is already aborted.
- Discard stale same-identity records after their signal aborts so listeners can be registered again.
- Add regressions for both abort-before-add and abort-after-add sequences.

## Breaking changes

None. Fragment refs remain experimental/gated; this aligns their listener behavior with host EventTargets.

## Verification

- Full ReactDOMFragmentRefs suites: 92 tests passed.
- DOM-node Flow, targeted ESLint, Prettier, and `git diff --check` passed.

Fixes #37449