### PR TITLE
oxc port: use IndexVec for dense ID-keyed maps

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -337,6 +337,7 @@ name = "react_compiler_inference"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "react_compiler_hir",
  "react_compiler_lowering",
@@ -376,6 +377,7 @@ name = "react_compiler_optimization"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "react_compiler_hir",
  "react_compiler_lowering",
@@ -389,6 +391,7 @@ version = "0.1.0"
 dependencies = [
  "hmac-sha256",
  "indexmap",
+ "oxc_index",
  "react_compiler_ast",
  "react_compiler_diagnostics",
  "react_compiler_hir",
@@ -401,6 +404,7 @@ name = "react_compiler_ssa"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "react_compiler_hir",
  "rustc-hash",
@@ -429,6 +433,7 @@ name = "react_compiler_validation"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "react_compiler_hir",
  "rustc-hash",

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -249,6 +249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,7 @@ name = "react_compiler_hir"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "rustc-hash",
  "serde",

--- a/compiler/crates/react_compiler_hir/Cargo.toml
+++ b/compiler/crates/react_compiler_hir/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 react_compiler_diagnostics = { path = "../react_compiler_diagnostics" }
 indexmap = { version = "2", features = ["serde"] }
+oxc_index = "5.0.0"
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/compiler/crates/react_compiler_hir/src/dominator.rs
+++ b/compiler/crates/react_compiler_hir/src/dominator.rs
@@ -9,7 +9,9 @@
 //! Uses the Cooper/Harvey/Kennedy algorithm from
 //! https://www.cs.rice.edu/~keith/Embed/dom.pdf
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
+
+use oxc_index::{IndexSlice, IndexVec};
 
 use react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
 
@@ -24,21 +26,19 @@ use crate::{BlockId, HirFunction, Terminal};
 pub struct PostDominator {
     /// The exit node (synthetic node representing function exit).
     pub exit: BlockId,
-    nodes: FxHashMap<BlockId, BlockId>,
+    /// Immediate post-dominator per block, indexed densely by block id.
+    nodes: IndexVec<BlockId, Option<BlockId>>,
 }
 
 impl PostDominator {
     /// Returns the immediate post-dominator of the given block, or None if
     /// the block post-dominates itself (i.e., it is the exit node).
     pub fn get(&self, id: BlockId) -> Option<BlockId> {
-        let dominator = self
-            .nodes
-            .get(&id)
-            .expect("Unknown node in post-dominator tree");
-        if *dominator == id {
+        let dominator = self.nodes[id].expect("Unknown node in post-dominator tree");
+        if dominator == id {
             None
         } else {
-            Some(*dominator)
+            Some(dominator)
         }
     }
 }
@@ -59,12 +59,13 @@ struct Graph {
     /// Nodes stored in iteration order (RPO for reverse graph).
     nodes: Vec<Node>,
     /// Map from BlockId to index in the nodes vec.
-    node_index: FxHashMap<BlockId, usize>,
+    /// Map from BlockId to index in the nodes vec, indexed densely by block id.
+    node_index: IndexVec<BlockId, Option<usize>>,
 }
 
 impl Graph {
     fn get_node(&self, id: BlockId) -> &Node {
-        let idx = self.node_index[&id];
+        let idx = self.node_index[id].expect("Unknown node in dominator graph");
         &self.nodes[idx]
     }
 }
@@ -90,7 +91,7 @@ pub fn compute_post_dominator_tree(
     // with themselves as dominator.
     if !include_throws_as_exit_node {
         for (id, _) in &func.body.blocks {
-            nodes.entry(*id).or_insert(*id);
+            nodes[*id].get_or_insert(*id);
         }
     }
 
@@ -110,20 +111,20 @@ fn build_reverse_graph(
     include_throws_as_exit_node: bool,
 ) -> Graph {
     let exit_id = BlockId(next_block_id_counter);
+    // All block ids are below `next_block_id_counter`; add one slot for the exit node.
+    let num_ids = next_block_id_counter as usize + 1;
 
     // Build initial nodes with reversed edges
-    let mut raw_nodes: FxHashMap<BlockId, Node> = FxHashMap::default();
+    let mut raw_nodes: IndexVec<BlockId, Option<Node>> =
+        IndexVec::from_vec((0..num_ids).map(|_| None).collect());
 
     // Create exit node
-    raw_nodes.insert(
-        exit_id,
-        Node {
-            id: exit_id,
-            index: 0,
-            preds: FxHashSet::default(),
-            succs: FxHashSet::default(),
-        },
-    );
+    raw_nodes[exit_id] = Some(Node {
+        id: exit_id,
+        index: 0,
+        preds: FxHashSet::default(),
+        succs: FxHashSet::default(),
+    });
 
     for (id, block) in &func.body.blocks {
         let successors = each_terminal_successor(&block.terminal);
@@ -135,18 +136,15 @@ fn build_reverse_graph(
 
         if is_return || (is_throw && include_throws_as_exit_node) {
             preds_set.insert(exit_id);
-            raw_nodes.get_mut(&exit_id).unwrap().succs.insert(*id);
+            raw_nodes[exit_id].as_mut().unwrap().succs.insert(*id);
         }
 
-        raw_nodes.insert(
-            *id,
-            Node {
-                id: *id,
-                index: 0,
-                preds: preds_set,
-                succs: succs_set,
-            },
-        );
+        raw_nodes[*id] = Some(Node {
+            id: *id,
+            index: 0,
+            preds: preds_set,
+            succs: succs_set,
+        });
     }
 
     // DFS from exit to compute RPO
@@ -158,11 +156,11 @@ fn build_reverse_graph(
     postorder.reverse();
 
     let mut nodes = Vec::with_capacity(postorder.len());
-    let mut node_index = FxHashMap::default();
+    let mut node_index: IndexVec<BlockId, Option<usize>> = IndexVec::from_vec(vec![None; num_ids]);
     for (idx, id) in postorder.into_iter().enumerate() {
-        let mut node = raw_nodes.remove(&id).unwrap();
+        let mut node = raw_nodes[id].take().unwrap();
         node.index = idx;
-        node_index.insert(id, idx);
+        node_index[id] = Some(idx);
         nodes.push(node);
     }
 
@@ -175,14 +173,14 @@ fn build_reverse_graph(
 
 fn dfs_postorder(
     id: BlockId,
-    nodes: &FxHashMap<BlockId, Node>,
+    nodes: &IndexSlice<BlockId, [Option<Node>]>,
     visited: &mut FxHashSet<BlockId>,
     postorder: &mut Vec<BlockId>,
 ) {
     if !visited.insert(id) {
         return;
     }
-    if let Some(node) = nodes.get(&id) {
+    if let Some(node) = &nodes[id] {
         for &succ in &node.succs {
             dfs_postorder(succ, nodes, visited, postorder);
         }
@@ -196,9 +194,10 @@ fn dfs_postorder(
 
 fn compute_immediate_dominators(
     graph: &Graph,
-) -> Result<FxHashMap<BlockId, BlockId>, CompilerDiagnostic> {
-    let mut doms: FxHashMap<BlockId, BlockId> = FxHashMap::default();
-    doms.insert(graph.entry, graph.entry);
+) -> Result<IndexVec<BlockId, Option<BlockId>>, CompilerDiagnostic> {
+    let mut doms: IndexVec<BlockId, Option<BlockId>> =
+        IndexVec::from_vec(vec![None; graph.node_index.len()]);
+    doms[graph.entry] = Some(graph.entry);
 
     let mut changed = true;
     while changed {
@@ -211,7 +210,7 @@ fn compute_immediate_dominators(
             // Find first processed predecessor
             let mut new_idom: Option<BlockId> = None;
             for &pred in &node.preds {
-                if doms.contains_key(&pred) {
+                if doms[pred].is_some() {
                     new_idom = Some(pred);
                     break;
                 }
@@ -235,13 +234,13 @@ fn compute_immediate_dominators(
                 if pred == new_idom {
                     continue;
                 }
-                if doms.contains_key(&pred) {
+                if doms[pred].is_some() {
                     new_idom = intersect(pred, new_idom, graph, &doms);
                 }
             }
 
-            if doms.get(&node.id) != Some(&new_idom) {
-                doms.insert(node.id, new_idom);
+            if doms[node.id] != Some(new_idom) {
+                doms[node.id] = Some(new_idom);
                 changed = true;
             }
         }
@@ -249,16 +248,21 @@ fn compute_immediate_dominators(
     Ok(doms)
 }
 
-fn intersect(a: BlockId, b: BlockId, graph: &Graph, doms: &FxHashMap<BlockId, BlockId>) -> BlockId {
+fn intersect(
+    a: BlockId,
+    b: BlockId,
+    graph: &Graph,
+    doms: &IndexSlice<BlockId, [Option<BlockId>]>,
+) -> BlockId {
     let mut block1 = graph.get_node(a);
     let mut block2 = graph.get_node(b);
     while block1.id != block2.id {
         while block1.index > block2.index {
-            let dom = doms[&block1.id];
+            let dom = doms[block1.id].expect("Expected dominator to be set for processed node");
             block1 = graph.get_node(dom);
         }
         while block2.index > block1.index {
-            let dom = doms[&block2.id];
+            let dom = doms[block2.id].expect("Expected dominator to be set for processed node");
             block2 = graph.get_node(dom);
         }
     }

--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -40,6 +40,26 @@ pub struct EvaluationOrder(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DeclarationId(pub u32);
 
+macro_rules! impl_idx {
+    ($($id:ty),+ $(,)?) => {
+        $(
+            impl oxc_index::Idx for $id {
+                const MAX: usize = u32::MAX as usize;
+
+                unsafe fn from_usize_unchecked(index: usize) -> Self {
+                    Self(index as u32)
+                }
+
+                fn index(self) -> usize {
+                    self.0 as usize
+                }
+            }
+        )+
+    };
+}
+
+impl_idx!(BlockId, IdentifierId, DeclarationId);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ScopeId(pub u32);
 

--- a/compiler/crates/react_compiler_inference/Cargo.toml
+++ b/compiler/crates/react_compiler_inference/Cargo.toml
@@ -11,4 +11,5 @@ react_compiler_optimization = { path = "../react_compiler_optimization" }
 react_compiler_ssa = { path = "../react_compiler_ssa" }
 react_compiler_utils = { path = "../react_compiler_utils" }
 indexmap = "2"
+oxc_index = "5.0.0"
 rustc-hash = "2"

--- a/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
@@ -13,6 +13,7 @@
 //! - `src/HIR/DeriveMinimalDependenciesHIR.ts`
 
 use indexmap::IndexMap;
+use oxc_index::IndexVec;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
 
@@ -28,6 +29,10 @@ use react_compiler_hir::{
 // =============================================================================
 // Public entry point
 // =============================================================================
+
+/// Sidemap from temporary identifiers to the dependency they represent,
+/// indexed densely by identifier id.
+type TemporariesMap = IndexVec<IdentifierId, Option<ReactiveScopeDependency>>;
 
 /// Main entry point: propagate scope dependencies through the HIR.
 /// Corresponds to TS `propagateScopeDependenciesHIR(fn)`.
@@ -67,8 +72,10 @@ pub fn propagate_scope_dependencies_hir(func: &mut HirFunction, env: &mut Enviro
 
     // Merge temporaries + temporariesReadInOptional
     let mut merged_temporaries = temporaries;
-    for (k, v) in temporaries_read_in_optional {
-        merged_temporaries.insert(k, v);
+    for (k, v) in temporaries_read_in_optional.into_iter_enumerated() {
+        if v.is_some() {
+            merged_temporaries[k] = v;
+        }
     }
 
     let scope_deps = collect_dependencies(
@@ -130,19 +137,22 @@ fn find_temporaries_used_outside_declaring_scope(
     func: &HirFunction,
     env: &Environment,
 ) -> FxHashSet<DeclarationId> {
-    let mut declarations: FxHashMap<DeclarationId, ScopeId> = FxHashMap::default();
+    // Declaring scope per declaration, indexed densely by declaration id
+    // (declaration ids share the identifier id space).
+    let mut declarations: IndexVec<DeclarationId, Option<ScopeId>> =
+        IndexVec::from_vec(vec![None; env.identifiers.len()]);
     let mut pruned_scopes: FxHashSet<ScopeId> = FxHashSet::default();
     let mut traversal = ScopeBlockTraversal::new();
     let mut used_outside_declaring_scope: FxHashSet<DeclarationId> = FxHashSet::default();
 
     let handle_place = |place_id: IdentifierId,
-                        declarations: &FxHashMap<DeclarationId, ScopeId>,
+                        declarations: &IndexVec<DeclarationId, Option<ScopeId>>,
                         traversal: &ScopeBlockTraversal,
                         pruned_scopes: &FxHashSet<ScopeId>,
                         used_outside: &mut FxHashSet<DeclarationId>,
                         env: &Environment| {
         let decl_id = env.identifiers[place_id.0 as usize].declaration_id;
-        if let Some(&declaring_scope) = declarations.get(&decl_id) {
+        if let Some(declaring_scope) = declarations[decl_id] {
             if !traversal.is_scope_active(declaring_scope)
                 && !pruned_scopes.contains(&declaring_scope)
             {
@@ -192,7 +202,7 @@ fn find_temporaries_used_outside_declaring_scope(
                         | InstructionValue::PropertyLoad { .. } => {
                             let decl_id =
                                 env.identifiers[instr.lvalue.identifier.0 as usize].declaration_id;
-                            declarations.insert(decl_id, scope);
+                            declarations[decl_id] = Some(scope);
                         }
                         _ => {}
                     }
@@ -229,8 +239,8 @@ fn collect_temporaries_sidemap(
     func: &HirFunction,
     env: &Environment,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-) -> FxHashMap<IdentifierId, ReactiveScopeDependency> {
-    let mut temporaries = FxHashMap::default();
+) -> TemporariesMap {
+    let mut temporaries = IndexVec::from_vec(vec![None; env.identifiers.len()]);
     collect_temporaries_sidemap_impl(
         func,
         env,
@@ -271,7 +281,7 @@ fn collect_temporaries_sidemap_impl(
     func: &HirFunction,
     env: &Environment,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-    temporaries: &mut FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &mut TemporariesMap,
     inner_fn_context: Option<EvaluationOrder>,
 ) {
     for (_block_id, block) in &func.body.blocks {
@@ -292,9 +302,9 @@ fn collect_temporaries_sidemap_impl(
                     loc,
                     ..
                 } if !used_outside => {
-                    if inner_fn_context.is_none() || temporaries.contains_key(&object.identifier) {
+                    if inner_fn_context.is_none() || temporaries[object.identifier].is_some() {
                         let prop = get_property(object, property, false, *loc, temporaries, env);
-                        temporaries.insert(instr.lvalue.identifier, prop);
+                        temporaries[instr.lvalue.identifier] = Some(prop);
                     }
                 }
                 InstructionValue::LoadLocal { place, loc, .. }
@@ -310,15 +320,12 @@ fn collect_temporaries_sidemap_impl(
                             .iter()
                             .any(|ctx| ctx.identifier == place.identifier)
                     {
-                        temporaries.insert(
-                            instr.lvalue.identifier,
-                            ReactiveScopeDependency {
-                                identifier: place.identifier,
-                                reactive: place.reactive,
-                                path: vec![],
-                                loc: *loc,
-                            },
-                        );
+                        temporaries[instr.lvalue.identifier] = Some(ReactiveScopeDependency {
+                            identifier: place.identifier,
+                            reactive: place.reactive,
+                            path: vec![],
+                            loc: *loc,
+                        });
                     }
                 }
                 value @ InstructionValue::LoadContext { place, loc, .. }
@@ -335,15 +342,12 @@ fn collect_temporaries_sidemap_impl(
                             .iter()
                             .any(|ctx| ctx.identifier == place.identifier)
                     {
-                        temporaries.insert(
-                            instr.lvalue.identifier,
-                            ReactiveScopeDependency {
-                                identifier: place.identifier,
-                                reactive: place.reactive,
-                                path: vec![],
-                                loc: *loc,
-                            },
-                        );
+                        temporaries[instr.lvalue.identifier] = Some(ReactiveScopeDependency {
+                            identifier: place.identifier,
+                            reactive: place.reactive,
+                            path: vec![],
+                            loc: *loc,
+                        });
                     }
                 }
                 InstructionValue::FunctionExpression { lowered_func, .. }
@@ -370,10 +374,10 @@ fn get_property(
     property_name: &PropertyLiteral,
     optional: bool,
     loc: Option<react_compiler_hir::SourceLocation>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &TemporariesMap,
     _env: &Environment,
 ) -> ReactiveScopeDependency {
-    let resolved = temporaries.get(&object.identifier);
+    let resolved = temporaries[object.identifier].as_ref();
     if let Some(resolved) = resolved {
         let mut path = resolved.path.clone();
         path.push(DependencyPathEntry {
@@ -406,7 +410,7 @@ fn get_property(
 // =============================================================================
 
 struct OptionalChainSidemap {
-    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries_read_in_optional: TemporariesMap,
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
     hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency>,
 }
@@ -426,7 +430,7 @@ fn collect_optional_chain_sidemap(func: &HirFunction, env: &Environment) -> Opti
     let mut ctx = OptionalTraversalContext {
         seen_optionals: FxHashSet::default(),
         processed_instrs_in_optional: FxHashSet::default(),
-        temporaries_read_in_optional: FxHashMap::default(),
+        temporaries_read_in_optional: IndexVec::from_vec(vec![None; env.identifiers.len()]),
         hoistable_objects: FxHashMap::default(),
     };
 
@@ -442,7 +446,7 @@ fn collect_optional_chain_sidemap(func: &HirFunction, env: &Environment) -> Opti
 struct OptionalTraversalContext {
     seen_optionals: FxHashSet<BlockId>,
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
-    temporaries_read_in_optional: FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries_read_in_optional: TemporariesMap,
     hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency>,
 }
 
@@ -672,16 +676,13 @@ fn traverse_optional_block(
 
             if !is_optional {
                 // Non-optional load: record that PropertyLoads from inner optional are hoistable
-                if let Some(inner_dep) = ctx.temporaries_read_in_optional.get(&inner_optional_id) {
-                    ctx.hoistable_objects
-                        .insert(optional_block.id, inner_dep.clone());
+                if let Some(inner_dep) = &ctx.temporaries_read_in_optional[inner_optional_id] {
+                    let inner_dep = inner_dep.clone();
+                    ctx.hoistable_objects.insert(optional_block.id, inner_dep);
                 }
             }
 
-            let base = ctx
-                .temporaries_read_in_optional
-                .get(&inner_optional_id)?
-                .clone();
+            let base = ctx.temporaries_read_in_optional[inner_optional_id].clone()?;
             (&test_block.terminal, base)
         }
         _ => return None,
@@ -772,10 +773,8 @@ fn traverse_optional_block(
             }
             _ => BlockId(0),
         }));
-    ctx.temporaries_read_in_optional
-        .insert(match_result.consequent_id, load.clone());
-    ctx.temporaries_read_in_optional
-        .insert(match_result.property_id, load);
+    ctx.temporaries_read_in_optional[match_result.consequent_id] = Some(load.clone());
+    ctx.temporaries_read_in_optional[match_result.property_id] = Some(load);
 
     Some(match_result.consequent_id)
 }
@@ -963,7 +962,7 @@ struct BlockInfo {
 fn collect_hoistable_property_loads(
     func: &HirFunction,
     env: &Environment,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &TemporariesMap,
     hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency>,
 ) -> FxHashMap<BlockId, BlockInfo> {
     let mut registry = PropertyPathRegistry::new();
@@ -995,7 +994,7 @@ fn collect_hoistable_property_loads(
 }
 
 struct CollectHoistableContext<'a> {
-    temporaries: &'a FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &'a TemporariesMap,
     known_immutable_identifiers: &'a FxHashSet<IdentifierId>,
     hoistable_from_optionals: &'a FxHashMap<BlockId, ReactiveScopeDependency>,
     nested_fn_immutable_context: Option<&'a FxHashSet<IdentifierId>>,
@@ -1028,26 +1027,21 @@ fn in_range(id: EvaluationOrder, range: &MutableRange) -> bool {
 
 fn get_maybe_non_null_in_instruction(
     value: &InstructionValue,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &TemporariesMap,
 ) -> Option<ReactiveScopeDependency> {
     match value {
-        InstructionValue::PropertyLoad { object, .. } => Some(
-            temporaries
-                .get(&object.identifier)
-                .cloned()
-                .unwrap_or_else(|| ReactiveScopeDependency {
+        InstructionValue::PropertyLoad { object, .. } => {
+            Some(temporaries[object.identifier].clone().unwrap_or_else(|| {
+                ReactiveScopeDependency {
                     identifier: object.identifier,
                     reactive: object.reactive,
                     path: vec![],
                     loc: object.loc,
-                }),
-        ),
-        InstructionValue::Destructure { value: val, .. } => {
-            temporaries.get(&val.identifier).cloned()
+                }
+            }))
         }
-        InstructionValue::ComputedLoad { object, .. } => {
-            temporaries.get(&object.identifier).cloned()
-        }
+        InstructionValue::Destructure { value: val, .. } => temporaries[val.identifier].clone(),
+        InstructionValue::ComputedLoad { object, .. } => temporaries[object.identifier].clone(),
         _ => None,
     }
 }
@@ -1508,7 +1502,7 @@ fn recursively_propagate_non_null(
 fn collect_hoistable_and_propagate(
     func: &HirFunction,
     env: &Environment,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &TemporariesMap,
     hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency>,
 ) -> (FxHashMap<BlockId, BTreeSet<usize>>, PropertyPathRegistry) {
     let mut registry = PropertyPathRegistry::new();
@@ -1818,12 +1812,15 @@ struct Decl {
 
 /// Context for dependency collection.
 struct DependencyCollectionContext<'a> {
-    declarations: FxHashMap<DeclarationId, Decl>,
-    reassignments: FxHashMap<IdentifierId, Decl>,
+    /// Declaration record per declaration id (declaration ids share the
+    /// identifier id space).
+    declarations: IndexVec<DeclarationId, Option<Decl>>,
+    /// Latest reassignment record per identifier id.
+    reassignments: IndexVec<IdentifierId, Option<Decl>>,
     scope_stack: Vec<ScopeId>,
     dep_stack: Vec<Vec<ReactiveScopeDependency>>,
     deps: IndexMap<ScopeId, Vec<ReactiveScopeDependency>, FxBuildHasher>,
-    temporaries: &'a FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &'a TemporariesMap,
     #[allow(dead_code)]
     temporaries_used_outside_scope: &'a FxHashSet<DeclarationId>,
     processed_instrs_in_optional: &'a FxHashSet<ProcessedInstr>,
@@ -1832,13 +1829,14 @@ struct DependencyCollectionContext<'a> {
 
 impl<'a> DependencyCollectionContext<'a> {
     fn new(
+        num_identifiers: usize,
         temporaries_used_outside_scope: &'a FxHashSet<DeclarationId>,
-        temporaries: &'a FxHashMap<IdentifierId, ReactiveScopeDependency>,
+        temporaries: &'a TemporariesMap,
         processed_instrs_in_optional: &'a FxHashSet<ProcessedInstr>,
     ) -> Self {
         Self {
-            declarations: FxHashMap::default(),
-            reassignments: FxHashMap::default(),
+            declarations: IndexVec::from_vec(vec![None; num_identifiers]),
+            reassignments: IndexVec::from_vec(vec![None; num_identifiers]),
             scope_stack: Vec::new(),
             dep_stack: Vec::new(),
             deps: IndexMap::default(),
@@ -1884,15 +1882,16 @@ impl<'a> DependencyCollectionContext<'a> {
             return;
         }
         let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-        if !self.declarations.contains_key(&decl_id) {
-            self.declarations.insert(decl_id, decl.clone());
+        let slot = &mut self.declarations[decl_id];
+        if slot.is_none() {
+            *slot = Some(decl.clone());
         }
-        self.reassignments.insert(identifier_id, decl);
+        self.reassignments[identifier_id] = Some(decl);
     }
 
     fn has_declared(&self, identifier_id: IdentifierId, env: &Environment) -> bool {
         let decl_id = env.identifiers[identifier_id.0 as usize].declaration_id;
-        self.declarations.contains_key(&decl_id)
+        self.declarations[decl_id].is_some()
     }
 
     fn check_valid_dependency(&self, dep: &ReactiveScopeDependency, env: &Environment) -> bool {
@@ -1907,10 +1906,9 @@ impl<'a> DependencyCollectionContext<'a> {
         }
 
         let ident = &env.identifiers[dep.identifier.0 as usize];
-        let current_declaration = self
-            .reassignments
-            .get(&dep.identifier)
-            .or_else(|| self.declarations.get(&ident.declaration_id));
+        let current_declaration = self.reassignments[dep.identifier]
+            .as_ref()
+            .or(self.declarations[ident.declaration_id].as_ref());
 
         if let Some(current_scope) = self.current_scope() {
             if let Some(decl) = current_declaration {
@@ -1922,10 +1920,8 @@ impl<'a> DependencyCollectionContext<'a> {
     }
 
     fn visit_operand(&mut self, place: &Place, env: &mut Environment) {
-        let dep = self
-            .temporaries
-            .get(&place.identifier)
-            .cloned()
+        let dep = self.temporaries[place.identifier]
+            .clone()
             .unwrap_or_else(|| ReactiveScopeDependency {
                 identifier: place.identifier,
                 reactive: place.reactive,
@@ -1952,7 +1948,7 @@ impl<'a> DependencyCollectionContext<'a> {
         let decl_id = ident.declaration_id;
 
         // Record scope declarations for values used outside their declaring scope
-        if let Some(original_decl) = self.declarations.get(&decl_id) {
+        if let Some(original_decl) = &self.declarations[decl_id] {
             if !original_decl.scope_stack.is_empty() {
                 let orig_scope_stack = original_decl.scope_stack.clone();
                 for &scope_id in &orig_scope_stack {
@@ -2031,7 +2027,7 @@ impl<'a> DependencyCollectionContext<'a> {
     fn is_deferred_dependency_instr(&self, instr: &Instruction) -> bool {
         self.processed_instrs_in_optional
             .contains(&ProcessedInstr::Instruction(instr.lvalue.identifier))
-            || self.temporaries.contains_key(&instr.lvalue.identifier)
+            || self.temporaries[instr.lvalue.identifier].is_some()
     }
 
     fn is_deferred_dependency_terminal(&self, block_id: BlockId) -> bool {
@@ -2081,8 +2077,9 @@ fn visit_inner_function_blocks(
 
     for (inner_bid, inner_instr_ids, inner_phis, inner_terminal) in &inner_blocks {
         for &(_pred_id, op_id) in inner_phis {
-            if let Some(maybe_optional) = ctx.temporaries.get(&op_id) {
-                ctx.visit_dependency(maybe_optional.clone(), env);
+            if let Some(maybe_optional) = &ctx.temporaries[op_id] {
+                let maybe_optional = maybe_optional.clone();
+                ctx.visit_dependency(maybe_optional, env);
             }
         }
 
@@ -2232,10 +2229,11 @@ fn collect_dependencies(
     func: &HirFunction,
     env: &mut Environment,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
-    temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
+    temporaries: &TemporariesMap,
     processed_instrs_in_optional: &FxHashSet<ProcessedInstr>,
 ) -> IndexMap<ScopeId, Vec<ReactiveScopeDependency>, FxBuildHasher> {
     let mut ctx = DependencyCollectionContext::new(
+        env.identifiers.len(),
         used_outside_declaring_scope,
         temporaries,
         processed_instrs_in_optional,
@@ -2298,8 +2296,9 @@ fn handle_function_deps(
         // Record phi operands
         for phi in &block.phis {
             for (_pred_id, operand) in &phi.operands {
-                if let Some(maybe_optional_chain) = ctx.temporaries.get(&operand.identifier) {
-                    ctx.visit_dependency(maybe_optional_chain.clone(), env);
+                if let Some(maybe_optional_chain) = &ctx.temporaries[operand.identifier] {
+                    let maybe_optional_chain = maybe_optional_chain.clone();
+                    ctx.visit_dependency(maybe_optional_chain, env);
                 }
             }
         }

--- a/compiler/crates/react_compiler_optimization/Cargo.toml
+++ b/compiler/crates/react_compiler_optimization/Cargo.toml
@@ -9,4 +9,5 @@ react_compiler_hir = { path = "../react_compiler_hir" }
 react_compiler_lowering = { path = "../react_compiler_lowering" }
 react_compiler_ssa = { path = "../react_compiler_ssa" }
 indexmap = "2"
+oxc_index = "5.0.0"
 rustc-hash = "2"

--- a/compiler/crates/react_compiler_optimization/src/prune_maybe_throws.rs
+++ b/compiler/crates/react_compiler_optimization/src/prune_maybe_throws.rs
@@ -10,7 +10,7 @@
 //!
 //! Analogous to TS `Optimization/PruneMaybeThrows.ts`.
 
-use rustc_hash::FxHashMap;
+use oxc_index::IndexVec;
 
 use react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, ErrorCategory, GENERATED_SOURCE,
@@ -48,8 +48,11 @@ pub fn prune_maybe_throws(
                 let mut updates = Vec::new();
                 for (predecessor, _) in &phi.operands {
                     if !preds.contains(predecessor) {
-                        let mapped_terminal =
-                            terminal_mapping.get(predecessor).copied().ok_or_else(|| {
+                        let mapped_terminal = terminal_mapping
+                            .get(*predecessor)
+                            .copied()
+                            .flatten()
+                            .ok_or_else(|| {
                                 CompilerDiagnostic::new(
                                     ErrorCategory::Invariant,
                                     "Expected non-existing phi operand's predecessor to have been mapped to a new terminal",
@@ -86,8 +89,19 @@ pub fn prune_maybe_throws(
     Ok(())
 }
 
-fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, BlockId>> {
-    let mut terminal_mapping: FxHashMap<BlockId, BlockId> = FxHashMap::default();
+fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<IndexVec<BlockId, Option<BlockId>>> {
+    // Both keys (continuations) and values (source blocks) are ids of blocks present
+    // in the function body, so the maximum present id bounds the id space.
+    let num_ids = func
+        .body
+        .blocks
+        .keys()
+        .map(|id| id.0 as usize + 1)
+        .max()
+        .unwrap_or(0);
+    let mut terminal_mapping: IndexVec<BlockId, Option<BlockId>> =
+        IndexVec::from_vec(vec![None; num_ids]);
+    let mut mapped_any = false;
     let instructions = &func.instructions;
 
     for block in func.body.blocks.values_mut() {
@@ -102,8 +116,9 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
             .any(|instr_id| instruction_may_throw(&instructions[instr_id.0 as usize]));
 
         if !can_throw {
-            let source = terminal_mapping.get(&block.id).copied().unwrap_or(block.id);
-            terminal_mapping.insert(continuation, source);
+            let source = terminal_mapping[block.id].unwrap_or(block.id);
+            terminal_mapping[continuation] = Some(source);
+            mapped_any = true;
             // Null out the handler rather than replacing with Goto.
             // Preserving the MaybeThrow makes the continuations clear for
             // BuildReactiveFunction, while nulling out the handler tells us
@@ -114,7 +129,7 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
         }
     }
 
-    if terminal_mapping.is_empty() {
+    if !mapped_any {
         None
     } else {
         Some(terminal_mapping)

--- a/compiler/crates/react_compiler_reactive_scopes/Cargo.toml
+++ b/compiler/crates/react_compiler_reactive_scopes/Cargo.toml
@@ -8,6 +8,7 @@ react_compiler_ast = { path = "../react_compiler_ast" }
 react_compiler_diagnostics = { path = "../react_compiler_diagnostics" }
 react_compiler_hir = { path = "../react_compiler_hir" }
 indexmap = "2"
+oxc_index = "5.0.0"
 rustc-hash = "2"
 serde_json = "1"
 hmac-sha256 = "1"

--- a/compiler/crates/react_compiler_reactive_scopes/src/merge_reactive_scopes_that_invalidate_together.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/merge_reactive_scopes_that_invalidate_together.rs
@@ -8,7 +8,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts`.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
+
+use oxc_index::IndexVec;
 
 use react_compiler_diagnostics::CompilerError;
 use react_compiler_hir::{
@@ -24,6 +26,13 @@ use crate::visitors::{
     visit_reactive_function,
 };
 
+/// Last usage per declaration, indexed densely by declaration id
+/// (declaration ids share the identifier id space).
+type LastUsageMap = IndexVec<DeclarationId, Option<EvaluationOrder>>;
+
+/// Temporary-to-source declaration mapping, indexed densely by declaration id.
+type TemporariesMap = IndexVec<DeclarationId, Option<DeclarationId>>;
+
 // =============================================================================
 // Public entry point
 // =============================================================================
@@ -34,16 +43,18 @@ pub fn merge_reactive_scopes_that_invalidate_together(
     func: &mut ReactiveFunction,
     env: &mut Environment,
 ) -> Result<(), CompilerError> {
+    let num_identifiers = env.identifiers.len();
+
     // Pass 1: find last usage of each declaration
     let visitor = FindLastUsageVisitor { env: &*env };
-    let mut last_usage: FxHashMap<DeclarationId, EvaluationOrder> = FxHashMap::default();
+    let mut last_usage: LastUsageMap = IndexVec::from_vec(vec![None; num_identifiers]);
     visit_reactive_function(func, &visitor, &mut last_usage);
 
     // Pass 2+3: merge scopes
     let mut transform = MergeTransform {
         env,
         last_usage,
-        temporaries: FxHashMap::default(),
+        temporaries: IndexVec::from_vec(vec![None; num_identifiers]),
     };
     let mut state: Option<Vec<ReactiveScopeDependency>> = None;
     transform_reactive_function(func, &mut transform, &mut state)
@@ -59,7 +70,7 @@ struct FindLastUsageVisitor<'a> {
 }
 
 impl<'a> ReactiveFunctionVisitor for FindLastUsageVisitor<'a> {
-    type State = FxHashMap<DeclarationId, EvaluationOrder>;
+    type State = LastUsageMap;
 
     fn env(&self) -> &Environment {
         self.env
@@ -67,10 +78,7 @@ impl<'a> ReactiveFunctionVisitor for FindLastUsageVisitor<'a> {
 
     fn visit_place(&self, id: EvaluationOrder, place: &Place, state: &mut Self::State) {
         let decl_id = self.env.identifiers[place.identifier.0 as usize].declaration_id;
-        let entry = state.entry(decl_id).or_insert(id);
-        if id > *entry {
-            *entry = id;
-        }
+        state[decl_id] = Some(state[decl_id].map_or(id, |prev| prev.max(id)));
     }
 }
 
@@ -81,8 +89,8 @@ impl<'a> ReactiveFunctionVisitor for FindLastUsageVisitor<'a> {
 /// TS: `class Transform extends ReactiveFunctionTransform<ReactiveScopeDependencies | null>`
 struct MergeTransform<'a> {
     env: &'a mut Environment,
-    last_usage: FxHashMap<DeclarationId, EvaluationOrder>,
-    temporaries: FxHashMap<DeclarationId, DeclarationId>,
+    last_usage: LastUsageMap,
+    temporaries: TemporariesMap,
 }
 
 impl<'a> ReactiveFunctionTransform for MergeTransform<'a> {
@@ -186,7 +194,7 @@ impl<'a> MergeTransform<'a> {
                                                 let src_decl = self.env.identifiers
                                                     [place.identifier.0 as usize]
                                                     .declaration_id;
-                                                self.temporaries.insert(decl_id, src_decl);
+                                                self.temporaries[decl_id] = Some(src_decl);
                                             }
                                         }
                                     }
@@ -210,12 +218,9 @@ impl<'a> MergeTransform<'a> {
                                             let value_decl = self.env.identifiers
                                                 [value.identifier.0 as usize]
                                                 .declaration_id;
-                                            let mapped = self
-                                                .temporaries
-                                                .get(&value_decl)
-                                                .copied()
-                                                .unwrap_or(value_decl);
-                                            self.temporaries.insert(store_decl, mapped);
+                                            let mapped =
+                                                self.temporaries[value_decl].unwrap_or(value_decl);
+                                            self.temporaries[store_decl] = Some(mapped);
                                         } else {
                                             // Non-const StoreLocal — reset
                                             let c = current.take().unwrap();
@@ -396,18 +401,14 @@ impl<'a> MergeTransform<'a> {
 // =============================================================================
 
 /// Updates scope declarations to remove any that are not used after the scope.
-fn update_scope_declarations(
-    scope_id: ScopeId,
-    last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
-    env: &mut Environment,
-) {
+fn update_scope_declarations(scope_id: ScopeId, last_usage: &LastUsageMap, env: &mut Environment) {
     let range_end = env.scopes[scope_id.0 as usize].range.end;
     env.scopes[scope_id.0 as usize]
         .declarations
         .retain(|(_id, decl)| {
             let decl_declaration_id = env.identifiers[decl.identifier.0 as usize].declaration_id;
-            match last_usage.get(&decl_declaration_id) {
-                Some(last_used_at) => *last_used_at >= range_end,
+            match last_usage[decl_declaration_id] {
+                Some(last_used_at) => last_used_at >= range_end,
                 // If not tracked, keep the declaration (conservative)
                 None => true,
             }
@@ -418,12 +419,12 @@ fn update_scope_declarations(
 fn are_lvalues_last_used_by_scope(
     scope_id: ScopeId,
     lvalues: &FxHashSet<DeclarationId>,
-    last_usage: &FxHashMap<DeclarationId, EvaluationOrder>,
+    last_usage: &LastUsageMap,
     env: &Environment,
 ) -> bool {
     let range_end = env.scopes[scope_id.0 as usize].range.end;
     for lvalue in lvalues {
-        if let Some(&last_used_at) = last_usage.get(lvalue) {
+        if let Some(last_used_at) = last_usage[*lvalue] {
             if last_used_at >= range_end {
                 return false;
             }
@@ -437,7 +438,7 @@ fn can_merge_scopes(
     current_id: ScopeId,
     next_id: ScopeId,
     env: &Environment,
-    temporaries: &FxHashMap<DeclarationId, DeclarationId>,
+    temporaries: &TemporariesMap,
 ) -> bool {
     let current = &env.scopes[current_id.0 as usize];
     let next = &env.scopes[next_id.0 as usize];
@@ -483,8 +484,7 @@ fn can_merge_scopes(
             let dep_decl = env.identifiers[dep.identifier.0 as usize].declaration_id;
             current.declarations.iter().any(|(_key, decl)| {
                 let decl_decl_id = env.identifiers[decl.identifier.0 as usize].declaration_id;
-                decl_decl_id == dep_decl
-                    || temporaries.get(&dep_decl).copied() == Some(decl_decl_id)
+                decl_decl_id == dep_decl || temporaries[dep_decl] == Some(decl_decl_id)
             })
         })
     {

--- a/compiler/crates/react_compiler_reactive_scopes/src/promote_used_temporaries.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/promote_used_temporaries.rs
@@ -8,7 +8,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PromoteUsedTemporaries.ts`.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
+
+use oxc_index::IndexVec;
 
 use react_compiler_hir::DeclarationId;
 use react_compiler_hir::FunctionId;
@@ -36,13 +38,19 @@ use react_compiler_hir::environment::Environment;
 struct State {
     tags: FxHashSet<DeclarationId>,
     promoted: FxHashSet<DeclarationId>,
-    pruned: FxHashMap<DeclarationId, PrunedInfo>,
+    /// Pruned-scope info per declaration, indexed densely by declaration id
+    /// (declaration ids share the identifier id space).
+    pruned: IndexVec<DeclarationId, Option<PrunedInfo>>,
 }
 
 struct PrunedInfo {
     active_scopes: Vec<ScopeId>,
     used_outside_scope: bool,
 }
+
+/// Interposed-temporary tracking state, indexed densely by identifier id.
+/// Each entry holds the tracked identifier and whether it needs promotion.
+type InterState = IndexVec<IdentifierId, Option<(IdentifierId, bool)>>;
 
 // =============================================================================
 // Public entry point
@@ -54,7 +62,7 @@ pub fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut Environme
     let mut state = State {
         tags: FxHashSet::default(),
         promoted: FxHashSet::default(),
-        pruned: FxHashMap::default(),
+        pruned: IndexVec::from_vec((0..env.identifiers.len()).map(|_| None).collect()),
     };
 
     // Phase 1: collect promotable temporaries (jsx tags, pruned scope usage)
@@ -89,7 +97,7 @@ pub fn promote_used_temporaries(func: &mut ReactiveFunction, env: &mut Environme
             }
         }
     }
-    let mut inter_state: FxHashMap<IdentifierId, (IdentifierId, bool)> = FxHashMap::default();
+    let mut inter_state: InterState = IndexVec::from_vec(vec![None; env.identifiers.len()]);
     promote_interposed_block(
         &func.body,
         &mut state,
@@ -129,13 +137,10 @@ fn collect_promotable_block(
                 let scope_data = &env.scopes[scope.scope.0 as usize];
                 for (_id, decl) in &scope_data.declarations {
                     let identifier = &env.identifiers[decl.identifier.0 as usize];
-                    state.pruned.insert(
-                        identifier.declaration_id,
-                        PrunedInfo {
-                            active_scopes: active_scopes.clone(),
-                            used_outside_scope: false,
-                        },
-                    );
+                    state.pruned[identifier.declaration_id] = Some(PrunedInfo {
+                        active_scopes: active_scopes.clone(),
+                        used_outside_scope: false,
+                    });
                 }
                 collect_promotable_block(&scope.instructions, state, active_scopes, env);
             }
@@ -154,7 +159,7 @@ fn collect_promotable_place(
 ) {
     if !active_scopes.is_empty() {
         let identifier = &env.identifiers[place.identifier.0 as usize];
-        if let Some(pruned) = state.pruned.get_mut(&identifier.declaration_id) {
+        if let Some(pruned) = state.pruned[identifier.declaration_id].as_mut() {
             if let Some(last) = active_scopes.last() {
                 if !pruned.active_scopes.contains(last) {
                     pruned.used_outside_scope = true;
@@ -360,7 +365,7 @@ fn promote_temporaries_block(block: &ReactiveBlock, state: &mut State, env: &mut
                 for (id, decl_id) in decls {
                     let identifier = &env.identifiers[id.0 as usize];
                     if identifier.name.is_none() {
-                        if let Some(pruned) = state.pruned.get(&decl_id) {
+                        if let Some(pruned) = &state.pruned[decl_id] {
                             if pruned.used_outside_scope {
                                 promote_identifier(id, state, env);
                             }
@@ -554,7 +559,7 @@ fn visit_hir_function_for_promotion(func_id: FunctionId, state: &mut State, env:
 fn promote_interposed_block(
     block: &ReactiveBlock,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,
@@ -594,11 +599,11 @@ fn promote_interposed_block(
 fn promote_interposed_place(
     place: &Place,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &FxHashSet<IdentifierId>,
     env: &mut Environment,
 ) {
-    if let Some(&(id, needs_promotion)) = inter_state.get(&place.identifier) {
+    if let Some((id, needs_promotion)) = inter_state[place.identifier] {
         let identifier = &env.identifiers[id.0 as usize];
         if needs_promotion && identifier.name.is_none() && !consts.contains(&id) {
             promote_identifier(id, state, env);
@@ -609,7 +614,7 @@ fn promote_interposed_place(
 fn promote_interposed_instruction(
     instr: &ReactiveInstruction,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,
@@ -679,17 +684,14 @@ fn promote_interposed_instruction(
                                 .is_some())
                     {
                         // Mark all tracked temporaries as needing promotion
-                        let keys: Vec<IdentifierId> = inter_state.keys().cloned().collect();
-                        for key in keys {
-                            if let Some(entry) = inter_state.get_mut(&key) {
-                                entry.1 = true;
-                            }
+                        for entry in inter_state.iter_mut().flatten() {
+                            entry.1 = true;
                         }
                     }
                     if let Some(lvalue) = &instr.lvalue {
                         let identifier = &env.identifiers[lvalue.identifier.0 as usize];
                         if identifier.name.is_none() {
-                            inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
+                            inter_state[lvalue.identifier] = Some((lvalue.identifier, false));
                         }
                     }
                 }
@@ -719,7 +721,7 @@ fn promote_interposed_instruction(
                             if consts.contains(&load_place.identifier) {
                                 consts.insert(lvalue.identifier);
                             }
-                            inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
+                            inter_state[lvalue.identifier] = Some((lvalue.identifier, false));
                         }
                     }
                     // Visit operands
@@ -738,7 +740,7 @@ fn promote_interposed_instruction(
                         }
                         let identifier = &env.identifiers[lvalue.identifier.0 as usize];
                         if identifier.name.is_none() {
-                            inter_state.insert(lvalue.identifier, (lvalue.identifier, false));
+                            inter_state[lvalue.identifier] = Some((lvalue.identifier, false));
                         }
                     }
                     // Visit operands
@@ -802,7 +804,7 @@ fn promote_interposed_instruction(
 fn promote_interposed_value(
     value: &ReactiveValue,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,
@@ -846,7 +848,7 @@ fn promote_interposed_value(
 fn promote_interposed_terminal(
     stmt: &ReactiveTerminalStatement,
     state: &mut State,
-    inter_state: &mut FxHashMap<IdentifierId, (IdentifierId, bool)>,
+    inter_state: &mut InterState,
     consts: &mut FxHashSet<IdentifierId>,
     globals: &mut FxHashSet<IdentifierId>,
     env: &mut Environment,

--- a/compiler/crates/react_compiler_reactive_scopes/src/stabilize_block_ids.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/stabilize_block_ids.rs
@@ -10,9 +10,10 @@
 //!
 //! Corresponds to `src/ReactiveScopes/StabilizeBlockIds.ts`.
 
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxBuildHasher;
 
 use indexmap::IndexSet;
+use oxc_index::IndexVec;
 use react_compiler_hir::{
     BlockId, ReactiveFunction, ReactiveScopeBlock, ReactiveTerminal, ReactiveTerminalStatement,
     environment::Environment,
@@ -23,6 +24,33 @@ use crate::visitors::{
     visit_reactive_function,
 };
 
+/// Mapping from original block ids to stable sequential ids, indexed densely by
+/// block id. `next` is the next sequential id to assign (i.e. the number of ids
+/// mapped so far).
+struct BlockIdMappings {
+    map: IndexVec<BlockId, Option<BlockId>>,
+    next: u32,
+}
+
+impl BlockIdMappings {
+    fn new(num_block_ids: usize) -> Self {
+        Self {
+            map: IndexVec::from_vec(vec![None; num_block_ids]),
+            next: 0,
+        }
+    }
+
+    fn get_or_insert(&mut self, id: BlockId) -> BlockId {
+        if let Some(mapped) = self.map[id] {
+            return mapped;
+        }
+        let mapped = BlockId(self.next);
+        self.next += 1;
+        self.map[id] = Some(mapped);
+        mapped
+    }
+}
+
 /// Rewrites block IDs to sequential values.
 /// TS: `stabilizeBlockIds`
 pub fn stabilize_block_ids(func: &mut ReactiveFunction, env: &mut Environment) {
@@ -32,10 +60,9 @@ pub fn stabilize_block_ids(func: &mut ReactiveFunction, env: &mut Environment) {
     visit_reactive_function(func, &collector, &mut referenced);
 
     // Build mappings: referenced block IDs -> sequential IDs (insertion-order deterministic)
-    let mut mappings: FxHashMap<BlockId, BlockId> = FxHashMap::default();
+    let mut mappings = BlockIdMappings::new(env.next_block_id_counter as usize);
     for block_id in &referenced {
-        let len = mappings.len() as u32;
-        mappings.entry(*block_id).or_insert(BlockId(len));
+        mappings.get_or_insert(*block_id);
     }
 
     // Pass 2: Rewrite block IDs using ReactiveFunctionTransform
@@ -80,18 +107,13 @@ impl<'a> ReactiveFunctionVisitor for CollectReferencedLabels<'a> {
 // Pass 2: RewriteBlockIds
 // =============================================================================
 
-fn get_or_insert_mapping(mappings: &mut FxHashMap<BlockId, BlockId>, id: BlockId) -> BlockId {
-    let len = mappings.len() as u32;
-    *mappings.entry(id).or_insert(BlockId(len))
-}
-
 /// TS: `class RewriteBlockIds extends ReactiveFunctionVisitor<Map<BlockId, BlockId>>`
 struct RewriteBlockIds<'a> {
     env: &'a mut Environment,
 }
 
 impl<'a> ReactiveFunctionTransform for RewriteBlockIds<'a> {
-    type State = FxHashMap<BlockId, BlockId>;
+    type State = BlockIdMappings;
 
     fn env(&self) -> &Environment {
         self.env
@@ -104,7 +126,7 @@ impl<'a> ReactiveFunctionTransform for RewriteBlockIds<'a> {
     ) -> Result<(), react_compiler_diagnostics::CompilerError> {
         let scope_data = &mut self.env.scopes[scope.scope.0 as usize];
         if let Some(ref mut early_return) = scope_data.early_return_value {
-            early_return.label = get_or_insert_mapping(state, early_return.label);
+            early_return.label = state.get_or_insert(early_return.label);
         }
         self.traverse_scope(scope, state)
     }
@@ -115,12 +137,12 @@ impl<'a> ReactiveFunctionTransform for RewriteBlockIds<'a> {
         state: &mut Self::State,
     ) -> Result<(), react_compiler_diagnostics::CompilerError> {
         if let Some(ref mut label) = stmt.label {
-            label.id = get_or_insert_mapping(state, label.id);
+            label.id = state.get_or_insert(label.id);
         }
 
         match &mut stmt.terminal {
             ReactiveTerminal::Break { target, .. } | ReactiveTerminal::Continue { target, .. } => {
-                *target = get_or_insert_mapping(state, *target);
+                *target = state.get_or_insert(*target);
             }
             _ => {}
         }

--- a/compiler/crates/react_compiler_ssa/Cargo.toml
+++ b/compiler/crates/react_compiler_ssa/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 react_compiler_diagnostics = { path = "../react_compiler_diagnostics" }
 react_compiler_hir = { path = "../react_compiler_hir" }
 indexmap = "2"
+oxc_index = "5.0.0"
 rustc-hash = "2"

--- a/compiler/crates/react_compiler_ssa/src/eliminate_redundant_phi.rs
+++ b/compiler/crates/react_compiler_ssa/src/eliminate_redundant_phi.rs
@@ -1,4 +1,6 @@
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
+
+use oxc_index::IndexVec;
 
 use react_compiler_hir::environment::Environment;
 use react_compiler_hir::visitors;
@@ -7,11 +9,33 @@ use react_compiler_hir::*;
 use crate::enter_ssa::placeholder_function;
 
 // =============================================================================
-// Helper: rewrite_place
+// Rewrite map
 // =============================================================================
 
-fn rewrite_place(place: &mut Place, rewrites: &FxHashMap<IdentifierId, IdentifierId>) {
-    if let Some(&rewrite) = rewrites.get(&place.identifier) {
+/// Rewrites from eliminated phi ids to their canonical ids, indexed densely by
+/// identifier id. `len` counts mapped entries (used for fixpoint detection).
+struct Rewrites {
+    map: IndexVec<IdentifierId, Option<IdentifierId>>,
+    len: usize,
+}
+
+impl Rewrites {
+    fn new(num_identifiers: usize) -> Self {
+        Self {
+            map: IndexVec::from_vec(vec![None; num_identifiers]),
+            len: 0,
+        }
+    }
+
+    fn insert(&mut self, key: IdentifierId, value: IdentifierId) {
+        if self.map[key].replace(value).is_none() {
+            self.len += 1;
+        }
+    }
+}
+
+fn rewrite_place(place: &mut Place, rewrites: &Rewrites) {
+    if let Some(rewrite) = rewrites.map[place.identifier] {
         place.identifier = rewrite;
     }
 }
@@ -21,7 +45,7 @@ fn rewrite_place(place: &mut Place, rewrites: &FxHashMap<IdentifierId, Identifie
 // =============================================================================
 
 pub fn eliminate_redundant_phi(func: &mut HirFunction, env: &mut Environment) {
-    let mut rewrites: FxHashMap<IdentifierId, IdentifierId> = FxHashMap::default();
+    let mut rewrites = Rewrites::new(env.identifiers.len());
     eliminate_redundant_phi_impl(func, env, &mut rewrites);
 }
 
@@ -32,7 +56,7 @@ pub fn eliminate_redundant_phi(func: &mut HirFunction, env: &mut Environment) {
 fn eliminate_redundant_phi_impl(
     func: &mut HirFunction,
     env: &mut Environment,
-    rewrites: &mut FxHashMap<IdentifierId, IdentifierId>,
+    rewrites: &mut Rewrites,
 ) {
     let ir = &mut func.body;
 
@@ -41,7 +65,7 @@ fn eliminate_redundant_phi_impl(
 
     let mut size;
     loop {
-        size = rewrites.len();
+        size = rewrites.len;
 
         let block_ids: Vec<BlockId> = ir.blocks.keys().copied().collect();
         for block_id in &block_ids {
@@ -149,7 +173,7 @@ fn eliminate_redundant_phi_impl(
             });
         }
 
-        if !(rewrites.len() > size && has_back_edge) {
+        if !(rewrites.len > size && has_back_edge) {
             break;
         }
     }

--- a/compiler/crates/react_compiler_validation/Cargo.toml
+++ b/compiler/crates/react_compiler_validation/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 indexmap = "2"
+oxc_index = "5.0.0"
 rustc-hash = "2"
 react_compiler_diagnostics = { path = "../react_compiler_diagnostics" }
 react_compiler_hir = { path = "../react_compiler_hir" }

--- a/compiler/crates/react_compiler_validation/src/validate_hooks_usage.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_hooks_usage.rs
@@ -10,9 +10,10 @@
 //! and not called dynamically. Also validates that hooks are not
 //! called inside function expressions.
 
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxBuildHasher;
 
 use indexmap::IndexMap;
+use oxc_index::IndexVec;
 use react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerError, CompilerErrorDetail, ErrorCategory, SourceLocation,
 };
@@ -35,6 +36,9 @@ enum Kind {
     Local,
 }
 
+/// Value classification per identifier, indexed densely by identifier id.
+type ValueKinds = IndexVec<IdentifierId, Option<Kind>>;
+
 fn join_kinds(a: Kind, b: Kind) -> Kind {
     if a == Kind::Error || b == Kind::Error {
         Kind::Error
@@ -49,12 +53,8 @@ fn join_kinds(a: Kind, b: Kind) -> Kind {
     }
 }
 
-fn get_kind_for_place(
-    place: &Place,
-    value_kinds: &FxHashMap<IdentifierId, Kind>,
-    identifiers: &[Identifier],
-) -> Kind {
-    let known_kind = value_kinds.get(&place.identifier).copied();
+fn get_kind_for_place(place: &Place, value_kinds: &ValueKinds, identifiers: &[Identifier]) -> Kind {
+    let known_kind = value_kinds[place.identifier];
     let ident = &identifiers[place.identifier.0 as usize];
     if let Some(ref name) = ident.name {
         if is_hook_name(name.value()) {
@@ -86,11 +86,11 @@ fn get_hook_kind_for_id<'a>(
 
 fn visit_place(
     place: &Place,
-    value_kinds: &FxHashMap<IdentifierId, Kind>,
+    value_kinds: &ValueKinds,
     errors_by_loc: &mut IndexMap<SourceLocation, CompilerErrorDetail, FxBuildHasher>,
     env: &mut Environment,
 ) -> Result<(), CompilerError> {
-    let kind = value_kinds.get(&place.identifier).copied();
+    let kind = value_kinds[place.identifier];
     if kind == Some(Kind::KnownHook) {
         record_invalid_hook_usage_error(place, errors_by_loc, env)?;
     }
@@ -99,11 +99,11 @@ fn visit_place(
 
 fn record_conditional_hook_error(
     place: &Place,
-    value_kinds: &mut FxHashMap<IdentifierId, Kind>,
+    value_kinds: &mut ValueKinds,
     errors_by_loc: &mut IndexMap<SourceLocation, CompilerErrorDetail, FxBuildHasher>,
     env: &mut Environment,
 ) -> Result<(), CompilerError> {
-    value_kinds.insert(place.identifier, Kind::Error);
+    value_kinds[place.identifier] = Some(Kind::Error);
     let reason = "Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)".to_string();
     if let Some(loc) = place.loc {
         let previous = errors_by_loc.get(&loc);
@@ -201,7 +201,7 @@ pub fn validate_hooks_usage(
     let unconditional_blocks = compute_unconditional_blocks(func, env.next_block_id().0)?;
     let mut errors_by_loc: IndexMap<SourceLocation, CompilerErrorDetail, FxBuildHasher> =
         IndexMap::default();
-    let mut value_kinds: FxHashMap<IdentifierId, Kind> = FxHashMap::default();
+    let mut value_kinds: ValueKinds = IndexVec::from_vec(vec![None; env.identifiers.len()]);
 
     // Process params
     for param in &func.params {
@@ -210,7 +210,7 @@ pub fn validate_hooks_usage(
             ParamPattern::Spread(s) => &s.place,
         };
         let kind = get_kind_for_place(place, &value_kinds, &env.identifiers);
-        value_kinds.insert(place.identifier, kind);
+        value_kinds[place.identifier] = Some(kind);
     }
 
     // Process blocks
@@ -223,11 +223,11 @@ pub fn validate_hooks_usage(
                 Kind::Local
             };
             for (_, operand) in &phi.operands {
-                if let Some(&operand_kind) = value_kinds.get(&operand.identifier) {
+                if let Some(operand_kind) = value_kinds[operand.identifier] {
                     kind = join_kinds(kind, operand_kind);
                 }
             }
-            value_kinds.insert(phi.place.identifier, kind);
+            value_kinds[phi.place.identifier] = Some(kind);
         }
 
         // Process instructions
@@ -239,16 +239,16 @@ pub fn validate_hooks_usage(
                 InstructionValue::LoadGlobal { .. } => {
                     if get_hook_kind_for_id(lvalue_id, &env.identifiers, &env.types, env)?.is_some()
                     {
-                        value_kinds.insert(lvalue_id, Kind::KnownHook);
+                        value_kinds[lvalue_id] = Some(Kind::KnownHook);
                     } else {
-                        value_kinds.insert(lvalue_id, Kind::Global);
+                        value_kinds[lvalue_id] = Some(Kind::Global);
                     }
                 }
                 InstructionValue::LoadContext { place, .. }
                 | InstructionValue::LoadLocal { place, .. } => {
                     visit_place(place, &value_kinds, &mut errors_by_loc, env)?;
                     let kind = get_kind_for_place(place, &value_kinds, &env.identifiers);
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::StoreLocal { lvalue, value, .. }
                 | InstructionValue::StoreContext { lvalue, value, .. } => {
@@ -257,15 +257,15 @@ pub fn validate_hooks_usage(
                         get_kind_for_place(value, &value_kinds, &env.identifiers),
                         get_kind_for_place(&lvalue.place, &value_kinds, &env.identifiers),
                     );
-                    value_kinds.insert(lvalue.place.identifier, kind);
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue.place.identifier] = Some(kind);
+                    value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::ComputedLoad { object, .. } => {
                     visit_place(object, &value_kinds, &mut errors_by_loc, env)?;
                     let kind = get_kind_for_place(object, &value_kinds, &env.identifiers);
                     let lvalue_kind =
                         get_kind_for_place(&instr.lvalue, &value_kinds, &env.identifiers);
-                    value_kinds.insert(lvalue_id, join_kinds(lvalue_kind, kind));
+                    value_kinds[lvalue_id] = Some(join_kinds(lvalue_kind, kind));
                 }
                 InstructionValue::PropertyLoad {
                     object, property, ..
@@ -300,7 +300,7 @@ pub fn validate_hooks_usage(
                             }
                         }
                     };
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
                     let callee_kind = get_kind_for_place(callee, &value_kinds, &env.identifiers);
@@ -383,7 +383,7 @@ pub fn validate_hooks_usage(
                                 }
                             }
                         };
-                        value_kinds.insert(place.identifier, kind);
+                        value_kinds[place.identifier] = Some(kind);
                     }
                 }
                 InstructionValue::ObjectMethod { lowered_func, .. }
@@ -396,11 +396,11 @@ pub fn validate_hooks_usage(
                     visit_all_operands(&instr.value, &value_kinds, &mut errors_by_loc, env)?;
                     // Set kind for instr.lvalue
                     let kind = get_kind_for_place(&instr.lvalue, &value_kinds, &env.identifiers);
-                    value_kinds.insert(lvalue_id, kind);
+                    value_kinds[lvalue_id] = Some(kind);
                     // Also set kind for value-level lvalues (e.g. DeclareLocal, PrefixUpdate, PostfixUpdate)
                     for lv in visitors::each_instruction_value_lvalue(&instr.value) {
                         let lv_kind = get_kind_for_place(&lv, &value_kinds, &env.identifiers);
-                        value_kinds.insert(lv.identifier, lv_kind);
+                        value_kinds[lv.identifier] = Some(lv_kind);
                     }
                 }
             }
@@ -513,7 +513,7 @@ fn hook_kind_display(kind: &HookKind) -> &'static str {
 /// Uses the canonical `each_instruction_value_operand` from visitors.
 fn visit_all_operands(
     value: &InstructionValue,
-    value_kinds: &FxHashMap<IdentifierId, Kind>,
+    value_kinds: &ValueKinds,
     errors_by_loc: &mut IndexMap<SourceLocation, CompilerErrorDetail, FxBuildHasher>,
     env: &mut Environment,
 ) -> Result<(), CompilerError> {


### PR DESCRIPTION
Add typed indexing support for existing HIR ID types, then replace hash maps with `oxc_index::IndexVec` where block, identifier, and declaration IDs form bounded dense spaces.

The converted maps cover dominator computation, scope dependency propagation, maybe-throw pruning, reactive-scope processing, redundant phi elimination, and hook validation. Explicit counters preserve behavior where hash-map length previously controlled fixpoint detection or sequential ID assignment.

Ported from oxc-project/oxc commit `ba35a0d` by Boshen <boshenc@gmail.com>:
https://github.com/oxc-project/oxc/commit/ba35a0d2e992d02bd9286bf45bae113465ef81a8

Original Oxc author: @Boshen.

Validation:
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `cargo check --manifest-path compiler/Cargo.toml --workspace --all-targets`
- `cd compiler && yarn snap --rust` (1,810 passed)
- `git diff --check`

Criterion full-corpus benchmark (1,809 fixtures, 50 samples, compared with saved main baseline): -0.30% (95% CI: -1.00% to +0.55%, p=0.45). No performance change detected.

Peak RSS (50 fresh-process full-corpus samples): main mean 198.4 MiB; this PR mean 200.3 MiB; change +0.96%. This PR sample range: 197.7-203.7 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485
