### PR TITLE
[DOM] Clean up Fragment listeners on signal abort

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2991,6 +2991,7 @@ type StoredEventListener = {
   // When once:true, a wrapper that removes the fragment listener after the
   // first fire. Otherwise the same as listener.
   attachedListener: EventListener,
+  cleanup: void | (() => void),
 };
 
 export type FragmentInstanceType = {
@@ -3034,6 +3035,15 @@ FragmentInstance.prototype.addEventListener = function (
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): void {
+  let signal: void | AbortSignal;
+  let cleanup: void | (() => void);
+  if (optionsOrUseCapture != null && typeof optionsOrUseCapture !== 'boolean') {
+    signal = optionsOrUseCapture.signal;
+    if (signal != null && signal.aborted) {
+      return;
+    }
+  }
+
   if (this._eventListeners === null) {
     this._eventListeners = [];
   }
@@ -3063,12 +3073,27 @@ FragmentInstance.prototype.addEventListener = function (
         }
       };
     }
+    if (signal != null) {
+      const onAbort = function () {
+        fragmentInstance.removeEventListener(
+          type,
+          listener,
+          optionsOrUseCapture,
+        );
+      };
+      signal.addEventListener('abort', onAbort, {once: true});
+      cleanup = function () {
+        // $FlowFixMe[incompatible-use]
+        signal.removeEventListener('abort', onAbort);
+      };
+    }
     const attachOptions = getAttachOptions(optionsOrUseCapture);
     listeners.push({
       type,
       listener,
       optionsOrUseCapture,
       attachedListener,
+      cleanup,
     });
     traverseFragmentInstancesAndTextInstances(
       this._fragmentFiber,
@@ -3110,8 +3135,11 @@ FragmentInstance.prototype.removeEventListener = function (
   if (index === -1) {
     return;
   }
-  const {attachedListener, optionsOrUseCapture: storedOptions} =
-    listeners[index];
+  const {
+    attachedListener,
+    optionsOrUseCapture: storedOptions,
+    cleanup,
+  } = listeners[index];
   const attachOptions = getAttachOptions(storedOptions);
   traverseFragmentInstancesAndTextInstances(
     this._fragmentFiber,
@@ -3121,6 +3149,9 @@ FragmentInstance.prototype.removeEventListener = function (
     attachOptions,
   );
   listeners.splice(index, 1);
+  if (cleanup != null) {
+    cleanup();
+  }
 };
 function removeEventListenerFromChild(
   child: Fiber,
@@ -3138,14 +3169,17 @@ function isOnceOption(opts: ?EventListenerOptionsOrUseCapture): boolean {
 function getAttachOptions(
   opts: void | EventListenerOptionsOrUseCapture,
 ): void | EventListenerOptionsOrUseCapture {
-  // Strip once when attaching to host children; Fragment owns once semantics.
-  if (opts == null || typeof opts === 'boolean' || opts.once !== true) {
+  // Strip once and signal when attaching to host children; Fragment owns once and signal semantics.
+  if (
+    opts == null ||
+    typeof opts === 'boolean' ||
+    (opts.once !== true && !(opts.signal instanceof AbortSignal))
+  ) {
     return opts;
   }
   return {
     capture: opts.capture,
     passive: opts.passive,
-    signal: opts.signal,
   };
 }
 function normalizeListenerOptions(

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3074,18 +3074,15 @@ FragmentInstance.prototype.addEventListener = function (
       };
     }
     if (signal != null) {
-      const onAbort = function () {
-        fragmentInstance.removeEventListener(
-          type,
-          listener,
-          optionsOrUseCapture,
-        );
-      };
+      const onAbort = fragmentInstance.removeEventListener.bind(
+        fragmentInstance,
+        type,
+        listener,
+        optionsOrUseCapture,
+      );
       signal.addEventListener('abort', onAbort, {once: true});
-      cleanup = function () {
-        // $FlowFixMe[incompatible-use]
-        signal.removeEventListener('abort', onAbort);
-      };
+      // $FlowFixMe[method-unbinding]
+      cleanup = signal.removeEventListener.bind(signal, 'abort', onAbort);
     }
     const attachOptions = getAttachOptions(optionsOrUseCapture);
     listeners.push({

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -2991,7 +2991,7 @@ type StoredEventListener = {
   // When once:true, a wrapper that removes the fragment listener after the
   // first fire. Otherwise the same as listener.
   attachedListener: EventListener,
-  cleanup: void | (() => void),
+  cleanup: null | (() => void),
 };
 
 export type FragmentInstanceType = {
@@ -3035,11 +3035,11 @@ FragmentInstance.prototype.addEventListener = function (
   listener: EventListener,
   optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
 ): void {
-  let signal: void | AbortSignal;
-  let cleanup: void | (() => void);
+  let signal: null | AbortSignal = null;
+  let cleanup: null | (() => void) = null;
   if (optionsOrUseCapture != null && typeof optionsOrUseCapture !== 'boolean') {
-    signal = optionsOrUseCapture.signal;
-    if (signal != null && signal.aborted) {
+    signal = optionsOrUseCapture.signal || null;
+    if (signal !== null && signal.aborted) {
       return;
     }
   }
@@ -3073,7 +3073,7 @@ FragmentInstance.prototype.addEventListener = function (
         }
       };
     }
-    if (signal != null) {
+    if (signal !== null) {
       const onAbort = fragmentInstance.removeEventListener.bind(
         fragmentInstance,
         type,
@@ -3146,7 +3146,7 @@ FragmentInstance.prototype.removeEventListener = function (
     attachOptions,
   );
   listeners.splice(index, 1);
-  if (cleanup != null) {
+  if (cleanup !== null) {
     cleanup();
   }
 };

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -1098,6 +1098,122 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
+      // @gate enableFragmentRefs
+      it('should remove the listener when the signal is aborted before registration', async () => {
+        const fragmentRef = React.createRef();
+        const childRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+        let logs = [];
+
+        function registeredListener() {
+          logs.push('registered');
+        }
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <div ref={childRef}>child</div>
+            </Fragment>,
+          );
+        });
+
+        const signal = AbortSignal.abort();
+        fragmentRef.current.addEventListener('click', registeredListener, {
+          signal,
+        });
+        childRef.current.click();
+        expect(logs).toEqual([]);
+
+        // The event listener can be re-added
+        fragmentRef.current.addEventListener('click', registeredListener);
+        logs = [];
+        childRef.current.click();
+        expect(logs).toEqual(['registered']);
+      });
+
+      // @gate enableFragmentRefs
+      it('should remove the listener when the signal is aborted after registration', async () => {
+        const fragmentRef = React.createRef();
+        const childRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+        let logs = [];
+
+        function registeredListener() {
+          logs.push('registered');
+        }
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <div ref={childRef}>child</div>
+            </Fragment>,
+          );
+        });
+
+        const controller = new AbortController();
+        fragmentRef.current.addEventListener('click', registeredListener, {
+          signal: controller.signal,
+        });
+        childRef.current.click();
+        expect(logs).toEqual(['registered']);
+
+        logs = [];
+        controller.abort();
+        childRef.current.click();
+        expect(logs).toEqual([]);
+
+        // The event listener can be re-added
+        fragmentRef.current.addEventListener('click', registeredListener);
+        logs = [];
+        childRef.current.click();
+        expect(logs).toEqual(['registered']);
+      });
+
+      // @gate enableFragmentRefs
+      it('should NOT remove the new subscription when the signal for the old subscription is aborted', async () => {
+        const fragmentRef = React.createRef();
+        const childRef = React.createRef();
+        const root = ReactDOMClient.createRoot(container);
+        let logs = [];
+
+        function registeredListener() {
+          logs.push('registered');
+        }
+
+        await act(() => {
+          root.render(
+            <Fragment ref={fragmentRef}>
+              <div ref={childRef}>child</div>
+            </Fragment>,
+          );
+        });
+
+        const controller = new AbortController();
+        fragmentRef.current.addEventListener('click', registeredListener, {
+          signal: controller.signal,
+        });
+        childRef.current.click();
+        expect(logs).toEqual(['registered']);
+
+        fragmentRef.current.removeEventListener('click', registeredListener);
+        logs = [];
+        childRef.current.click();
+        expect(logs).toEqual([]);
+
+        // Added without a signal
+        fragmentRef.current.addEventListener('click', registeredListener);
+        logs = [];
+        childRef.current.click();
+        // Listener is called
+        expect(logs).toEqual(['registered']);
+
+        logs = [];
+        controller.abort();
+        childRef.current.click();
+        // Listener is called
+        expect(logs).toEqual(['registered']);
+      });
+
       // @gate enableFragmentRefs && enableFragmentRefsTextNodes
       it('adds an event listener to a newly added text child', async () => {
         const fragmentRef = React.createRef();


### PR DESCRIPTION
## Summary

Closes #37450
Fixes https://github.com/react/react/issues/37449

Listeners registered with `options.signal` are supposed to be removed when the signal is aborted.

Since `FragmentInstance` does not clean up its tracked listeners on abort, previously removed listeners cannot be re-attached.

## How did you test this change?

- added tests characterizing the bug in the first commit
