### PR TITLE
React Compiler: avoid cloning inference state for the last successor

### DIFF
--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -220,14 +220,29 @@ pub fn infer_mutation_aliasing_effects(
                 return Err(diag);
             }
 
-            // Queue successors
+            // Queue successors. TS passes the same state object to every
+            // successor; Rust has to hand each one its own copy, but the last
+            // successor can take ownership instead of cloning. Straight-line
+            // blocks have a single successor, so they clone not at all.
             let successors = terminal_successors(&func.body.blocks[&block_id].terminal);
-            for next_block_id in successors {
+            let last = successors.len();
+            let mut state = Some(state);
+            for (i, next_block_id) in successors.into_iter().enumerate() {
+                let outgoing = if i + 1 == last {
+                    state
+                        .take()
+                        .expect("state is taken only on the last successor")
+                } else {
+                    state
+                        .as_ref()
+                        .expect("state is live until the last successor")
+                        .clone()
+                };
                 queue(
                     &mut queued_states,
                     &states_by_block,
                     next_block_id,
-                    state.clone(),
+                    outgoing,
                 );
             }
         }

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -225,19 +225,10 @@ pub fn infer_mutation_aliasing_effects(
             // successor can take ownership instead of cloning. Straight-line
             // blocks have a single successor, so they clone not at all.
             let successors = terminal_successors(&func.body.blocks[&block_id].terminal);
-            let last = successors.len();
-            let mut state = Some(state);
-            for (i, next_block_id) in successors.into_iter().enumerate() {
-                let outgoing = if i + 1 == last {
-                    state
-                        .take()
-                        .expect("state is taken only on the last successor")
-                } else {
-                    state
-                        .as_ref()
-                        .expect("state is live until the last successor")
-                        .clone()
-                };
+            let outgoing_states = std::iter::repeat_n(state, successors.len());
+            for (next_block_id, outgoing) in
+                  successors.into_iter().zip(outgoing_states)
+              {
                 queue(
                     &mut queued_states,
                     &states_by_block,


### PR DESCRIPTION
## Summary

In the mutation/aliasing effects fixpoint, each block's outgoing state is handed to every successor. TS passes the same `InferenceState` object to each one, so a block visit costs a single clone regardless of how many successors it has. Rust cannot share the object, so the port clones once per successor -- `1 + N` copies, vs TS just does `1`.

The state is dead after the successor loop, so the last successor can take ownership instead of copying. Straight-line blocks have a single successor and now do no cloning here at all; branches drop from `N` copies to `N - 1`.

`InferenceState` holds two hash maps (`values` and `variables`), so each avoided clone is two table allocations plus their contents.

The remaining clone, which stores the entry state in `states_by_block`, corresponds to the clone TS also performs and is left alone. Removing it would require sharing the state rather than copying it.

## How did you test this change?

All 1810 Rust compiler fixtures pass with byte-identical output.

Measured over 232 real `.tsx` files from the Next.js source tree (1.5 MiB), driven through `swc_ecma_react_compiler::transform`, which is the path Turbopack uses. Allocation counts come from a counting global allocator and are exact:

  allocations   7,054,323 -> 6,315,166   (-10.5%)
  churn         1526.99 MiB -> 1438.44 MiB  (-5.8%)

Wall time on the same corpus moved about -3%.
