### PR TITLE
oxc port: use dense identifier state in reactive-place inference

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -337,6 +337,7 @@ name = "react_compiler_inference"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "react_compiler_hir",
  "react_compiler_lowering",

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -249,6 +249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,7 @@ name = "react_compiler_hir"
 version = "0.1.0"
 dependencies = [
  "indexmap",
+ "oxc_index",
  "react_compiler_diagnostics",
  "rustc-hash",
  "serde",

--- a/compiler/crates/react_compiler_hir/Cargo.toml
+++ b/compiler/crates/react_compiler_hir/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 react_compiler_diagnostics = { path = "../react_compiler_diagnostics" }
 indexmap = { version = "2", features = ["serde"] }
+oxc_index = "5.0.0"
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -40,6 +40,26 @@ pub struct EvaluationOrder(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DeclarationId(pub u32);
 
+macro_rules! impl_idx {
+    ($($id:ty),+ $(,)?) => {
+        $(
+            impl oxc_index::Idx for $id {
+                const MAX: usize = u32::MAX as usize;
+
+                unsafe fn from_usize_unchecked(index: usize) -> Self {
+                    Self(index as u32)
+                }
+
+                fn index(self) -> usize {
+                    self.0 as usize
+                }
+            }
+        )+
+    };
+}
+
+impl_idx!(BlockId, IdentifierId, DeclarationId);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ScopeId(pub u32);
 

--- a/compiler/crates/react_compiler_inference/Cargo.toml
+++ b/compiler/crates/react_compiler_inference/Cargo.toml
@@ -11,4 +11,5 @@ react_compiler_optimization = { path = "../react_compiler_optimization" }
 react_compiler_ssa = { path = "../react_compiler_ssa" }
 react_compiler_utils = { path = "../react_compiler_utils" }
 indexmap = "2"
+oxc_index = "5.0.0"
 rustc-hash = "2"

--- a/compiler/crates/react_compiler_inference/src/infer_reactive_places.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_reactive_places.rs
@@ -14,7 +14,8 @@
 //! 4. Mutation with reactive operands
 //! 5. Conditional assignment based on reactive control flow
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use oxc_index::IndexVec;
+use rustc_hash::FxHashMap;
 
 use react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
 use react_compiler_hir::dominator::post_dominator_frontier;
@@ -42,8 +43,9 @@ pub fn infer_reactive_places(
     env: &mut Environment,
 ) -> Result<(), CompilerDiagnostic> {
     let mut aliased_identifiers = find_disjoint_mutable_values(func, env);
-    let mut reactive_map = ReactivityMap::new(&mut aliased_identifiers);
-    let mut stable_sidemap = StableSidemap::new();
+    let identifier_count = env.identifiers.len();
+    let mut reactive_map = ReactivityMap::new(&mut aliased_identifiers, identifier_count);
+    let mut stable_sidemap = StableSidemap::new(identifier_count);
 
     // Mark all function parameters as reactive
     for param in &func.params {
@@ -235,27 +237,31 @@ pub fn infer_reactive_places(
 
 struct ReactivityMap<'a> {
     has_changes: bool,
-    reactive: FxHashSet<IdentifierId>,
+    reactive: IndexVec<IdentifierId, bool>,
     aliased_identifiers: &'a mut DisjointSet<IdentifierId>,
 }
 
 impl<'a> ReactivityMap<'a> {
-    fn new(aliased_identifiers: &'a mut DisjointSet<IdentifierId>) -> Self {
+    fn new(
+        aliased_identifiers: &'a mut DisjointSet<IdentifierId>,
+        identifier_count: usize,
+    ) -> Self {
         ReactivityMap {
             has_changes: false,
-            reactive: FxHashSet::default(),
+            reactive: IndexVec::from_vec(vec![false; identifier_count]),
             aliased_identifiers,
         }
     }
 
     fn is_reactive(&mut self, id: IdentifierId) -> bool {
         let canonical = self.aliased_identifiers.find_opt(id).unwrap_or(id);
-        self.reactive.contains(&canonical)
+        self.reactive[canonical]
     }
 
     fn mark_reactive(&mut self, id: IdentifierId) {
         let canonical = self.aliased_identifiers.find_opt(id).unwrap_or(id);
-        if self.reactive.insert(canonical) {
+        if !self.reactive[canonical] {
+            self.reactive[canonical] = true;
             self.has_changes = true;
         }
     }
@@ -273,13 +279,13 @@ impl<'a> ReactivityMap<'a> {
 // =============================================================================
 
 struct StableSidemap {
-    map: FxHashMap<IdentifierId, bool>,
+    map: IndexVec<IdentifierId, Option<bool>>,
 }
 
 impl StableSidemap {
-    fn new() -> Self {
+    fn new(identifier_count: usize) -> Self {
         StableSidemap {
-            map: FxHashMap::default(),
+            map: IndexVec::from_vec(vec![None; identifier_count]),
         }
     }
 
@@ -295,9 +301,9 @@ impl StableSidemap {
                     let lvalue_ty =
                         &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
                     if is_stable_type(lvalue_ty) {
-                        self.map.insert(lvalue_id, true);
+                        self.map[lvalue_id] = Some(true);
                     } else {
-                        self.map.insert(lvalue_id, false);
+                        self.map[lvalue_id] = Some(false);
                     }
                 }
             }
@@ -308,27 +314,27 @@ impl StableSidemap {
                     let lvalue_ty =
                         &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
                     if is_stable_type(lvalue_ty) {
-                        self.map.insert(lvalue_id, true);
+                        self.map[lvalue_id] = Some(true);
                     } else {
-                        self.map.insert(lvalue_id, false);
+                        self.map[lvalue_id] = Some(false);
                     }
                 }
             }
             InstructionValue::PropertyLoad { object, .. } => {
                 let source_id = object.identifier;
-                if self.map.contains_key(&source_id) {
+                if self.map[source_id].is_some() {
                     let lvalue_ty =
                         &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
                     if is_stable_type_container(lvalue_ty) {
-                        self.map.insert(lvalue_id, false);
+                        self.map[lvalue_id] = Some(false);
                     } else if is_stable_type(lvalue_ty) {
-                        self.map.insert(lvalue_id, true);
+                        self.map[lvalue_id] = Some(true);
                     }
                 }
             }
             InstructionValue::Destructure { value: val, .. } => {
                 let source_id = val.identifier;
-                if self.map.contains_key(&source_id) {
+                if self.map[source_id].is_some() {
                     let lvalue_ids: Vec<IdentifierId> = visitors::each_instruction_lvalue(instr)
                         .into_iter()
                         .map(|p| p.identifier)
@@ -336,9 +342,9 @@ impl StableSidemap {
                     for lid in lvalue_ids {
                         let lid_ty = &env.types[env.identifiers[lid.0 as usize].type_.0 as usize];
                         if is_stable_type_container(lid_ty) {
-                            self.map.insert(lid, false);
+                            self.map[lid] = Some(false);
                         } else if is_stable_type(lid_ty) {
-                            self.map.insert(lid, true);
+                            self.map[lid] = Some(true);
                         }
                     }
                 }
@@ -346,14 +352,14 @@ impl StableSidemap {
             InstructionValue::StoreLocal {
                 lvalue, value: val, ..
             } => {
-                if let Some(&entry) = self.map.get(&val.identifier) {
-                    self.map.insert(lvalue_id, entry);
-                    self.map.insert(lvalue.place.identifier, entry);
+                if let Some(entry) = self.map[val.identifier] {
+                    self.map[lvalue_id] = Some(entry);
+                    self.map[lvalue.place.identifier] = Some(entry);
                 }
             }
             InstructionValue::LoadLocal { place, .. } => {
-                if let Some(&entry) = self.map.get(&place.identifier) {
-                    self.map.insert(lvalue_id, entry);
+                if let Some(entry) = self.map[place.identifier] {
+                    self.map[lvalue_id] = Some(entry);
                 }
             }
             _ => {}
@@ -361,7 +367,7 @@ impl StableSidemap {
     }
 
     fn is_stable(&self, id: IdentifierId) -> bool {
-        self.map.get(&id).copied().unwrap_or(false)
+        self.map[id].unwrap_or(false)
     }
 }
 
@@ -563,7 +569,7 @@ fn apply_reactive_flags_replay(
             let block = func.body.blocks.get_mut(block_id).unwrap();
             let phi = &mut block.phis[phi_idx];
 
-            if reactive_ids.contains(&phi.place.identifier) {
+            if reactive_ids[phi.place.identifier] {
                 phi.place.reactive = true;
             }
 
@@ -592,7 +598,7 @@ fn apply_reactive_flags_replay(
                     .collect();
             let mut has_reactive_input = false;
             for &op_id in &value_operand_ids {
-                if reactive_ids.contains(&op_id) {
+                if reactive_ids[op_id] {
                     has_reactive_input = true;
                 }
             }
@@ -629,7 +635,7 @@ fn apply_reactive_flags_replay(
             // Value operands: set reactive flag using canonical visitor
             let instr = &mut func.instructions[instr_id.0 as usize];
             visitors::for_each_instruction_value_operand_mut(&mut instr.value, &mut |place| {
-                if reactive_ids.contains(&place.identifier) {
+                if reactive_ids[place.identifier] {
                     place.reactive = true;
                 }
             });
@@ -639,7 +645,7 @@ fn apply_reactive_flags_replay(
             {
                 let inner_func = &mut env.functions[lowered_func.func.0 as usize];
                 for ctx in &mut inner_func.context {
-                    if reactive_ids.contains(&ctx.identifier) {
+                    if reactive_ids[ctx.identifier] {
                         ctx.reactive = true;
                     }
                 }
@@ -648,7 +654,7 @@ fn apply_reactive_flags_replay(
             // Lvalues: markReactive is called only when hasReactiveInput
             if has_reactive_input {
                 let lvalue_id = instr.lvalue.identifier;
-                if !stable_sidemap.is_stable(lvalue_id) && reactive_ids.contains(&lvalue_id) {
+                if !stable_sidemap.is_stable(lvalue_id) && reactive_ids[lvalue_id] {
                     instr.lvalue.reactive = true;
                 }
                 // Handle value lvalues — includes DeclareContext/StoreContext which
@@ -659,14 +665,14 @@ fn apply_reactive_flags_replay(
                     | InstructionValue::StoreLocal { lvalue, .. }
                     | InstructionValue::StoreContext { lvalue, .. } => {
                         let id = lvalue.place.identifier;
-                        if !stable_sidemap.is_stable(id) && reactive_ids.contains(&id) {
+                        if !stable_sidemap.is_stable(id) && reactive_ids[id] {
                             lvalue.place.reactive = true;
                         }
                     }
                     InstructionValue::Destructure { lvalue, .. } => {
                         visitors::for_each_pattern_operand_mut(&mut lvalue.pattern, &mut |place| {
                             if !stable_sidemap.is_stable(place.identifier)
-                                && reactive_ids.contains(&place.identifier)
+                                && reactive_ids[place.identifier]
                             {
                                 place.reactive = true;
                             }
@@ -675,7 +681,7 @@ fn apply_reactive_flags_replay(
                     InstructionValue::PrefixUpdate { lvalue, .. }
                     | InstructionValue::PostfixUpdate { lvalue, .. } => {
                         let id = lvalue.identifier;
-                        if !stable_sidemap.is_stable(id) && reactive_ids.contains(&id) {
+                        if !stable_sidemap.is_stable(id) && reactive_ids[id] {
                             lvalue.reactive = true;
                         }
                     }
@@ -687,7 +693,7 @@ fn apply_reactive_flags_replay(
         // 2c. Terminal operands
         let block = func.body.blocks.get_mut(block_id).unwrap();
         visitors::for_each_terminal_operand_mut(&mut block.terminal, &mut |place| {
-            if reactive_ids.contains(&place.identifier) {
+            if reactive_ids[place.identifier] {
                 place.reactive = true;
             }
         });
@@ -697,15 +703,12 @@ fn apply_reactive_flags_replay(
     apply_reactive_flags_to_inner_functions(func, env, &reactive_ids);
 }
 
-fn build_reactive_id_set(reactive_map: &mut ReactivityMap) -> FxHashSet<IdentifierId> {
-    let mut result = FxHashSet::default();
-    for &id in &reactive_map.reactive {
-        result.insert(id);
-    }
+fn build_reactive_id_set(reactive_map: &mut ReactivityMap) -> IndexVec<IdentifierId, bool> {
+    let mut result = reactive_map.reactive.clone();
     let reactive = &reactive_map.reactive;
     reactive_map.aliased_identifiers.for_each(|id, canonical| {
-        if reactive.contains(&canonical) {
-            result.insert(id);
+        if reactive[canonical] {
+            result[id] = true;
         }
     });
     result
@@ -714,7 +717,7 @@ fn build_reactive_id_set(reactive_map: &mut ReactivityMap) -> FxHashSet<Identifi
 fn apply_reactive_flags_to_inner_functions(
     func: &HirFunction,
     env: &mut Environment,
-    reactive_ids: &FxHashSet<IdentifierId>,
+    reactive_ids: &IndexVec<IdentifierId, bool>,
 ) {
     for (_block_id, block) in &func.body.blocks {
         for instr_id in &block.instructions {
@@ -733,7 +736,7 @@ fn apply_reactive_flags_to_inner_functions(
 fn apply_reactive_flags_to_inner_func(
     func_id: FunctionId,
     env: &mut Environment,
-    reactive_ids: &FxHashSet<IdentifierId>,
+    reactive_ids: &IndexVec<IdentifierId, bool>,
 ) {
     // Collect nested function IDs first to avoid borrow issues
     let nested_func_ids: Vec<FunctionId> = {
@@ -760,13 +763,13 @@ fn apply_reactive_flags_to_inner_func(
         for instr_id in &block.instructions {
             let instr = &mut inner_func.instructions[instr_id.0 as usize];
             visitors::for_each_instruction_value_operand_mut(&mut instr.value, &mut |place| {
-                if reactive_ids.contains(&place.identifier) {
+                if reactive_ids[place.identifier] {
                     place.reactive = true;
                 }
             });
         }
         visitors::for_each_terminal_operand_mut(&mut block.terminal, &mut |place| {
-            if reactive_ids.contains(&place.identifier) {
+            if reactive_ids[place.identifier] {
                 place.reactive = true;
             }
         });
@@ -776,7 +779,7 @@ fn apply_reactive_flags_to_inner_func(
     for nested_id in nested_func_ids {
         let nested_func = &mut env.functions[nested_id.0 as usize];
         for ctx in &mut nested_func.context {
-            if reactive_ids.contains(&ctx.identifier) {
+            if reactive_ids[ctx.identifier] {
                 ctx.reactive = true;
             }
         }


### PR DESCRIPTION
Replace hot function-wide `IdentifierId` hash state in reactive-place inference with `oxc_index::IndexVec` storage.

This branch includes the typed HIR ID compatibility commit from #37477 so it can target `main` independently. That commit is temporarily duplicated and can be removed after #37477 lands.

Ported from oxc-project/oxc commit `4b6ea23` by Boshen <boshenc@gmail.com>:
https://github.com/oxc-project/oxc/commit/4b6ea23be11ae1e081d50f8348f16d86b29b33cd

Original Oxc author: @Boshen.

Validation:
- `cargo check --manifest-path compiler/Cargo.toml -p react_compiler_inference`
- `cargo check --manifest-path compiler/Cargo.toml --workspace --all-targets`
- `cd compiler && yarn snap --rust` (1,810 passed)
- `git diff --check`

Criterion full-corpus benchmark (1,809 fixtures, 50 samples, compared with saved main baseline): +0.19% (95% CI: -0.53% to +0.87%, p=0.61). No performance change detected.

Peak RSS (50 fresh-process full-corpus samples): main mean 198.4 MiB; this PR mean 200.9 MiB; change +1.26%. This PR sample range: 198.8-203.7 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485
