### PR TITLE
[DOM] Always clean up Fragment dispatch targets

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3236,7 +3236,7 @@ FragmentInstance.prototype.dispatchEvent = function (
         }
       }
       const tempParent = temp.parentNode;
-      if (tempParent != null) {
+      if (tempParent !== null) {
         tempParent.removeChild(temp);
       }
     }

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3221,19 +3221,25 @@ FragmentInstance.prototype.dispatchEvent = function (
       }
     }
     parentHostInstance.appendChild(temp);
-    const cancelable = temp.dispatchEvent(event);
-    if (eventListeners) {
-      for (let i = 0; i < eventListeners.length; i++) {
-        const {type, attachedListener, optionsOrUseCapture} = eventListeners[i];
-        temp.removeEventListener(
-          type,
-          attachedListener,
-          getAttachOptions(optionsOrUseCapture),
-        );
+    try {
+      return temp.dispatchEvent(event);
+    } finally {
+      if (eventListeners) {
+        for (let i = 0; i < eventListeners.length; i++) {
+          const {type, attachedListener, optionsOrUseCapture} =
+            eventListeners[i];
+          temp.removeEventListener(
+            type,
+            attachedListener,
+            getAttachOptions(optionsOrUseCapture),
+          );
+        }
+      }
+      const tempParent = temp.parentNode;
+      if (tempParent != null) {
+        tempParent.removeChild(temp);
       }
     }
-    parentHostInstance.removeChild(temp);
-    return cancelable;
   } else {
     return parentHostInstance.dispatchEvent(event);
   }

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1750,6 +1750,64 @@ describe('FragmentRefs', () => {
         );
         expect(logs).toEqual([['click', undefined, undefined]]);
       });
+
+      // @gate enableFragmentRefs
+      it('removes its temporary node when native dispatch throws', async () => {
+        const fragmentRef = React.createRef();
+        const parentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+
+        await act(() => {
+          root.render(
+            <div ref={parentRef}>
+              <Fragment ref={fragmentRef} />
+            </div>,
+          );
+        });
+
+        expect(parentRef.current.childNodes).toHaveLength(0);
+        const error = new Error('dispatch failed');
+        const nativeDispatch = EventTarget.prototype.dispatchEvent;
+        const dispatch = jest
+          .spyOn(EventTarget.prototype, 'dispatchEvent')
+          .mockImplementation(function (event) {
+            if (this.nodeType === Node.TEXT_NODE) {
+              throw error;
+            }
+            return nativeDispatch.call(this, event);
+          });
+        try {
+          expect(() => {
+            fragmentRef.current.dispatchEvent(new Event('test'));
+          }).toThrow(error);
+        } finally {
+          dispatch.mockRestore();
+        }
+        expect(parentRef.current.childNodes).toHaveLength(0);
+      });
+
+      // @gate enableFragmentRefs
+      it('allows a listener to remove the temporary event target', async () => {
+        const fragmentRef = React.createRef();
+        const parentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+
+        await act(() => {
+          root.render(
+            <div ref={parentRef}>
+              <Fragment ref={fragmentRef} />
+            </div>,
+          );
+        });
+
+        fragmentRef.current.addEventListener('test', event => {
+          event.target.remove();
+        });
+        expect(() => {
+          fragmentRef.current.dispatchEvent(new Event('test'));
+        }).not.toThrow();
+        expect(parentRef.current.childNodes).toHaveLength(0);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #37455

- Tear down temporary Fragment dispatch listeners and DOM state in `finally`.
- Remove the private target from its actual parent only when it remains attached.


## Test plan

- added tests

