### PR TITLE
oxc port: use typed keys for aliasing effect interning

### DIFF
--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -1426,7 +1426,7 @@ pub enum AliasingEffect {
         mutates_function: bool,
         args: Vec<PlaceOrSpreadOrHole>,
         into: Place,
-        signature: Option<FunctionSignature>,
+        signature: Option<std::rc::Rc<FunctionSignature>>,
         loc: Option<SourceLocation>,
     },
     /// Function expression creation with captures.

--- a/compiler/crates/react_compiler_hir/src/type_config.rs
+++ b/compiler/crates/react_compiler_hir/src/type_config.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxBuildHasher;
 use crate::Effect;
 
 /// Mirrors TS `ValueKind` enum for use in config.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ValueKind {
     Mutable,

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -13,6 +13,7 @@
 
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use std::rc::Rc;
 
 use react_compiler_diagnostics::CompilerDiagnostic;
 use react_compiler_diagnostics::CompilerDiagnosticDetail;
@@ -660,15 +661,17 @@ enum MutationResult {
 // =============================================================================
 
 struct Context {
-    interned_effects: FxHashMap<String, AliasingEffect>,
-    instruction_signature_cache: FxHashMap<u32, InstructionSignature>,
+    interned_effects: FxHashMap<EffectKey, AliasingEffect>,
+    /// `Rc` lets `apply_signature` retain the signature while mutably borrowing
+    /// the context without cloning the complete effect list on every visit.
+    instruction_signature_cache: FxHashMap<u32, Rc<InstructionSignature>>,
     catch_handlers: FxHashMap<BlockId, Place>,
     is_function_expression: bool,
     hoisted_context_declarations: FxHashMap<DeclarationId, Option<Place>>,
     non_mutating_spreads: FxHashSet<IdentifierId>,
-    /// Cache of ValueIds keyed by effect hash, ensuring stable allocation-site identity
+    /// Cache of ValueIds keyed by effect key, ensuring stable allocation-site identity
     /// across fixpoint iterations. Mirrors TS `effectInstructionValueCache`.
-    effect_value_id_cache: FxHashMap<String, ValueId>,
+    effect_value_id_cache: FxHashMap<EffectKey, ValueId>,
     /// Maps ValueId to FunctionId for function expressions, so we can look up
     /// locally-declared functions when processing Apply effects.
     function_values: FxHashMap<ValueId, FunctionId>,
@@ -682,16 +685,16 @@ struct Context {
 
 impl Context {
     fn intern_effect(&mut self, effect: AliasingEffect) -> AliasingEffect {
-        let hash = hash_effect(&effect);
-        self.interned_effects.entry(hash).or_insert(effect).clone()
+        let key = effect_key(&effect);
+        self.interned_effects.entry(key).or_insert(effect).clone()
     }
 
     /// Get or create a stable ValueId for a given effect, ensuring fixpoint convergence.
     fn get_or_create_value_id(&mut self, effect: &AliasingEffect) -> ValueId {
-        let hash = hash_effect(effect);
+        let key = effect_key(effect);
         *self
             .effect_value_id_cache
-            .entry(hash)
+            .entry(key)
             .or_insert_with(ValueId::new)
     }
 }
@@ -701,10 +704,106 @@ struct InstructionSignature {
 }
 
 // =============================================================================
-// Helper: hash_effect
+// Helper: effect_key
 // =============================================================================
 
-fn hash_effect(effect: &AliasingEffect) -> String {
+/// Uses exactly the fields from the previous string identity. Other fields are
+/// intentionally ignored, while error-carrying variants still clone messages.
+#[derive(PartialEq, Eq, Hash)]
+enum EffectKey {
+    Apply {
+        receiver: IdentifierId,
+        function: IdentifierId,
+        mutates_function: bool,
+        args: Vec<ArgKey>,
+        into: IdentifierId,
+    },
+    CreateFrom {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    ImmutableCapture {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Assign {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Alias {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Capture {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    MaybeAlias {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    Create {
+        into: IdentifierId,
+        value: ValueKind,
+        reason: ValueReason,
+    },
+    Freeze {
+        value: IdentifierId,
+        reason: ValueReason,
+    },
+    Impure {
+        place: IdentifierId,
+    },
+    Render {
+        place: IdentifierId,
+    },
+    MutateFrozen {
+        place: IdentifierId,
+        reason: String,
+        description: Option<String>,
+    },
+    MutateGlobal {
+        place: IdentifierId,
+        reason: String,
+        description: Option<String>,
+    },
+    Mutate {
+        value: IdentifierId,
+    },
+    MutateConditionally {
+        value: IdentifierId,
+    },
+    MutateTransitive {
+        value: IdentifierId,
+    },
+    MutateTransitiveConditionally {
+        value: IdentifierId,
+    },
+    CreateFunction {
+        into: IdentifierId,
+        function_id: FunctionId,
+        captures: Vec<IdentifierId>,
+    },
+    // Synthetic assignment keys share the cache but cannot collide with effects.
+    AssignFrozen {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+    AssignCopy {
+        from: IdentifierId,
+        into: IdentifierId,
+    },
+}
+
+/// Identifier-only key for an `Apply` argument.
+#[derive(PartialEq, Eq, Hash)]
+enum ArgKey {
+    Place(IdentifierId),
+    Spread(IdentifierId),
+    Hole,
+}
+
+fn effect_key(effect: &AliasingEffect) -> EffectKey {
     match effect {
         AliasingEffect::Apply {
             receiver,
@@ -714,86 +813,102 @@ fn hash_effect(effect: &AliasingEffect) -> String {
             into,
             ..
         } => {
-            let args_str: Vec<String> = args
+            let mut key_args: Vec<ArgKey> = args
                 .iter()
                 .map(|a| match a {
-                    PlaceOrSpreadOrHole::Hole => String::new(),
-                    PlaceOrSpreadOrHole::Place(p) => format!("{}", p.identifier.0),
-                    PlaceOrSpreadOrHole::Spread(s) => format!("...{}", s.place.identifier.0),
+                    PlaceOrSpreadOrHole::Hole => ArgKey::Hole,
+                    PlaceOrSpreadOrHole::Place(p) => ArgKey::Place(p.identifier),
+                    PlaceOrSpreadOrHole::Spread(s) => ArgKey::Spread(s.place.identifier),
                 })
                 .collect();
-            format!(
-                "Apply:{}:{}:{}:{}:{}",
-                receiver.identifier.0,
-                function.identifier.0,
-                mutates_function,
-                args_str.join(","),
-                into.identifier.0
-            )
+            if matches!(key_args.as_slice(), [ArgKey::Hole]) {
+                // Preserve the old collision between no arguments and one hole.
+                key_args.clear();
+            }
+            EffectKey::Apply {
+                receiver: receiver.identifier,
+                function: function.identifier,
+                mutates_function: *mutates_function,
+                args: key_args,
+                into: into.identifier,
+            }
         }
-        AliasingEffect::CreateFrom { from, into } => {
-            format!("CreateFrom:{}:{}", from.identifier.0, into.identifier.0)
-        }
-        AliasingEffect::ImmutableCapture { from, into } => format!(
-            "ImmutableCapture:{}:{}",
-            from.identifier.0, into.identifier.0
-        ),
-        AliasingEffect::Assign { from, into } => {
-            format!("Assign:{}:{}", from.identifier.0, into.identifier.0)
-        }
-        AliasingEffect::Alias { from, into } => {
-            format!("Alias:{}:{}", from.identifier.0, into.identifier.0)
-        }
-        AliasingEffect::Capture { from, into } => {
-            format!("Capture:{}:{}", from.identifier.0, into.identifier.0)
-        }
-        AliasingEffect::MaybeAlias { from, into } => {
-            format!("MaybeAlias:{}:{}", from.identifier.0, into.identifier.0)
-        }
+        AliasingEffect::CreateFrom { from, into } => EffectKey::CreateFrom {
+            from: from.identifier,
+            into: into.identifier,
+        },
+        AliasingEffect::ImmutableCapture { from, into } => EffectKey::ImmutableCapture {
+            from: from.identifier,
+            into: into.identifier,
+        },
+        AliasingEffect::Assign { from, into } => EffectKey::Assign {
+            from: from.identifier,
+            into: into.identifier,
+        },
+        AliasingEffect::Alias { from, into } => EffectKey::Alias {
+            from: from.identifier,
+            into: into.identifier,
+        },
+        AliasingEffect::Capture { from, into } => EffectKey::Capture {
+            from: from.identifier,
+            into: into.identifier,
+        },
+        AliasingEffect::MaybeAlias { from, into } => EffectKey::MaybeAlias {
+            from: from.identifier,
+            into: into.identifier,
+        },
         AliasingEffect::Create {
             into,
             value,
             reason,
-        } => format!("Create:{}:{:?}:{:?}", into.identifier.0, value, reason),
-        AliasingEffect::Freeze { value, reason } => {
-            format!("Freeze:{}:{:?}", value.identifier.0, reason)
-        }
-        AliasingEffect::Impure { place, .. } => format!("Impure:{}", place.identifier.0),
-        AliasingEffect::Render { place } => format!("Render:{}", place.identifier.0),
-        AliasingEffect::MutateFrozen { place, error } => format!(
-            "MutateFrozen:{}:{}:{:?}",
-            place.identifier.0, error.reason, error.description
-        ),
-        AliasingEffect::MutateGlobal { place, error } => format!(
-            "MutateGlobal:{}:{}:{:?}",
-            place.identifier.0, error.reason, error.description
-        ),
-        AliasingEffect::Mutate { value, .. } => format!("Mutate:{}", value.identifier.0),
-        AliasingEffect::MutateConditionally { value } => {
-            format!("MutateConditionally:{}", value.identifier.0)
-        }
-        AliasingEffect::MutateTransitive { value } => {
-            format!("MutateTransitive:{}", value.identifier.0)
-        }
+        } => EffectKey::Create {
+            into: into.identifier,
+            value: *value,
+            reason: *reason,
+        },
+        AliasingEffect::Freeze { value, reason } => EffectKey::Freeze {
+            value: value.identifier,
+            reason: *reason,
+        },
+        AliasingEffect::Impure { place, .. } => EffectKey::Impure {
+            place: place.identifier,
+        },
+        AliasingEffect::Render { place } => EffectKey::Render {
+            place: place.identifier,
+        },
+        AliasingEffect::MutateFrozen { place, error } => EffectKey::MutateFrozen {
+            place: place.identifier,
+            reason: error.reason.clone(),
+            description: error.description.clone(),
+        },
+        AliasingEffect::MutateGlobal { place, error } => EffectKey::MutateGlobal {
+            place: place.identifier,
+            reason: error.reason.clone(),
+            description: error.description.clone(),
+        },
+        AliasingEffect::Mutate { value, .. } => EffectKey::Mutate {
+            value: value.identifier,
+        },
+        AliasingEffect::MutateConditionally { value } => EffectKey::MutateConditionally {
+            value: value.identifier,
+        },
+        AliasingEffect::MutateTransitive { value } => EffectKey::MutateTransitive {
+            value: value.identifier,
+        },
         AliasingEffect::MutateTransitiveConditionally { value } => {
-            format!("MutateTransitiveConditionally:{}", value.identifier.0)
+            EffectKey::MutateTransitiveConditionally {
+                value: value.identifier,
+            }
         }
         AliasingEffect::CreateFunction {
             into,
             function_id,
             captures,
-        } => {
-            let cap_str: Vec<String> = captures
-                .iter()
-                .map(|p| format!("{}", p.identifier.0))
-                .collect();
-            format!(
-                "CreateFunction:{}:{}:{}",
-                into.identifier.0,
-                function_id.0,
-                cap_str.join(",")
-            )
-        }
+        } => EffectKey::CreateFunction {
+            into: into.identifier,
+            function_id: *function_id,
+            captures: captures.iter().map(|place| place.identifier).collect(),
+        },
     }
 }
 
@@ -1079,7 +1194,9 @@ fn infer_block(
                 &func.instructions[instr_index],
                 func,
             );
-            context.instruction_signature_cache.insert(*instr_idx, sig);
+            context
+                .instruction_signature_cache
+                .insert(*instr_idx, Rc::new(sig));
         }
 
         // Apply signature
@@ -1652,8 +1769,10 @@ fn apply_effect(
                         env,
                         func,
                     )?;
-                    let cache_key =
-                        format!("Assign_frozen:{}:{}", from.identifier.0, into.identifier.0);
+                    let cache_key = EffectKey::AssignFrozen {
+                        from: from.identifier,
+                        into: into.identifier,
+                    };
                     let value_id = *context
                         .effect_value_id_cache
                         .entry(cache_key)
@@ -1668,8 +1787,10 @@ fn apply_effect(
                     state.define(into.identifier, value_id);
                 }
                 ValueKind::Global | ValueKind::Primitive => {
-                    let cache_key =
-                        format!("Assign_copy:{}:{}", from.identifier.0, into.identifier.0);
+                    let cache_key = EffectKey::AssignCopy {
+                        from: from.identifier,
+                        into: into.identifier,
+                    };
                     let value_id = *context
                         .effect_value_id_cache
                         .entry(cache_key)
@@ -3534,9 +3655,11 @@ fn is_builtin_collection_type(ty: &Type) -> bool {
 fn get_function_call_signature(
     env: &Environment,
     callee_id: IdentifierId,
-) -> Result<Option<FunctionSignature>, CompilerDiagnostic> {
+) -> Result<Option<Rc<FunctionSignature>>, CompilerDiagnostic> {
     let ty = &env.types[env.identifiers[callee_id.0 as usize].type_.0 as usize];
-    Ok(env.get_function_signature(ty)?.cloned())
+    Ok(env
+        .get_function_signature(ty)?
+        .map(|sig| Rc::new(sig.clone())))
 }
 
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {


### PR DESCRIPTION
Directly port Oxc's typed aliasing-effect interning optimization into React's Rust compiler.

- Replace formatted string cache keys with typed `EffectKey` and `ArgKey` values.
- Share cached instruction signatures and `Apply` function signatures through `Rc`.
- Preserve the previous cache identity, including intentionally ignored fields and the empty-arguments/single-hole collision.

Original Oxc change: [oxc@7808a6e](https://github.com/oxc-project/oxc/commit/7808a6e964154f9cfe26abc029786a634fbf6c06)

This PR contains one React commit corresponding 1:1 to the Oxc source commit.

Original Oxc author: @mds-ant.

Local checks:
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `cargo check --manifest-path compiler/Cargo.toml -p react_compiler_inference`

Remaining coverage runs in remote CI.

Criterion full-corpus benchmark (1,809 fixtures, 50 samples, compared with saved main baseline): -2.83% (95% CI: -3.55% to -1.97%, p<0.01). Performance improved.

Peak RSS (50 fresh-process full-corpus samples): main mean 198.4 MiB; this PR mean 192.3 MiB; change -3.07%. This PR sample range: 191.3-193.7 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485
