### PR TITLE
[Flight] Fix RangeError from exponential debug info growth

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -197,6 +197,7 @@ type BlockedChunk<T> = {
   _children: Array<SomeChunk<any>> | ProfilingResult, // Profiling-only
   _debugChunk: null, // DEV-only
   _debugInfo: ReactDebugInfo, // DEV-only
+  _receivedDebugInfo: null | Set<ReactDebugInfoEntry>, // DEV-only
   then(resolve: (T) => mixed, reject?: (mixed) => mixed): void,
 };
 type ResolvedModelChunk<T> = {
@@ -276,6 +277,7 @@ function ReactPromise(status: any, value: any, reason: any) {
   if (__DEV__) {
     this._debugChunk = null;
     this._debugInfo = [];
+    this._receivedDebugInfo = null;
   }
 }
 // We subclass Promise.prototype so that we get other methods like .catch
@@ -1170,6 +1172,10 @@ function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
         return;
       }
     }
+    if (__DEV__) {
+      // Only a blocked chunk receives debug info, so release the set here.
+      cyclicChunk._receivedDebugInfo = null;
+    }
     const initializedChunk: InitializedChunk<T> = chunk as any;
     initializedChunk.status = INITIALIZED;
     initializedChunk.value = value;
@@ -1771,7 +1777,7 @@ function fulfillReference(
       const element: any = handler.value;
       switch (key) {
         case '3':
-          if (__DEV__) {
+          if (__DEV__ && !reference.isDebug) {
             transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
           }
           element.props = mappedValue;
@@ -1789,7 +1795,7 @@ function fulfillReference(
           }
           break;
         default:
-          if (__DEV__) {
+          if (__DEV__ && !reference.isDebug) {
             transferReferencedDebugInfo(handler.chunk, fulfilledChunk);
           }
           break;
@@ -1810,6 +1816,10 @@ function fulfillReference(
       return;
     }
     const resolveListeners = chunk.value;
+    if (__DEV__) {
+      // Only a blocked chunk receives debug info, so release the set here.
+      chunk._receivedDebugInfo = null;
+    }
     const initializedChunk: InitializedChunk<any> = chunk as any;
     initializedChunk.status = INITIALIZED;
     initializedChunk.value = handler.value;
@@ -2148,25 +2158,37 @@ function resolveLazy(value: any): mixed {
 }
 
 function transferReferencedDebugInfo(
-  parentChunk: null | SomeChunk<any>,
+  receivingChunk: null | BlockedChunk<any>,
   referencedChunk: SomeChunk<any>,
 ): void {
   if (__DEV__) {
-    // We add the debug info to the initializing chunk since the resolution of
-    // that promise is also blocked by the referenced debug info. By adding it
-    // to both we can track it even if the array/element/lazy is extracted, or
-    // if the root is rendered as is.
-    if (parentChunk !== null) {
+    // We add the debug info to the receiving chunk since the resolution of that
+    // promise is also blocked by the referenced debug info. By adding it to
+    // both we can track it even if the array/element/lazy is extracted, or if
+    // the root is rendered as is.
+    if (receivingChunk !== null) {
       const referencedDebugInfo = referencedChunk._debugInfo;
-      const parentDebugInfo = parentChunk._debugInfo;
+      const receivingDebugInfo = receivingChunk._debugInfo;
+      // The receiving chunk takes each entry only once. A repeated entry
+      // carries no information. An entry repeats in two ways:
+      //
+      // - the receiving chunk references the same chunk more than once
+      // - two referenced chunks carry the same entry
+      //
+      // Without the set, the entries multiply along a chain of references.
+      let receivedDebugInfo = receivingChunk._receivedDebugInfo;
+      if (receivedDebugInfo === null) {
+        receivedDebugInfo = receivingChunk._receivedDebugInfo = new Set();
+      }
       for (let i = 0; i < referencedDebugInfo.length; ++i) {
         const debugInfoEntry = referencedDebugInfo[i];
         if (debugInfoEntry.name != null) {
           debugInfoEntry as ReactComponentInfo;
           // We're not transferring Component info since we use Component info
           // in Debug info to fill in gaps between Fibers for the parent stack.
-        } else {
-          parentDebugInfo.push(debugInfoEntry);
+        } else if (!receivedDebugInfo.has(debugInfoEntry)) {
+          receivedDebugInfo.add(debugInfoEntry);
+          receivingDebugInfo.push(debugInfoEntry);
         }
       }
     }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -3441,6 +3441,70 @@ describe('ReactFlightDOMBrowser', () => {
     );
   });
 
+  it('should not exponentially accumulate debug info when deduplicated references are blocked', async () => {
+    // Regression test for debug info that grows exponentially, along the path
+    // that resolves a reference asynchronously. A form streams its field groups
+    // in parallel. Every group derives its descriptors from the group above it.
+    // Those descriptors deduplicate to the row of that group, which gives this
+    // row one reference per descriptor. Every descriptor names the client
+    // component of the field, and that chunk has not loaded, so every row
+    // blocks and the references wait for it. A row hands its debug info to the
+    // references that wait on it, so each of them copies the whole array and
+    // the count doubles at every group.
+    let loadFieldChunk;
+    const fieldChunkLoaded = new Promise(resolve => (loadFieldChunk = resolve));
+    const Field = clientExports(
+      function Field() {
+        return null;
+      },
+      '1',
+      '/field.js',
+      fieldChunkLoaded,
+    );
+
+    async function loadGroup(descriptors) {
+      return descriptors;
+    }
+
+    const groupCount = 10;
+    const groups = [];
+    let descriptors = [{name: 'a'}, {name: 'b'}];
+    for (let i = 0; i < groupCount; i++) {
+      descriptors = descriptors.map(descriptor => ({
+        parent: descriptor,
+        Field,
+      }));
+      groups.push(loadGroup(descriptors));
+    }
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream({groups}, webpackMap),
+    );
+
+    const response = ReactServerDOMClient.createFromReadableStream(stream);
+
+    // The root row holds only Promises, so it resolves while the field chunk is
+    // still loading. Subscribing to every group initializes its row, and a
+    // group finds the group above it blocked.
+    const form = await response;
+    const allGroups = Promise.all(form.groups);
+    loadFieldChunk();
+    const resolvedGroups = await allGroups;
+
+    expect(resolvedGroups).toHaveLength(groupCount);
+
+    if (__DEV__) {
+      // A group resolves to an array, so Flight hands the debug info of the row
+      // to that array, which is what DevTools reads. Every group contributes a
+      // fixed number of entries, so the last group holds a multiple of the
+      // group count. Without deduplication in transferReferencedDebugInfo the
+      // count doubles at every group.
+      expect(resolvedGroups[groupCount - 1]._debugInfo.length).toBeLessThan(
+        100,
+      );
+    }
+  });
+
   describe('abort signal lifetime', () => {
     // Collects the lifetime signal that React bounds each abort listener with.
     // React passes that signal to addEventListener instead of calling

--- a/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
+++ b/packages/react-server/src/__tests__/ReactFlightAsyncDebugInfo-test.js
@@ -4160,4 +4160,59 @@ describe('ReactFlightAsyncDebugInfo', () => {
       `);
     }
   });
+
+  it('should not exponentially accumulate debug info on deduplicated model chunks', async () => {
+    // Regression test for debug info that grows exponentially with the length
+    // of the chain, along the path that resolves a reference synchronously.
+    // Each page derives its records from the records of the page before it.
+    // Those records deduplicate to the row of that page, which gives this row
+    // one reference per record. That page has already resolved by then, and it
+    // still holds its debug info because it resolves to a plain object. Only an
+    // array, an async iterable, an element, or a lazy node hands the debug info
+    // to the value. So each reference copies the entries of the previous page,
+    // and the count doubles at every page.
+    const pageCount = 10;
+
+    async function loadPage(pageNumber, previousRecords) {
+      await delay(0);
+      const records = previousRecords.map(record => ({previous: record}));
+      return {
+        records,
+        nextPage:
+          pageNumber === pageCount ? null : loadPage(pageNumber + 1, records),
+      };
+    }
+
+    const stream = ReactServerDOMServer.renderToPipeableStream(
+      loadPage(1, [{id: 'a'}, {id: 'b'}]),
+    );
+
+    const readable = new Stream.PassThrough(streamOptions);
+    const result = ReactServerDOMClient.createFromNodeStream(readable, {
+      moduleMap: {},
+      moduleLoading: {},
+    });
+    stream.pipe(readable);
+
+    let page = await result;
+    let lastPage = null;
+    let pagesRead = 1;
+    while (page.nextPage !== null) {
+      lastPage = page.nextPage;
+      page = await page.nextPage;
+      pagesRead++;
+    }
+    expect(pagesRead).toBe(pageCount);
+
+    await finishLoadingStream(readable);
+
+    if (__DEV__) {
+      // Flight represents a Promise in the model with the chunk of its row, so
+      // this reads the debug info of the row itself. Every page contributes a
+      // fixed number of entries, so the last page holds a multiple of the page
+      // count. Without deduplication in transferReferencedDebugInfo the count
+      // doubles at every page.
+      expect(lastPage._debugInfo.length).toBeLessThan(100);
+    }
+  });
 });


### PR DESCRIPTION
The Flight Client copies the debug info of a referenced chunk into the chunk that references it, so that the receiving chunk records what blocked it. It copies the entries once per reference, and a referenced chunk already carries the entries that it received itself. A response that deduplicates the same object across a chain of rows therefore multiplies the entries at every step. In development the array eventually grows past what the engine can allocate for it, and the client throws `RangeError: Invalid array length`.

The receiving chunk now takes each entry only once. The entries are copied by reference and never cloned on this path, so a comparison by identity is exact. The array becomes bounded by the number of distinct entries in the response rather than by a chosen limit.

The bookkeeping costs one `Set` per chunk that receives debug info, in development only. The set holds a reference to each entry rather than a copy, so the entries stay shared and nothing about the debug info is duplicated. A chunk receives entries only while it is blocked, so the fix releases the set as soon as the chunk initializes. Debug info still accumulates transitively, which this change does not alter.

This change also adds the `!reference.isDebug` guards that #37358 proposes for the element props branch and the default branch of `fulfillReference`. #35795 introduced the rule that a reference resolved during debug info resolution does not transfer, and it left those two branches behind. The guards make that rule hold at every branch. However, those branches reference debug chunks that carry no entries, so the guards change no observed behaviour, and they do not fix the growth in #37343, which comes from references in model chunks. #37343 also reports the call in `getOutlinedModel` as unguarded, which it is not, because #35795 already skips it there.

The rest of #37358 deduplicates the entries, which is the right direction, but it scans the receiving array for every candidate, which is quadratic in the size of the debug info. #37359 caps the array at a constant instead, which stops the crash but keeps copying the duplicates and drops debug info once a response passes the cap.

**Alternatives Considered**

- Tracking the referenced chunks rather than the entries would be cheaper, because it would need one map entry per referenced chunk. It would not be enough, because a chunk can reach the same entry through two paths. A chunk can hold a client reference directly and also reference a chunk that already received the debug info of that client reference.
- Recording the last receiving chunk on each entry would be exact while a chunk parses its model, where the transfers into it are consecutive. It would break once transfers into different chunks interleave, and that is the path the reported crash takes.
- Turning `_debugInfo` itself into a `Set` is not possible, because the reconciler, Fizz, the Flight Server and DevTools read it by index and depend on its order.

Fixes #37343
Closes #37358
Closes #37359