### PR TITLE
fix(reconciler): close child iterators on abrupt reconciliation exit

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1480,6 +1480,15 @@ function createChildReconciler(
       next(): IteratorResult<mixed, void> {
         return unwrapThenable(newChildren.next());
       },
+      return(value: mixed): IteratorResult<mixed, void> {
+        if (typeof newChildren.return === 'function') {
+          // Close the underlying async iterator. The result is a thenable but
+          // we intentionally do not unwrap it — the reconciler only needs to
+          // signal closure and does not consume the return value.
+          newChildren.return(value);
+        }
+        return {value: value, done: true};
+      },
     } as any;
 
     return reconcileChildrenIterator(
@@ -1509,6 +1518,9 @@ function createChildReconciler(
     let nextOldFiber = null;
 
     let knownKeys: Set<string> | null = null;
+
+    let iteratorDone = false;
+    try {
 
     let step = newChildren.next();
     for (
@@ -1567,6 +1579,7 @@ function createChildReconciler(
 
     if (step.done) {
       // We've reached the end of the new children. We can delete the rest.
+      iteratorDone = true;
       deleteRemainingChildren(returnFiber, oldFiber);
       if (getIsHydrating()) {
         const numberOfForks = newIdx;
@@ -1600,6 +1613,7 @@ function createChildReconciler(
         }
         previousNewFiber = newFiber;
       }
+      iteratorDone = true;
       if (getIsHydrating()) {
         const numberOfForks = newIdx;
         pushTreeFork(returnFiber, numberOfForks);
@@ -1657,6 +1671,8 @@ function createChildReconciler(
       }
     }
 
+    iteratorDone = true;
+
     if (shouldTrackSideEffects) {
       // Any existing children that weren't consumed above were deleted. We need
       // to add them to the deletion list.
@@ -1668,6 +1684,17 @@ function createChildReconciler(
       pushTreeFork(returnFiber, numberOfForks);
     }
     return resultingFirstChild;
+
+    } finally {
+      if (!iteratorDone && typeof newChildren.return === 'function') {
+        try {
+          newChildren.return();
+        } catch (_closeError) {
+          // Swallow — closing the iterator must not mask the original error
+          // that caused the abrupt exit from reconciliation.
+        }
+      }
+    }
   }
 
   function reconcileSingleTextNode(

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -1027,4 +1027,51 @@ describe('ReactFragment', () => {
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
+
+  it('should close an iterator when a yielded child throws during reconciliation', async () => {
+    const returnSpy = jest.fn();
+
+    function makeIterable() {
+      // The second item is a plain object — not a valid React child.
+      // createChild will throw via throwOnInvalidObjectType.
+      const items = [<span key="a">ok</span>, {invalid: true}];
+      return {
+        [Symbol.iterator]() {
+          let index = 0;
+          return {
+            next() {
+              if (index < items.length) {
+                return {value: items[index++], done: false};
+              }
+              return {value: undefined, done: true};
+            },
+            return() {
+              returnSpy();
+              return {value: undefined, done: true};
+            },
+          };
+        },
+      };
+    }
+
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromError(error) {
+        return {error};
+      }
+      render() {
+        return this.state.error ? (
+          <span>error</span>
+        ) : (
+          this.props.children
+        );
+      }
+    }
+
+    ReactNoop.render(
+      <ErrorBoundary>{makeIterable()}</ErrorBoundary>,
+    );
+    await waitForAll([]);
+    expect(returnSpy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #37441 — the reconciler manually consumes child iterators via `next()` but never calls `return()` when reconciliation throws partway through, leaving generator cleanup and resource release pending.

**Root cause:** `reconcileChildrenIterator` iterates children in three separate for-loops. If any call inside those loops throws (e.g. `createChild`, `updateSlot`, or `updateFromMap` encountering an invalid child type), the function exits without signaling the iterator. Per the iterator protocol, a consumer that stops early must call `return()` so the producer can run cleanup (`finally` blocks in generators, resource release in custom iterables).

Additionally, the async-iterable adapter in `reconcileChildrenAsyncIteratable` wraps the underlying `AsyncIterator` but only exposes `next()` — it omits `return()`, so even if the sync consumption path handled iterator close correctly, async iterables could never be closed.

**Fix:**
- Wrap the iterator consumption in `reconcileChildrenIterator` with `try/finally`. A tracking flag (`iteratorDone`) distinguishes normal completion from abrupt exit. The `finally` block calls `return()` only when the iterator did not run to completion, and swallows any error from `return()` itself to preserve the original reconciliation error.
- Add a `return()` method to the sync adapter created for async iterables that forwards to the underlying async iterator's `return()`.

## Changed files

- `packages/react-reconciler/src/ReactChildFiber.js` — try/finally in `reconcileChildrenIterator`; `return()` on async adapter
- `packages/react-reconciler/src/__tests__/ReactFragment-test.js` — regression test: custom iterable with a `return()` spy that verifies it is called when a yielded child triggers an error

## Test plan

- [x] New test: iterator `return()` spy called on reconciliation error — passed
- [x] Full `ReactFragment-test.js` suite — 25/25 passed
- [x] Full `packages/react-reconciler/src/__tests__/` — 77 suites, 1146 passed, 0 failures