### PR TITLE
perf(server): replace quadratic task queue drain with index-based FIFO

### DIFF
--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -14,10 +14,19 @@ export opaque type Chunk = Uint8Array;
 export type BinaryChunk = Uint8Array;
 
 const channel = new MessageChannel();
-const taskQueue = [];
+let taskQueue: Array<() => void> = [];
+let taskQueueHead = 0;
 channel.port1.onmessage = () => {
-  const task = taskQueue.shift();
-  if (task) {
+  if (taskQueueHead < taskQueue.length) {
+    const task = taskQueue[taskQueueHead];
+    taskQueue[taskQueueHead] = (undefined: any);
+    taskQueueHead++;
+    // Compact when the consumed prefix is both large enough to matter and
+    // at least half the array, so the copy is amortized.
+    if (taskQueueHead > 1024 && taskQueueHead > (taskQueue.length >>> 1)) {
+      taskQueue = taskQueue.slice(taskQueueHead);
+      taskQueueHead = 0;
+    }
     task();
   }
 };


### PR DESCRIPTION
## Summary

Fixes #37453 — the browser server stream scheduler stores pending callbacks in an array and removes one per `MessageChannel` delivery with `Array.shift()`. Each shift copies every remaining element, making queue draining O(n²) in the number of scheduled tasks during a burst.

**Fix:** Replace `shift()` with a head-index that advances in O(1). Consumed slots are nulled out so callbacks can be garbage-collected. When the consumed prefix exceeds both 1024 entries and half the array length, the live tail is compacted into a fresh array. This preserves FIFO ordering, supports reentrant scheduling, and keeps amortized memory bounded.

## Changed files

- `packages/react-server/src/ReactServerStreamConfigBrowser.js` — replace `shift()` with indexed dequeue and periodic compaction

## Test plan

- [x] `ReactDOMFizzServer-test.js` — 183/183 passed (core SSR streaming tests)
- [x] `packages/react-server/` — 2/3 suites passed (1 pre-existing snapshot failure in `ReactFlightAsyncDebugInfo-test.js`, unrelated to this change — confirmed by running on unmodified `main`)