### PR TITLE
oxc port: compute post-dominator frontiers together

### DIFF
--- a/compiler/crates/react_compiler_hir/src/dominator.rs
+++ b/compiler/crates/react_compiler_hir/src/dominator.rs
@@ -27,6 +27,18 @@ pub struct PostDominator {
     nodes: FxHashMap<BlockId, BlockId>,
 }
 
+/// Stores the post-dominator frontier for each block.
+pub struct PostDominatorFrontiers {
+    frontiers: FxHashMap<BlockId, FxHashSet<BlockId>>,
+}
+
+impl PostDominatorFrontiers {
+    /// Iterates over the blocks in `id`'s post-dominator frontier.
+    pub fn iter(&self, id: BlockId) -> impl Iterator<Item = BlockId> + '_ {
+        self.frontiers.get(&id).into_iter().flatten().copied()
+    }
+}
+
 impl PostDominator {
     /// Returns the immediate post-dominator of the given block, or None if
     /// the block post-dominates itself (i.e., it is the exit node).
@@ -40,6 +52,11 @@ impl PostDominator {
         } else {
             Some(*dominator)
         }
+    }
+
+    /// Iterates over `id` and its ancestors in the post-dominator tree.
+    fn ancestors(&self, id: BlockId) -> impl Iterator<Item = BlockId> + '_ {
+        std::iter::successors(Some(id), |&id| self.get(id))
     }
 }
 
@@ -269,62 +286,36 @@ fn intersect(a: BlockId, b: BlockId, graph: &Graph, doms: &FxHashMap<BlockId, Bl
 // Post-dominator frontier
 // =============================================================================
 
-/// Computes the post-dominator frontier of `target_id`. These are immediate
-/// predecessors of nodes that post-dominate `target_id` from which execution may
-/// not reach `target_id`. Intuitively, these are the earliest blocks from which
-/// execution branches such that it may or may not reach the target block.
-pub fn post_dominator_frontier(
+/// Computes the post-dominator frontiers of all blocks using the Cytron algorithm.
+///
+/// The frontier of a block contains the earliest blocks from which execution branches
+/// such that it may or may not reach that block. Walking each CFG edge up the immediate
+/// post-dominator chain avoids separately reverse-walking the whole CFG for every block.
+pub fn compute_post_dominator_frontiers(
     func: &HirFunction,
-    post_dominators: &PostDominator,
-    target_id: BlockId,
-) -> FxHashSet<BlockId> {
-    let target_post_dominators = post_dominators_of(func, post_dominators, target_id);
-    let mut visited = FxHashSet::default();
-    let mut frontier = FxHashSet::default();
+    next_block_id_counter: u32,
+    include_throws_as_exit_node: bool,
+) -> Result<PostDominatorFrontiers, CompilerDiagnostic> {
+    let post_dominators =
+        compute_post_dominator_tree(func, next_block_id_counter, include_throws_as_exit_node)?;
+    let mut frontiers: FxHashMap<BlockId, FxHashSet<BlockId>> = FxHashMap::default();
 
-    let mut to_visit: Vec<BlockId> = target_post_dominators.iter().copied().collect();
-    to_visit.push(target_id);
-
-    for block_id in to_visit {
-        if !visited.insert(block_id) {
-            continue;
-        }
-        if let Some(block) = func.body.blocks.get(&block_id) {
-            for &pred in &block.preds {
-                if !target_post_dominators.contains(&pred) {
-                    frontier.insert(pred);
-                }
+    // Apply Cytron's dominance-frontier algorithm to the reverse CFG. An original
+    // edge `block_id -> successor` is `successor -> block_id` in the reverse CFG,
+    // whose dominator tree is the post-dominator tree computed above.
+    for (&block_id, block) in &func.body.blocks {
+        let stop = post_dominators.get(block_id);
+        for successor in each_terminal_successor(&block.terminal) {
+            for runner in post_dominators
+                .ancestors(successor)
+                .take_while(|&runner| Some(runner) != stop)
+            {
+                frontiers.entry(runner).or_default().insert(block_id);
             }
         }
     }
-    frontier
-}
 
-/// Walks up the post-dominator tree to collect all blocks that post-dominate `target_id`.
-pub fn post_dominators_of(
-    func: &HirFunction,
-    post_dominators: &PostDominator,
-    target_id: BlockId,
-) -> FxHashSet<BlockId> {
-    let mut result = FxHashSet::default();
-    let mut visited = FxHashSet::default();
-    let mut queue = vec![target_id];
-
-    while let Some(current_id) = queue.pop() {
-        if !visited.insert(current_id) {
-            continue;
-        }
-        if let Some(block) = func.body.blocks.get(&current_id) {
-            for &pred in &block.preds {
-                let pred_post_dom = post_dominators.get(pred).unwrap_or(pred);
-                if pred_post_dom == target_id || result.contains(&pred_post_dom) {
-                    result.insert(pred);
-                }
-                queue.push(pred);
-            }
-        }
-    }
-    result
+    Ok(PostDominatorFrontiers { frontiers })
 }
 
 // =============================================================================

--- a/compiler/crates/react_compiler_inference/src/infer_reactive_places.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_reactive_places.rs
@@ -17,7 +17,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
-use react_compiler_hir::dominator::post_dominator_frontier;
+use react_compiler_hir::dominator::{PostDominatorFrontiers, compute_post_dominator_frontiers};
 use react_compiler_hir::environment::Environment;
 use react_compiler_hir::object_shape::HookKind;
 use react_compiler_hir::visitors;
@@ -54,15 +54,10 @@ pub fn infer_reactive_places(
         reactive_map.mark_reactive(place.identifier);
     }
 
-    // Compute control dominators
-    let post_dominators = react_compiler_hir::dominator::compute_post_dominator_tree(
-        func,
-        env.next_block_id().0,
-        false,
-    )?;
-
     // Collect block IDs for iteration
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
+
+    let frontiers = compute_post_dominator_frontiers(func, env.next_block_id().0, false)?;
 
     // Track phi operand reactive flags during fixpoint.
     // In TS, isReactive() sets place.reactive as a side effect. But when a phi
@@ -76,7 +71,7 @@ pub fn infer_reactive_places(
         for block_id in &block_ids {
             let block = func.body.blocks.get(block_id).unwrap();
             let has_reactive_control =
-                is_reactive_controlled_block(block.id, func, &post_dominators, &mut reactive_map);
+                is_reactive_controlled_block(block.id, func, &frontiers, &mut reactive_map);
 
             // Process phi nodes
             let block = func.body.blocks.get(block_id).unwrap();
@@ -100,12 +95,8 @@ pub fn infer_reactive_places(
                     reactive_map.mark_reactive(phi.place.identifier);
                 } else {
                     for (pred, _operand) in &phi.operands {
-                        if is_reactive_controlled_block(
-                            *pred,
-                            func,
-                            &post_dominators,
-                            &mut reactive_map,
-                        ) {
+                        if is_reactive_controlled_block(*pred, func, &frontiers, &mut reactive_map)
+                        {
                             reactive_map.mark_reactive(phi.place.identifier);
                             break;
                         }
@@ -372,12 +363,11 @@ impl StableSidemap {
 fn is_reactive_controlled_block(
     block_id: BlockId,
     func: &HirFunction,
-    post_dominators: &react_compiler_hir::dominator::PostDominator,
+    frontiers: &PostDominatorFrontiers,
     reactive_map: &mut ReactivityMap,
 ) -> bool {
-    let frontier = post_dominator_frontier(func, post_dominators, block_id);
-    for frontier_block_id in &frontier {
-        let control_block = func.body.blocks.get(frontier_block_id).unwrap();
+    for frontier_block_id in frontiers.iter(block_id) {
+        let control_block = func.body.blocks.get(&frontier_block_id).unwrap();
         match &control_block.terminal {
             Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
                 if reactive_map.is_reactive(test.identifier) {

--- a/compiler/crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs
@@ -17,7 +17,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, ErrorCategory,
 };
-use react_compiler_hir::dominator::{compute_post_dominator_tree, post_dominator_frontier};
+use react_compiler_hir::dominator::compute_post_dominator_frontiers;
 use react_compiler_hir::environment::Environment;
 use react_compiler_hir::{
     BlockId, HirFunction, Identifier, IdentifierId, IdentifierName, InstructionValue,
@@ -310,15 +310,14 @@ fn create_ref_controlled_block_checker(
     identifiers: &[Identifier],
     types: &[Type],
 ) -> Result<FxHashMap<BlockId, bool>, CompilerDiagnostic> {
-    let post_dominators = compute_post_dominator_tree(func, next_block_id_counter, false)?;
+    let frontiers = compute_post_dominator_frontiers(func, next_block_id_counter, false)?;
     let mut cache: FxHashMap<BlockId, bool> = FxHashMap::default();
 
     for (block_id, _block) in &func.body.blocks {
-        let frontier = post_dominator_frontier(func, &post_dominators, *block_id);
         let mut is_controlled = false;
 
-        for frontier_block_id in &frontier {
-            let control_block = &func.body.blocks[frontier_block_id];
+        for frontier_block_id in frontiers.iter(*block_id) {
+            let control_block = &func.body.blocks[&frontier_block_id];
             match &control_block.terminal {
                 Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
                     if is_derived_from_ref(test.identifier, ref_derived_values, identifiers, types)


### PR DESCRIPTION
Directly port Oxc's all-at-once post-dominator frontier computation into React's Rust compiler.

- Compute every post-dominator frontier in one Cytron-style pass instead of reverse-walking the CFG separately for every block.
- Reuse the computed frontiers in reactive-place inference.
- Reuse the same result in set-state validation.

Original Oxc change: [oxc@fd61cd8](https://github.com/oxc-project/oxc/commit/fd61cd860f2751ef0b27c3b64823a62b52b63aba)

This PR contains one React commit corresponding 1:1 to the Oxc source commit and preserves its algorithm comments.

Original Oxc author: @Boshen.

Local checks:
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `cargo check --manifest-path compiler/Cargo.toml --workspace --all-targets`

Remaining coverage runs in remote CI.

Criterion full-corpus benchmark (1,809 fixtures, 50 samples, compared with saved main baseline): -0.36% (95% CI: -1.03% to +0.31%, p=0.31). No performance change detected.

Peak RSS (50 fresh-process full-corpus samples): main mean 198.4 MiB; this PR mean 201.6 MiB; change +1.61%. This PR sample range: 200.9-202.8 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485
