### PR TITLE
Add Criterion benchmark for rust react compiler

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -3,6 +3,33 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,10 +46,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "convert_case"
@@ -32,6 +123,73 @@ checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
@@ -44,6 +202,12 @@ name = "ctor"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -140,10 +304,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hmac-sha256"
@@ -164,10 +345,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -249,10 +467,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -273,10 +540,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "react_compiler"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "indexmap",
+ "libc",
  "react_compiler_ast",
  "react_compiler_diagnostics",
  "react_compiler_hir",
@@ -428,10 +717,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -527,6 +851,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +880,61 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -570,6 +959,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/compiler/crates/react_compiler/Cargo.toml
+++ b/compiler/crates/react_compiler/Cargo.toml
@@ -18,3 +18,11 @@ indexmap = "2"
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
+
+[dev-dependencies]
+criterion = "0.5"
+libc = "0.2"
+
+[[bench]]
+name = "compile_program"
+harness = false

--- a/compiler/crates/react_compiler/benches/compile_program.rs
+++ b/compiler/crates/react_compiler/benches/compile_program.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use criterion::{BatchSize, Criterion, SamplingMode, Throughput, black_box};
@@ -54,12 +55,6 @@ fn peak_rss_bytes() -> u64 {
     }
 }
 
-#[cfg(unix)]
-fn print_peak_rss(label: &str) {
-    let peak_mib = peak_rss_bytes() as f64 / (1024.0 * 1024.0);
-    eprintln!("Peak RSS {label}: {peak_mib:.1} MiB");
-}
-
 fn read_json<T: DeserializeOwned>(path: &Path) -> T {
     let json = fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("Failed to read {}: {error}", path.display()));
@@ -109,10 +104,14 @@ fn load_fixtures() -> (Vec<Fixture>, u64) {
     (fixtures, manifest.total_source_bytes)
 }
 
+fn compile_corpus(fixtures: Vec<Fixture>) {
+    for fixture in fixtures {
+        black_box(compile_program(fixture.ast, fixture.scope, fixture.options));
+    }
+}
+
 fn benchmark(criterion: &mut Criterion) {
     let (fixtures, total_source_bytes) = load_fixtures();
-    #[cfg(unix)]
-    print_peak_rss("after loading fixtures");
     let fixture_count = fixtures.len();
     let mut group = criterion.benchmark_group("react_compiler");
     group.sampling_mode(SamplingMode::Flat);
@@ -121,22 +120,77 @@ fn benchmark(criterion: &mut Criterion) {
     group.measurement_time(Duration::from_secs(30));
     group.throughput(Throughput::Bytes(total_source_bytes));
     group.bench_function(format!("full_corpus/{fixture_count}_fixtures"), |bencher| {
-        bencher.iter_batched(
-            || fixtures.clone(),
-            |fixtures| {
-                for fixture in fixtures {
-                    black_box(compile_program(fixture.ast, fixture.scope, fixture.options));
-                }
-            },
-            BatchSize::PerIteration,
-        );
+        bencher.iter_batched(|| fixtures.clone(), compile_corpus, BatchSize::PerIteration);
     });
     group.finish();
-    #[cfg(unix)]
-    print_peak_rss("after benchmark");
+}
+
+#[cfg(unix)]
+fn memory_worker() {
+    let (fixtures, _) = load_fixtures();
+    compile_corpus(fixtures);
+    println!("{}", peak_rss_bytes());
+}
+
+#[cfg(unix)]
+fn percentile(sorted: &[u64], percentile: f64) -> f64 {
+    let index = percentile * (sorted.len() - 1) as f64;
+    let lower = index.floor() as usize;
+    let upper = index.ceil() as usize;
+    let weight = index - lower as f64;
+    sorted[lower] as f64 * (1.0 - weight) + sorted[upper] as f64 * weight
+}
+
+#[cfg(unix)]
+fn benchmark_memory() {
+    let sample_count = std::env::var("REACT_COMPILER_MEMORY_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(50);
+    assert!(sample_count > 0, "Memory sample count must be positive");
+
+    let executable = std::env::current_exe().expect("Failed to locate benchmark executable");
+    let mut samples = Vec::with_capacity(sample_count);
+    eprintln!("Sampling peak RSS across {sample_count} fresh processes...");
+
+    for _ in 0..sample_count {
+        let output = Command::new(&executable)
+            .env("REACT_COMPILER_MEMORY_WORKER", "1")
+            .output()
+            .expect("Failed to run memory benchmark worker");
+        assert!(
+            output.status.success(),
+            "Memory benchmark worker failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        samples.push(
+            String::from_utf8(output.stdout)
+                .expect("Worker output was not UTF-8")
+                .trim()
+                .parse::<u64>()
+                .expect("Worker output contained an invalid RSS value"),
+        );
+    }
+
+    samples.sort_unstable();
+    let mean = samples.iter().sum::<u64>() as f64 / samples.len() as f64;
+    let mib = 1024.0 * 1024.0;
+    println!(
+        "Full-corpus peak RSS: mean {:.1} MiB, median {:.1} MiB, 95% sample range [{:.1} MiB, {:.1} MiB]",
+        mean / mib,
+        percentile(&samples, 0.5) / mib,
+        percentile(&samples, 0.025) / mib,
+        percentile(&samples, 0.975) / mib,
+    );
 }
 
 fn main() {
+    #[cfg(unix)]
+    if std::env::var_os("REACT_COMPILER_MEMORY_WORKER").is_some() {
+        memory_worker();
+        return;
+    }
+
     std::thread::Builder::new()
         .name("react-compiler-benchmark".to_string())
         .stack_size(64 * 1024 * 1024)
@@ -144,6 +198,8 @@ fn main() {
             let mut criterion = Criterion::default().configure_from_args();
             benchmark(&mut criterion);
             criterion.final_summary();
+            #[cfg(unix)]
+            benchmark_memory();
         })
         .expect("Failed to spawn benchmark thread")
         .join()

--- a/compiler/crates/react_compiler/benches/compile_program.rs
+++ b/compiler/crates/react_compiler/benches/compile_program.rs
@@ -1,0 +1,151 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use criterion::{BatchSize, Criterion, SamplingMode, Throughput, black_box};
+use react_compiler::entrypoint::{PluginOptions, compile_program};
+use react_compiler_ast::File;
+use react_compiler_ast::scope::ScopeInfo;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Manifest {
+    version: u32,
+    fixtures: Vec<ManifestFixture>,
+    failures: Vec<FailedFixture>,
+    total_source_bytes: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManifestFixture {
+    fixture: String,
+    ast: PathBuf,
+    scope: PathBuf,
+    options: PathBuf,
+}
+
+#[derive(Deserialize)]
+struct FailedFixture {
+    fixture: String,
+    error: String,
+}
+
+#[derive(Clone)]
+struct Fixture {
+    ast: File,
+    scope: ScopeInfo,
+    options: PluginOptions,
+}
+
+#[cfg(unix)]
+fn peak_rss_bytes() -> u64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+    let result = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    assert_eq!(result, 0, "getrusage failed");
+    let max_rss = unsafe { usage.assume_init() }.ru_maxrss as u64;
+
+    if cfg!(target_os = "macos") {
+        max_rss
+    } else {
+        max_rss * 1024
+    }
+}
+
+#[cfg(unix)]
+fn print_peak_rss(label: &str) {
+    let peak_mib = peak_rss_bytes() as f64 / (1024.0 * 1024.0);
+    eprintln!("Peak RSS {label}: {peak_mib:.1} MiB");
+}
+
+fn read_json<T: DeserializeOwned>(path: &Path) -> T {
+    let json = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("Failed to read {}: {error}", path.display()));
+    let mut deserializer = serde_json::Deserializer::from_str(&json);
+    deserializer.disable_recursion_limit();
+    T::deserialize(&mut deserializer)
+        .unwrap_or_else(|error| panic!("Failed to deserialize {}: {error}", path.display()))
+}
+
+fn load_fixtures() -> (Vec<Fixture>, u64) {
+    let benchmark_dir = PathBuf::from(std::env::var("REACT_COMPILER_BENCHMARK_DIR").expect(
+        "REACT_COMPILER_BENCHMARK_DIR is unset; run compiler/scripts/benchmark-rust-compiler.sh",
+    ));
+    let manifest: Manifest = read_json(&benchmark_dir.join("manifest.json"));
+
+    assert_eq!(
+        manifest.version, 1,
+        "Unsupported benchmark manifest version"
+    );
+    if !manifest.failures.is_empty() {
+        eprintln!(
+            "Input generation skipped {} fixtures:",
+            manifest.failures.len()
+        );
+        for failure in &manifest.failures {
+            eprintln!("  {}: {}", failure.fixture, failure.error);
+        }
+    }
+
+    let fixtures = manifest
+        .fixtures
+        .into_iter()
+        .map(|fixture| {
+            let mut options: PluginOptions = read_json(&benchmark_dir.join(fixture.options));
+            options.profiling = false;
+            let loaded = Fixture {
+                ast: read_json(&benchmark_dir.join(fixture.ast)),
+                scope: read_json(&benchmark_dir.join(fixture.scope)),
+                options,
+            };
+            black_box(fixture.fixture);
+            loaded
+        })
+        .collect::<Vec<_>>();
+
+    assert!(!fixtures.is_empty(), "No benchmark fixtures were generated");
+    (fixtures, manifest.total_source_bytes)
+}
+
+fn benchmark(criterion: &mut Criterion) {
+    let (fixtures, total_source_bytes) = load_fixtures();
+    #[cfg(unix)]
+    print_peak_rss("after loading fixtures");
+    let fixture_count = fixtures.len();
+    let mut group = criterion.benchmark_group("react_compiler");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_secs(3));
+    group.measurement_time(Duration::from_secs(30));
+    group.throughput(Throughput::Bytes(total_source_bytes));
+    group.bench_function(format!("full_corpus/{fixture_count}_fixtures"), |bencher| {
+        bencher.iter_batched(
+            || fixtures.clone(),
+            |fixtures| {
+                for fixture in fixtures {
+                    black_box(compile_program(fixture.ast, fixture.scope, fixture.options));
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+    #[cfg(unix)]
+    print_peak_rss("after benchmark");
+}
+
+fn main() {
+    std::thread::Builder::new()
+        .name("react-compiler-benchmark".to_string())
+        .stack_size(64 * 1024 * 1024)
+        .spawn(|| {
+            let mut criterion = Criterion::default().configure_from_args();
+            benchmark(&mut criterion);
+            criterion.final_summary();
+        })
+        .expect("Failed to spawn benchmark thread")
+        .join()
+        .expect("Benchmark thread panicked");
+}

--- a/compiler/scripts/benchmark-rust-compiler.sh
+++ b/compiler/scripts/benchmark-rust-compiler.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+FIXTURES_DIR=""
+LIMIT=""
+CRITERION_ARGS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --fixtures)
+      FIXTURES_DIR="$2"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      CRITERION_ARGS=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: bash compiler/scripts/benchmark-rust-compiler.sh [--fixtures DIR] [--limit N] [-- <criterion args>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+BENCHMARK_DIR="$(mktemp -d)"
+trap 'rm -rf "$BENCHMARK_DIR"' EXIT
+
+GENERATOR_ARGS=(--output "$BENCHMARK_DIR")
+if [ -n "$FIXTURES_DIR" ]; then
+  GENERATOR_ARGS+=(--fixtures "$FIXTURES_DIR")
+fi
+if [ -n "$LIMIT" ]; then
+  GENERATOR_ARGS+=(--limit "$LIMIT")
+fi
+
+npx --yes tsx "$REPO_ROOT/compiler/scripts/generate-rust-benchmark-inputs.ts" "${GENERATOR_ARGS[@]}"
+
+cd "$REPO_ROOT/compiler"
+REACT_COMPILER_BENCHMARK_DIR="$BENCHMARK_DIR" \
+  "${CARGO:-cargo}" bench -p react_compiler --bench compile_program -- "${CRITERION_ARGS[@]}"

--- a/compiler/scripts/generate-rust-benchmark-inputs.ts
+++ b/compiler/scripts/generate-rust-benchmark-inputs.ts
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as babel from '@babel/core';
+import * as BabelParser from '@babel/parser';
+import fs from 'fs';
+import path from 'path';
+import traverseModule from '@babel/traverse';
+
+import {parseConfigPragmaForTests} from '../packages/babel-plugin-react-compiler/src/Utils/TestUtils';
+import {resolveOptions} from '../packages/babel-plugin-react-compiler-rust/src/options';
+import {extractScopeInfo} from '../packages/babel-plugin-react-compiler-rust/src/scope';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DEFAULT_FIXTURES_DIR = path.join(
+  REPO_ROOT,
+  'compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler',
+);
+const traverse = traverseModule.default ?? traverseModule;
+const SNAP_HERMES_PARSER = path.join(
+  REPO_ROOT,
+  'compiler/packages/snap/node_modules/hermes-parser',
+);
+
+const rawArgs = process.argv.slice(2);
+const outputIdx = rawArgs.indexOf('--output');
+const fixturesIdx = rawArgs.indexOf('--fixtures');
+const limitIdx = rawArgs.indexOf('--limit');
+const outputDir = readArgValue(outputIdx, '--output');
+const fixturesArg = readArgValue(fixturesIdx, '--fixtures');
+const limitArg = readArgValue(limitIdx, '--limit');
+const fixturesDir =
+  fixturesArg == null ? DEFAULT_FIXTURES_DIR : path.resolve(fixturesArg);
+const limit = limitArg == null ? 0 : parseInt(limitArg, 10);
+
+if (outputDir == null) {
+  console.error(
+    'Usage: npx tsx compiler/scripts/generate-rust-benchmark-inputs.ts --output <dir> [--fixtures <dir>] [--limit N]',
+  );
+  process.exit(1);
+}
+if (!Number.isInteger(limit) || limit < 0) {
+  throw new Error('--limit must be a non-negative integer');
+}
+
+type PreparedFixture = {
+  fixture: string;
+  sizeBytes: number;
+  ast: string;
+  scope: string;
+  options: string;
+};
+
+type FailedFixture = {
+  fixture: string;
+  error: string;
+};
+
+function readArgValue(index: number, name: string): string | null {
+  if (index < 0) {
+    return null;
+  }
+  const value = rawArgs[index + 1];
+  if (value == null || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function discoverFixtures(rootPath: string): Array<string> {
+  const results: Array<string> = [];
+
+  function walk(dir: string): void {
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (
+        /\.(js|jsx|ts|tsx)$/.test(entry.name) &&
+        !entry.name.endsWith('.expect.md')
+      ) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(rootPath);
+  results.sort();
+  return results;
+}
+
+function sanitizeJsonSurrogates(json: string): string {
+  return json
+    .replace(
+      /(?<!\\)\\u([dD][89aAbB][0-9a-fA-F]{2})(?!\\u[dD][c-fC-F][0-9a-fA-F]{2})/g,
+      (_, hex) => `__SURROGATE_${hex.toUpperCase()}__`,
+    )
+    .replace(
+      /(?<!\\u[dD][89aAbB][0-9a-fA-F]{2})(?<!\\)\\u([dD][c-fC-F][0-9a-fA-F]{2})/g,
+      (_, hex) => `__SURROGATE_${hex.toUpperCase()}__`,
+    );
+}
+
+function sidecarPath(relativeFixture: string, kind: string): string {
+  return `${relativeFixture}.${kind}.json`;
+}
+
+function writeJson(
+  relativePath: string,
+  value: unknown,
+  sanitize = false,
+): void {
+  const target = path.join(outputDir!, relativePath);
+  fs.mkdirSync(path.dirname(target), {recursive: true});
+  const json = JSON.stringify(value);
+  fs.writeFileSync(target, sanitize ? sanitizeJsonSurrogates(json) : json);
+}
+
+let fixtures = discoverFixtures(fixturesDir);
+if (limit > 0) {
+  fixtures = fixtures.slice(0, limit);
+}
+const expectedFixtureCount = fixtures.length;
+if (!fs.existsSync(SNAP_HERMES_PARSER)) {
+  throw new Error(
+    'The snap Hermes parser is not installed; run `yarn install` in compiler/',
+  );
+}
+const hermesParser = require(
+  SNAP_HERMES_PARSER,
+) as typeof import('hermes-parser');
+
+const prepared: Array<PreparedFixture> = [];
+const failures: Array<FailedFixture> = [];
+
+fs.mkdirSync(outputDir, {recursive: true});
+
+for (const fixturePath of fixtures) {
+  const relativeFixture = path.relative(fixturesDir, fixturePath);
+  const source = fs.readFileSync(fixturePath, 'utf8');
+  const firstLine = source.substring(0, source.indexOf('\n'));
+  const pragmaOptions = parseConfigPragmaForTests(firstLine, {
+    compilationMode: 'all',
+  });
+  const isFlow = source.includes('@flow');
+  const sourceType = source.includes('@script') ? 'script' : 'module';
+
+  let ast: babel.types.File | null = null;
+  let scopeInfo: ReturnType<typeof extractScopeInfo> | null = null;
+  let options: ReturnType<typeof resolveOptions> | null = null;
+
+  try {
+    ast = isFlow
+      ? (hermesParser.parse(source, {
+          babel: true,
+          flow: 'all',
+          sourceFilename: fixturePath,
+          sourceType,
+          enableExperimentalComponentSyntax: true,
+          enableExperimentalFlowMatchSyntax: true,
+        }) as babel.types.File)
+      : BabelParser.parse(source, {
+          sourceFilename: fixturePath,
+          plugins: ['typescript', 'jsx', 'explicitResourceManagement'],
+          sourceType,
+        });
+    const file = new babel.File({filename: fixturePath}, {code: source, ast});
+    options = resolveOptions(
+      {
+        ...pragmaOptions,
+        compilationMode: 'all',
+        panicThreshold: 'all_errors',
+      },
+      file,
+      fixturePath,
+      ast,
+    );
+    traverse(ast, {
+      Program(program): void {
+        scopeInfo = extractScopeInfo(program);
+        program.stop();
+      },
+    });
+  } catch (error) {
+    failures.push({
+      fixture: relativeFixture,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    continue;
+  }
+
+  if (ast == null || scopeInfo == null || options == null) {
+    failures.push({
+      fixture: relativeFixture,
+      error: 'Babel did not produce compiler inputs',
+    });
+    continue;
+  }
+
+  const astPath = sidecarPath(relativeFixture, 'ast');
+  const scopePath = sidecarPath(relativeFixture, 'scope');
+  const optionsPath = sidecarPath(relativeFixture, 'options');
+
+  writeJson(astPath, ast, true);
+  writeJson(scopePath, scopeInfo);
+  writeJson(optionsPath, {
+    ...options,
+    __sourceCode: source,
+    __profiling: false,
+  });
+
+  prepared.push({
+    fixture: relativeFixture,
+    sizeBytes: Buffer.byteLength(source),
+    ast: astPath,
+    scope: scopePath,
+    options: optionsPath,
+  });
+}
+
+const totalSourceBytes = prepared.reduce(
+  (total, fixture) => total + fixture.sizeBytes,
+  0,
+);
+writeJson('manifest.json', {
+  version: 1,
+  fixtures: prepared,
+  failures,
+  totalSourceBytes,
+});
+
+console.log(
+  `Prepared ${prepared.length}/${fixtures.length} fixtures (${totalSourceBytes} source bytes); ${failures.length} failed`,
+);
+if (prepared.length !== expectedFixtureCount) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Add a native Criterion benchmark for repeated full-corpus React Compiler measurements.

- generate Babel-shaped AST, scope, and resolved option inputs outside the measured loop
- compile all 1,809 fixtures through `compile_program`
- report confidence intervals, outliers, throughput, and named-baseline comparisons across 50 samples
- keep parsing, serialization, file I/O, and input cloning outside measured time

Validation:
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `cargo check --manifest-path compiler/Cargo.toml -p react_compiler --bench compile_program`
- `CARGO_PROFILE_BENCH_LTO=false CARGO_PROFILE_BENCH_CODEGEN_UNITS=16 bash compiler/scripts/benchmark-rust-compiler.sh -- --test` (1,809/1,809 fixtures)