### PR TITLE
Avoid quadratic browser server task draining

### DIFF
--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -14,10 +14,17 @@ export opaque type Chunk = Uint8Array;
 export type BinaryChunk = Uint8Array;
 
 const channel = new MessageChannel();
-const taskQueue = [];
+const taskQueue: Array<null | (() => void)> = [];
+// Keep a head index so draining a burst does not repeatedly shift the array.
+let taskQueueIndex = 0;
 channel.port1.onmessage = () => {
-  const task = taskQueue.shift();
-  if (task) {
+  const task = taskQueue[taskQueueIndex];
+  taskQueue[taskQueueIndex++] = null;
+  if (taskQueueIndex === taskQueue.length) {
+    taskQueue.length = 0;
+    taskQueueIndex = 0;
+  }
+  if (task != null) {
     task();
   }
 };


### PR DESCRIPTION
## Summary

- Consume browser server tasks through a head index instead of `Array.shift()`.
- Clear each consumed callback immediately and reset queue storage once drained.
- Preserve FIFO, reentrant scheduling, and thrown-callback cleanup behavior.

## Breaking changes

None. This is an internal scheduling implementation change.

## Verification

- ReactDOMFizzServerBrowser and ReactDOMFizzStaticBrowser: 51 tests passed.
- ReactFlightDOMBrowser: 60 tests passed.
- DOM-browser Flow, targeted ESLint, Prettier, and `git diff --check` passed.
- Bounded operation benchmark, 100,000 callbacks / median 5 runs: shift 6442.20 ms; indexed 0.11 ms. This is algorithmic evidence, not a production throughput claim.

Fixes #37453