### PR TITLE
fix(children): close iterators when React.Children.map callback throws

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -305,17 +305,29 @@ function mapIntoArray(
       const iterator = iteratorFn.call(iterableChildren);
       let step;
       let ii = 0;
-      // $FlowFixMe[incompatible-use] `iteratorFn` might return null according to typing.
-      while (!(step = iterator.next()).done) {
-        child = step.value;
-        nextName = nextNamePrefix + getElementKey(child, ii++);
-        subtreeCount += mapIntoArray(
-          child,
-          array,
-          escapedPrefix,
-          nextName,
-          callback,
-        );
+      let iteratorDone = false;
+      try {
+        // $FlowFixMe[incompatible-use] `iteratorFn` might return null according to typing.
+        while (!(step = iterator.next()).done) {
+          child = step.value;
+          nextName = nextNamePrefix + getElementKey(child, ii++);
+          subtreeCount += mapIntoArray(
+            child,
+            array,
+            escapedPrefix,
+            nextName,
+            callback,
+          );
+        }
+        iteratorDone = true;
+      } finally {
+        if (!iteratorDone && typeof iterator.return === 'function') {
+          try {
+            iterator.return();
+          } catch (_closeError) {
+            // Swallow — closing the iterator must not mask the original error.
+          }
+        }
       }
     } else if (type === 'object') {
       if (typeof (children as any).then === 'function') {

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -1224,4 +1224,36 @@ describe('ReactChildren', () => {
       ]);
     });
   });
+
+  it('should close an iterator when mapping throws', () => {
+    const returnSpy = jest.fn();
+    const iterable = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return {
+          next() {
+            if (i < 3) {
+              return {value: <span key={String(i++)} />, done: false};
+            }
+            return {value: undefined, done: true};
+          },
+          return() {
+            returnSpy();
+            return {value: undefined, done: true};
+          },
+        };
+      },
+    };
+
+    expect(() => {
+      React.Children.map(iterable, (child, index) => {
+        if (index === 1) {
+          throw new Error('map callback error');
+        }
+        return child;
+      });
+    }).toThrow('map callback error');
+
+    expect(returnSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #37427 — `React.Children.map` (and `forEach`, `count`, `toArray`) manually iterates via `iterator.next()` but never calls `iterator.return()` when the map callback or recursive traversal throws.

**Root cause:** `mapIntoArray` in `ReactChildren.js` consumes the iterator in a while loop. If the user-supplied `callback` or the recursive `mapIntoArray` call throws, the function exits without signaling the iterator. Per the iterator protocol, a consumer that stops early must call `return()` so the producer can run cleanup (`finally` blocks in generators, resource release in custom iterables).

**Fix:** Wrap the iteration loop in `try/finally`. A tracking flag (`iteratorDone`) distinguishes normal completion from abrupt exit. The `finally` block calls `return()` only when the iterator did not run to completion, and swallows any error from `return()` itself to preserve the original error.

## Changed files

- `packages/react/src/ReactChildren.js` — try/finally around iterator consumption in `mapIntoArray`
- `packages/react/src/__tests__/ReactChildren-test.js` — regression test: custom iterable with a `return()` spy, map callback throws on second element, verifies `return()` was called exactly once

## Test plan

- [x] New test: iterator `return()` spy called when map callback throws — passed
- [x] Full `ReactChildren-test.js` suite — 43/43 passed