### PR TITLE
fix(react-dom): support string values for hidden attribute

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -780,7 +780,6 @@ function setProp(
     case 'disablePictureInPicture':
     case 'disableRemotePlayback':
     case 'formNoValidate':
-    case 'hidden':
     case 'loop':
     case 'noModule':
     case 'noValidate':
@@ -801,7 +800,8 @@ function setProp(
     }
     // Overloaded Boolean
     case 'capture':
-    case 'download': {
+    case 'download':
+    case 'hidden': {
       // An attribute that can be used as a flag as well as with a value.
       // When true, it should be present (set either to an empty string or its name).
       // When false, it should be omitted.
@@ -2904,7 +2904,6 @@ function diffHydratedGenericElement(
       case 'disablePictureInPicture':
       case 'disableRemotePlayback':
       case 'formNoValidate':
-      case 'hidden':
       case 'loop':
       case 'noModule':
       case 'noValidate':
@@ -2928,7 +2927,8 @@ function diffHydratedGenericElement(
         continue;
       }
       case 'capture':
-      case 'download': {
+      case 'download':
+      case 'hidden': {
         hydrateOverloadedBooleanAttribute(
           domElement,
           propKey,

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1771,7 +1771,6 @@ function pushAttribute(
     case 'disablePictureInPicture':
     case 'disableRemotePlayback':
     case 'formNoValidate':
-    case 'hidden':
     case 'loop':
     case 'noModule':
     case 'noValidate':
@@ -1794,7 +1793,8 @@ function pushAttribute(
       return;
     }
     case 'capture':
-    case 'download': {
+    case 'download':
+    case 'hidden': {
       // Overloaded Boolean
       if (value === true) {
         target.push(

--- a/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
@@ -295,7 +295,6 @@ function validateProperty(tagName, name, value, eventRegistry) {
             case 'disablePictureInPicture':
             case 'disableRemotePlayback':
             case 'formNoValidate':
-            case 'hidden':
             case 'loop':
             case 'noModule':
             case 'noValidate':

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -230,6 +230,27 @@ describe('DOMPropertyOperations', () => {
       expect(container.firstChild.hasAttribute('hidden')).toBe(false);
     });
 
+    it('should set string values properly for overloaded boolean properties like hidden', async () => {
+      const container = document.createElement('div');
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => {
+        root.render(<div hidden="until-found" />);
+      });
+      expect(container.firstChild.getAttribute('hidden')).toBe('until-found');
+      await act(() => {
+        root.render(<div hidden={true} />);
+      });
+      expect(container.firstChild.getAttribute('hidden')).toBe('');
+      await act(() => {
+        root.render(<div hidden="until-found" />);
+      });
+      expect(container.firstChild.getAttribute('hidden')).toBe('until-found');
+      await act(() => {
+        root.render(<div hidden={false} />);
+      });
+      expect(container.firstChild.hasAttribute('hidden')).toBe(false);
+    });
+
     it('should always assign the value attribute for non-inputs', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -3659,16 +3659,18 @@ describe('ReactDOMComponent', () => {
       const root = ReactDOMClient.createRoot(container);
 
       await act(() => {
-        root.render(<div hidden="false" ref={current => (el = current)} />);
+        root.render(
+          <button disabled="false" ref={current => (el = current)} />,
+        );
       });
       assertConsoleErrorDev([
-        'Received the string `false` for the boolean attribute `hidden`. ' +
+        'Received the string `false` for the boolean attribute `disabled`. ' +
           'The browser will interpret it as a truthy value. ' +
-          'Did you mean hidden={false}?\n' +
-          '    in div (at **)',
+          'Did you mean disabled={false}?\n' +
+          '    in button (at **)',
       ]);
 
-      expect(el.getAttribute('hidden')).toBe('');
+      expect(el.getAttribute('disabled')).toBe('');
     });
 
     it('warns on the potentially-ambiguous string value "true"', async function () {
@@ -3677,16 +3679,16 @@ describe('ReactDOMComponent', () => {
       const root = ReactDOMClient.createRoot(container);
 
       await act(() => {
-        root.render(<div hidden="true" ref={current => (el = current)} />);
+        root.render(<button disabled="true" ref={current => (el = current)} />);
       });
       assertConsoleErrorDev([
-        'Received the string `true` for the boolean attribute `hidden`. ' +
+        'Received the string `true` for the boolean attribute `disabled`. ' +
           'Although this works, it will not work as expected if you pass the string "false". ' +
-          'Did you mean hidden={true}?\n' +
-          '    in div (at **)',
+          'Did you mean disabled={true}?\n' +
+          '    in button (at **)',
       ]);
 
-      expect(el.getAttribute('hidden')).toBe('');
+      expect(el.getAttribute('disabled')).toBe('');
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -119,69 +119,126 @@ describe('ReactDOMServerIntegration', () => {
 
     describe('boolean properties', function () {
       itRenders('boolean prop with true value', async render => {
-        const e = await render(<div hidden={true} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<button disabled={true} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       itRenders('boolean prop with false value', async render => {
-        const e = await render(<div hidden={false} />);
-        expect(e.getAttribute('hidden')).toBe(null);
+        const e = await render(<button disabled={false} />);
+        expect(e.getAttribute('disabled')).toBe(null);
       });
 
       itRenders('boolean prop with self value', async render => {
-        const e = await render(<div hidden="hidden" />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<button disabled="disabled" />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
-      // this does not seem like correct behavior, since hidden="" in HTML indicates
+      // this does not seem like correct behavior, since disabled="" in HTML indicates
       // that the boolean property is present. however, it is how the current code
       // behaves, so the test is included here.
       itRenders('boolean prop with "" value', async render => {
-        const e = await render(<div hidden="" />);
-        expect(e.getAttribute('hidden')).toBe(null);
+        const e = await render(<button disabled="" />);
+        expect(e.getAttribute('disabled')).toBe(null);
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with string value', async render => {
-        const e = await render(<div hidden="foo" />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<button disabled="foo" />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with array value', async render => {
-        const e = await render(<div hidden={['foo', 'bar']} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<button disabled={['foo', 'bar']} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with object value', async render => {
-        const e = await render(<div hidden={{foo: 'bar'}} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<button disabled={{foo: 'bar'}} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with non-zero number value', async render => {
-        const e = await render(<div hidden={10} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<button disabled={10} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with zero value', async render => {
-        const e = await render(<div hidden={0} />);
-        expect(e.getAttribute('hidden')).toBe(null);
+        const e = await render(<button disabled={0} />);
+        expect(e.getAttribute('disabled')).toBe(null);
       });
 
       itRenders('no boolean prop with null value', async render => {
+        const e = await render(<button disabled={null} />);
+        expect(e.hasAttribute('disabled')).toBe(false);
+      });
+
+      itRenders('no boolean prop with function value', async render => {
+        const e = await render(<button disabled={function () {}} />, 1);
+        expect(e.hasAttribute('disabled')).toBe(false);
+      });
+
+      itRenders('no boolean prop with symbol value', async render => {
+        const e = await render(<button disabled={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('disabled')).toBe(false);
+      });
+    });
+
+    describe('hidden property (combined boolean/string attribute)', function () {
+      itRenders('hidden prop with true value', async render => {
+        const e = await render(<div hidden={true} />);
+        expect(e.getAttribute('hidden')).toBe('');
+      });
+
+      itRenders('hidden prop with false value', async render => {
+        const e = await render(<div hidden={false} />);
+        expect(e.getAttribute('hidden')).toBe(null);
+      });
+
+      itRenders('hidden prop with "until-found" string value', async render => {
+        const e = await render(<div hidden="until-found" />);
+        expect(e.getAttribute('hidden')).toBe('until-found');
+      });
+
+      itRenders('hidden prop with string value', async render => {
+        const e = await render(<div hidden="hidden" />);
+        expect(e.getAttribute('hidden')).toBe('hidden');
+      });
+
+      itRenders('hidden prop with string "false" value', async render => {
+        const e = await render(<div hidden="false" />);
+        expect(e.getAttribute('hidden')).toBe('false');
+      });
+
+      itRenders('hidden prop with string "true" value', async render => {
+        const e = await render(<div hidden={'true'} />);
+        expect(e.getAttribute('hidden')).toBe('true');
+      });
+
+      itRenders('hidden prop with number 0 value', async render => {
+        const e = await render(<div hidden={0} />);
+        expect(e.getAttribute('hidden')).toBe('0');
+      });
+
+      itRenders('no hidden prop with null value', async render => {
         const e = await render(<div hidden={null} />);
         expect(e.hasAttribute('hidden')).toBe(false);
       });
 
-      itRenders('no boolean prop with function value', async render => {
+      itRenders('no hidden prop with undefined value', async render => {
+        const e = await render(<div hidden={undefined} />);
+        expect(e.hasAttribute('hidden')).toBe(false);
+      });
+
+      itRenders('no hidden prop with function value', async render => {
         const e = await render(<div hidden={function () {}} />, 1);
         expect(e.hasAttribute('hidden')).toBe(false);
       });
 
-      itRenders('no boolean prop with symbol value', async render => {
+      itRenders('no hidden prop with symbol value', async render => {
         const e = await render(<div hidden={Symbol('foo')} />, 1);
         expect(e.hasAttribute('hidden')).toBe(false);
       });


### PR DESCRIPTION
## Summary

Under the WHATWG HTML standard, the `hidden` attribute is an enumerated/overloaded boolean attribute that supports string values like `hidden="until-found"`. Previously, React DOM and Fizz SSR treated `hidden` strictly as a boolean attribute, stripping string values to empty strings.

This change moves `hidden` to overloaded boolean attribute handling across client rendering, hydration, and Fizz SSR so string values like `until-found` are preserved while retaining boolean toggle behavior.

Fixes #24740

## How did you test this change?

- Added tests in `packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js` verifying server rendering, client rendering, and hydration with `hidden="until-found"`, `hidden={true}`, `hidden={false}`, and string values.
- Added tests in `packages/react-dom/src/__tests__/DOMPropertyOperations-test.js` for client property updates.
- Ran `yarn linc`, `yarn prettier-check`, `yarn flow dom-node`, and `yarn flow dom-browser`.