### PR TITLE
oxc port: remove avoidable string allocations

### DIFF
--- a/compiler/crates/react_compiler_hir/src/object_shape.rs
+++ b/compiler/crates/react_compiler_hir/src/object_shape.rs
@@ -72,25 +72,31 @@ pub enum HookKind {
     Custom,
 }
 
+impl HookKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HookKind::UseContext => "useContext",
+            HookKind::UseState => "useState",
+            HookKind::UseActionState => "useActionState",
+            HookKind::UseReducer => "useReducer",
+            HookKind::UseRef => "useRef",
+            HookKind::UseEffect => "useEffect",
+            HookKind::UseLayoutEffect => "useLayoutEffect",
+            HookKind::UseInsertionEffect => "useInsertionEffect",
+            HookKind::UseMemo => "useMemo",
+            HookKind::UseCallback => "useCallback",
+            HookKind::UseTransition => "useTransition",
+            HookKind::UseImperativeHandle => "useImperativeHandle",
+            HookKind::UseEffectEvent => "useEffectEvent",
+            HookKind::UseOptimistic => "useOptimistic",
+            HookKind::Custom => "Custom",
+        }
+    }
+}
+
 impl std::fmt::Display for HookKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HookKind::UseContext => write!(f, "useContext"),
-            HookKind::UseState => write!(f, "useState"),
-            HookKind::UseActionState => write!(f, "useActionState"),
-            HookKind::UseReducer => write!(f, "useReducer"),
-            HookKind::UseRef => write!(f, "useRef"),
-            HookKind::UseEffect => write!(f, "useEffect"),
-            HookKind::UseLayoutEffect => write!(f, "useLayoutEffect"),
-            HookKind::UseInsertionEffect => write!(f, "useInsertionEffect"),
-            HookKind::UseMemo => write!(f, "useMemo"),
-            HookKind::UseCallback => write!(f, "useCallback"),
-            HookKind::UseTransition => write!(f, "useTransition"),
-            HookKind::UseImperativeHandle => write!(f, "useImperativeHandle"),
-            HookKind::UseEffectEvent => write!(f, "useEffectEvent"),
-            HookKind::UseOptimistic => write!(f, "useOptimistic"),
-            HookKind::Custom => write!(f, "Custom"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -6422,74 +6422,82 @@ fn lower_jsx_element(
     }
 }
 
-/// Split a string on line endings, handling \r\n, \n, and \r.
-fn split_line_endings(s: &str) -> Vec<&str> {
-    let mut lines = Vec::new();
-    let mut start = 0;
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'\r' {
-            lines.push(&s[start..i]);
-            if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
-                i += 2;
+/// Split a string on line endings, handling \r\n, \n, and \r without allocating.
+/// The second tuple element is the byte length of the line ending.
+fn split_line_endings(s: &str) -> impl Iterator<Item = (&str, usize)> {
+    let mut remaining = Some(s);
+    std::iter::from_fn(move || {
+        let line = remaining.take()?;
+        let bytes = line.as_bytes();
+        let end = bytes.iter().position(|byte| matches!(byte, b'\r' | b'\n'));
+        if let Some(end) = end {
+            let line_ending_len = if bytes[end] == b'\r' && bytes.get(end + 1) == Some(&b'\n') {
+                2
             } else {
-                i += 1;
-            }
-            start = i;
-        } else if bytes[i] == b'\n' {
-            lines.push(&s[start..i]);
-            i += 1;
-            start = i;
+                1
+            };
+            remaining = Some(&line[end + line_ending_len..]);
+            Some((&line[..end], line_ending_len))
         } else {
-            i += 1;
+            Some((line, 0))
         }
-    }
-    lines.push(&s[start..]);
-    lines
+    })
 }
 
 /// Trims whitespace according to the JSX spec.
 /// Implementation ported from Babel's cleanJSXElementLiteralChild.
 fn trim_jsx_text(original: &str) -> Option<String> {
-    // Split on \r\n, \n, or \r to handle all line ending styles (matching TS split(/\r\n|\n|\r/))
-    let lines: Vec<&str> = split_line_endings(original);
+    if !original
+        .bytes()
+        .any(|byte| matches!(byte, b'\r' | b'\n' | b'\t'))
+    {
+        return (!original.is_empty()).then(|| original.to_string());
+    }
+
+    // Split on \r\n, \n, or \r to handle all line ending styles (matching TS split(/\r\n|\n|\r/)).
+    let mut line_count = 0;
+    let mut last_non_empty_line = None;
+    for (i, (line, _)) in split_line_endings(original).enumerate() {
+        line_count += 1;
+        if line.bytes().any(|byte| !matches!(byte, b' ' | b'\t')) {
+            last_non_empty_line = Some(i);
+        }
+    }
+    let last_non_empty_line = match last_non_empty_line {
+        Some(line) => line,
+        None if line_count == 1 => 0,
+        None => return None,
+    };
 
     // NOTE: when builder.fbt_depth > 0, the TS skips whitespace trimming entirely.
     // That check is handled by the caller (lower_jsx_element) before calling this function.
 
-    let mut last_non_empty_line = 0;
-    for (i, line) in lines.iter().enumerate() {
-        if line.contains(|c: char| c != ' ' && c != '\t') {
-            last_non_empty_line = i;
-        }
-    }
-
     let mut str = String::new();
 
-    for (i, line) in lines.iter().enumerate() {
+    for (i, (line, _)) in split_line_endings(original).enumerate() {
         let is_first_line = i == 0;
-        let is_last_line = i == lines.len() - 1;
+        let is_last_line = i == line_count - 1;
         let is_last_non_empty_line = i == last_non_empty_line;
 
-        // Replace rendered whitespace tabs with spaces
-        let mut trimmed_line = line.replace('\t', " ");
+        let mut trimmed_line = line;
 
         // Trim whitespace touching a newline (leading whitespace on non-first lines)
         if !is_first_line {
-            trimmed_line = trimmed_line.trim_start_matches(' ').to_string();
+            trimmed_line = trimmed_line.trim_start_matches([' ', '\t']);
         }
 
         // Trim whitespace touching an endline (trailing whitespace on non-last lines)
         if !is_last_line {
-            trimmed_line = trimmed_line.trim_end_matches(' ').to_string();
+            trimmed_line = trimmed_line.trim_end_matches([' ', '\t']);
         }
 
         if !trimmed_line.is_empty() {
-            if !is_last_non_empty_line {
-                trimmed_line.push(' ');
+            for c in trimmed_line.chars() {
+                str.push(if c == '\t' { ' ' } else { c });
             }
-            str.push_str(&trimmed_line);
+            if !is_last_non_empty_line {
+                str.push(' ');
+            }
         }
     }
 

--- a/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
+++ b/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
@@ -560,14 +560,22 @@ fn evaluate_instruction(
             loc,
         } => {
             if subexprs.is_empty() {
-                // No subexpressions: join all cooked quasis
-                let mut result_string = String::new();
-                for q in quasis {
-                    match &q.cooked {
-                        Some(cooked) => result_string.push_str(cooked),
-                        None => return None,
+                // A template without substitutions normally has one quasi.
+                let result_string = match quasis.as_slice() {
+                    [] => String::new(),
+                    [quasi] => quasi.cooked.clone()?,
+                    quasis => {
+                        let capacity = quasis
+                            .iter()
+                            .map(|quasi| quasi.cooked.as_ref().map(String::len))
+                            .sum::<Option<usize>>()?;
+                        let mut result = String::with_capacity(capacity);
+                        for quasi in quasis {
+                            result.push_str(quasi.cooked.as_ref().unwrap());
+                        }
+                        result
                     }
-                }
+                };
                 let loc = *loc;
                 let result = Constant::Primitive {
                     value: PrimitiveValue::String(JsString::from_marker_string(&result_string)),
@@ -589,33 +597,33 @@ fn evaluate_instruction(
             }
 
             let mut quasi_index = 0usize;
-            let mut result_string = quasis[quasi_index].cooked.as_ref().unwrap().clone();
+            let mut result_string = String::new();
+            result_string.push_str(quasis[quasi_index].cooked.as_ref().unwrap());
             quasi_index += 1;
 
             for sub_expr in subexprs {
-                let sub_expr_value = read(constants, sub_expr);
-                let sub_prim = match sub_expr_value {
-                    Some(Constant::Primitive { ref value, .. }) => value,
-                    _ => return None,
+                let Some(Constant::Primitive { value, .. }) = constants.get(&sub_expr.identifier)
+                else {
+                    return None;
                 };
-
-                let expression_str = match sub_prim {
-                    PrimitiveValue::Null => "null".to_string(),
-                    PrimitiveValue::Boolean(b) => b.to_string(),
-                    PrimitiveValue::Number(n) => format_js_number(n.value()),
-                    PrimitiveValue::String(s) => s.to_marker_string(),
-                    // TS rejects undefined subexpression values
+                match value {
+                    PrimitiveValue::Null => result_string.push_str("null"),
+                    PrimitiveValue::Boolean(value) => {
+                        result_string.push_str(if *value { "true" } else { "false" });
+                    }
+                    PrimitiveValue::Number(value) => {
+                        result_string.push_str(&format_js_number(value.value()));
+                    }
+                    PrimitiveValue::String(value) => {
+                        result_string.push_str(&value.to_marker_string());
+                    }
                     PrimitiveValue::Undefined => return None,
-                };
+                }
 
-                let suffix = match &quasis[quasi_index].cooked {
-                    Some(s) => s.clone(),
-                    None => return None,
-                };
+                let suffix = quasis[quasi_index].cooked.as_ref().unwrap();
                 quasi_index += 1;
 
-                result_string.push_str(&expression_str);
-                result_string.push_str(&suffix);
+                result_string.push_str(suffix);
             }
 
             let loc = *loc;

--- a/compiler/crates/react_compiler_optimization/src/name_anonymous_functions.rs
+++ b/compiler/crates/react_compiler_optimization/src/name_anonymous_functions.rs
@@ -31,7 +31,7 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
 
     let nodes = name_anonymous_functions_impl(func, env);
 
-    fn visit(node: &Node, prefix: &str, updates: &mut Vec<(FunctionId, String)>) {
+    fn visit(node: &Node, prefix: &mut String, updates: &mut Vec<(FunctionId, String)>) {
         if node.generated_name.is_some() && node.existing_name_hint.is_none() {
             // Only add the prefix to anonymous functions regardless of nesting depth
             let name = format!("{}{}]", prefix, node.generated_name.as_ref().unwrap());
@@ -48,16 +48,19 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
             fallback = "<anonymous>";
             fallback
         };
-        let next_prefix = format!("{}{} > ", prefix, label);
+        let previous_len = prefix.len();
+        prefix.push_str(label);
+        prefix.push_str(" > ");
         for inner in &node.inner {
-            visit(inner, &next_prefix, updates);
+            visit(inner, prefix, updates);
         }
+        prefix.truncate(previous_len);
     }
 
     let mut updates: Vec<(FunctionId, String)> = Vec::new();
-    let prefix = format!("{}[", fn_id);
+    let mut prefix = format!("{}[", fn_id);
     for node in &nodes {
-        visit(node, &prefix, &mut updates);
+        visit(node, &mut prefix, &mut updates);
     }
 
     if updates.is_empty() {
@@ -264,20 +267,14 @@ fn handle_call(
     let callee_ty = &env.types[callee_ident.type_.0 as usize];
     let hook_kind = env.get_hook_kind_for_type(callee_ty).ok().flatten();
 
-    let callee_name: String = if let Some(hk) = hook_kind {
+    let callee_name = if let Some(hk) = hook_kind {
         if *hk != HookKind::Custom {
-            hk.to_string()
+            hk.as_str()
         } else {
-            names
-                .get(&callee_id)
-                .cloned()
-                .unwrap_or_else(|| "(anonymous)".to_string())
+            names.get(&callee_id).map_or("(anonymous)", String::as_str)
         }
     } else {
-        names
-            .get(&callee_id)
-            .cloned()
-            .unwrap_or_else(|| "(anonymous)".to_string())
+        names.get(&callee_id).map_or("(anonymous)", String::as_str)
     };
 
     // Count how many args are tracked functions


### PR DESCRIPTION
Port the React-applicable string allocation reductions from Oxc:

- expose allocation-free `HookKind::as_str()` formatting
- reuse the anonymous-function naming prefix buffer and borrow callee names
- iterate JSX line endings without allocating an intermediate vector
- build folded template literal strings in one output buffer

React retains its owned `String`/`JsString` representation, existing JavaScript number conversion, and one final owned allocation at HIR boundaries. Oxc-only arena, frontend, scope, regexp, and resolver changes are omitted.

Ported from oxc-project/oxc commit `173c734` by Cameron <cameron.clark@hey.com>:
https://github.com/oxc-project/oxc/commit/173c73444afec7a797d8dd123810cf62be514dd2

Original Oxc author: @camc314.

Validation:
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `cargo check --manifest-path compiler/Cargo.toml --workspace --all-targets`
- `cd compiler && yarn snap --rust` (1,810 passed)
- Criterion full-corpus benchmark (1,809 fixtures, 50 samples): main 513.19 ms; this PR 512.00 ms; change -0.23% (95% CI: -0.97% to +0.53%, p=0.56). No performance change detected.
- `git diff --check`

Peak RSS (50 fresh-process full-corpus samples): main mean 198.4 MiB; this PR mean 198.0 MiB; change -0.20%. This PR sample range: 196.8-200.0 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485
