### PR TITLE
oxc port: Use FxHashMap for the lookup-only aliasing node map

### DIFF
--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_ranges.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_ranges.rs
@@ -107,13 +107,13 @@ impl Node {
 }
 
 struct AliasingState {
-    nodes: IndexMap<IdentifierId, Node, FxBuildHasher>,
+    nodes: FxHashMap<IdentifierId, Node>,
 }
 
 impl AliasingState {
     fn new() -> Self {
         AliasingState {
-            nodes: IndexMap::default(),
+            nodes: FxHashMap::default(),
         }
     }
 


### PR DESCRIPTION
Change `AliasingState::nodes` from `IndexMap` to `FxHashMap`. The map is only used for lookup, insertion, mutation, and containment, so it does not need insertion ordering.

The order-sensitive `created_from`, `captures`, `aliases`, and `maybe_aliases` maps remain unchanged.

Ported from oxc-project/oxc commit `1c96753` by Boshen <boshenc@gmail.com>:
https://github.com/oxc-project/oxc/commit/1c96753d9cd8ed538b16f50b3adeef9a05c76181

Original Oxc author: @Boshen.

Validation:
- `cargo check --manifest-path compiler/Cargo.toml -p react_compiler_inference`
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `git diff --check`

Criterion full-corpus benchmark (1,809 fixtures, 50 samples, compared with saved main baseline): +0.35% (95% CI: -0.46% to +1.22%, p=0.44). No performance change detected.

Peak RSS (50 fresh-process full-corpus samples): main mean 198.4 MiB; this PR mean 195.9 MiB; change -1.26%. This PR sample range: 192.2-198.9 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485
