### PR TITLE
Unobserve removed Fragment children

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3826,6 +3826,11 @@ export function deleteChildFromFragmentInstance(
     return;
   }
   const instance: InstanceWithFragmentHandles = childInstance as any;
+  if (fragmentInstance._observers !== null) {
+    fragmentInstance._observers.forEach(observer => {
+      observer.unobserve(instance);
+    });
+  }
   if (enableFragmentRefsInstanceHandles) {
     if (instance.reactFragments != null) {
       instance.reactFragments.delete(fragmentInstance);

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1766,6 +1766,7 @@ describe('FragmentRefs', () => {
           logs.push(entry.target.id);
         });
       });
+      const unobserve = jest.spyOn(observer, 'unobserve');
       function Test({showB}) {
         const fragmentRef = React.useRef(null);
         React.useEffect(() => {
@@ -1805,10 +1806,12 @@ describe('FragmentRefs', () => {
       await act(() => root.render(<Test showB={true} />));
       simulateAllChildrenIntersecting();
       expect(logs).toEqual(['childA', 'childB']);
+      const childB = container.querySelector('#childB');
 
       // Hide child and expect it to be unobserved
       logs = [];
       await act(() => root.render(<Test showB={false} />));
+      expect(unobserve).toHaveBeenCalledWith(childB);
       simulateAllChildrenIntersecting();
       expect(logs).toEqual(['childA']);
 


### PR DESCRIPTION
## Summary

- Unobserve removed Fragment element children from every registered observer.
- Mirror the existing insertion behavior while continuing to skip text children.
- Strengthen the dynamic-child regression with the exact removed node assertion.

## Breaking changes

None. Fragment refs remain experimental/gated; this completes expected observer cleanup.

## Verification

- Full ReactDOMFragmentRefs suites: 90 tests passed.
- DOM-node Flow, targeted ESLint, Prettier, and `git diff --check` passed.

Fixes #37451