### PR TITLE
oxc port: transform reactive blocks in place

### DIFF
--- a/compiler/crates/react_compiler_reactive_scopes/src/merge_reactive_scopes_that_invalidate_together.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/merge_reactive_scopes_that_invalidate_together.rs
@@ -338,19 +338,20 @@ impl<'a> MergeTransform<'a> {
             return Ok(());
         }
 
-        let mut next_instructions: Vec<ReactiveStatement> = Vec::new();
-        let mut index = 0;
         let all_stmts: Vec<ReactiveStatement> = std::mem::take(block);
+        let mut next_instructions: Vec<ReactiveStatement> = Vec::with_capacity(all_stmts.len());
+        let mut stmts = all_stmts.into_iter();
+        let mut index = 0;
 
         for entry in &merged {
             // Push everything before the merge range
             while index < entry.from {
-                next_instructions.push(all_stmts[index].clone());
+                next_instructions.push(stmts.next().unwrap());
                 index += 1;
             }
             // The first item in the merge range must be a scope
-            let mut merged_scope = match &all_stmts[entry.from] {
-                ReactiveStatement::Scope(s) => s.clone(),
+            let mut merged_scope = match stmts.next().unwrap() {
+                ReactiveStatement::Scope(scope) => scope,
                 _ => {
                     return Err(react_compiler_diagnostics::CompilerDiagnostic::new(
                         react_compiler_diagnostics::ErrorCategory::Invariant,
@@ -362,29 +363,25 @@ impl<'a> MergeTransform<'a> {
             };
             index += 1;
             while index < entry.to {
-                let stmt = &all_stmts[index];
+                let stmt = stmts.next().unwrap();
                 index += 1;
                 match stmt {
                     ReactiveStatement::Scope(inner_scope) => {
-                        merged_scope
-                            .instructions
-                            .extend(inner_scope.instructions.clone());
+                        let inner_scope_id = inner_scope.scope;
+                        merged_scope.instructions.extend(inner_scope.instructions);
                         self.env.scopes[merged_scope.scope.0 as usize]
                             .merged
-                            .push(inner_scope.scope);
+                            .push(inner_scope_id);
                     }
-                    _ => {
-                        merged_scope.instructions.push(stmt.clone());
+                    stmt => {
+                        merged_scope.instructions.push(stmt);
                     }
                 }
             }
             next_instructions.push(ReactiveStatement::Scope(merged_scope));
         }
         // Push remaining
-        while index < all_stmts.len() {
-            next_instructions.push(all_stmts[index].clone());
-            index += 1;
-        }
+        next_instructions.extend(stmts);
 
         *block = next_instructions;
         Ok(())

--- a/compiler/crates/react_compiler_reactive_scopes/src/visitors.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/visitors.rs
@@ -735,70 +735,55 @@ pub trait ReactiveFunctionTransform {
         Ok(Transformed::Keep)
     }
 
+    fn transform_statement(
+        &mut self,
+        statement: &mut ReactiveStatement,
+        state: &mut Self::State,
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
+        match statement {
+            ReactiveStatement::Instruction(instruction) => {
+                self.transform_instruction(instruction, state)
+            }
+            ReactiveStatement::Scope(scope) => self.transform_scope(scope, state),
+            ReactiveStatement::PrunedScope(scope) => self.transform_pruned_scope(scope, state),
+            ReactiveStatement::Terminal(terminal) => self.transform_terminal(terminal, state),
+        }
+    }
+
     fn traverse_block(
         &mut self,
         block: &mut ReactiveBlock,
         state: &mut Self::State,
     ) -> Result<(), CompilerError> {
-        let mut next_block: Option<Vec<ReactiveStatement>> = None;
-        let len = block.len();
-        for i in 0..len {
-            // Take the statement out temporarily
-            let mut stmt = std::mem::replace(
-                &mut block[i],
-                // Placeholder — will be overwritten or discarded
-                ReactiveStatement::Instruction(ReactiveInstruction {
-                    id: EvaluationOrder(0),
-                    lvalue: None,
-                    value: ReactiveValue::Instruction(
-                        react_compiler_hir::InstructionValue::Debugger { loc: None },
-                    ),
-                    effects: None,
-                    loc: None,
-                }),
-            );
-            let transformed = match &mut stmt {
-                ReactiveStatement::Instruction(instr) => {
-                    self.transform_instruction(instr, state)?
-                }
-                ReactiveStatement::Scope(scope) => self.transform_scope(scope, state)?,
-                ReactiveStatement::PrunedScope(scope) => {
-                    self.transform_pruned_scope(scope, state)?
-                }
-                ReactiveStatement::Terminal(terminal) => {
-                    self.transform_terminal(terminal, state)?
-                }
+        let mut index = 0;
+        let first_change = loop {
+            let Some(statement) = block.get_mut(index) else {
+                return Ok(());
             };
-            match transformed {
-                Transformed::Keep => {
-                    if let Some(ref mut nb) = next_block {
-                        nb.push(stmt);
-                    } else {
-                        // Put it back
-                        block[i] = stmt;
-                    }
-                }
-                Transformed::Remove => {
-                    if next_block.is_none() {
-                        next_block = Some(block[..i].to_vec());
-                    }
-                }
+            match self.transform_statement(statement, state)? {
+                Transformed::Keep => index += 1,
                 Transformed::Replace(replacement) => {
-                    if next_block.is_none() {
-                        next_block = Some(block[..i].to_vec());
-                    }
-                    next_block.as_mut().unwrap().push(replacement);
+                    block[index] = replacement;
+                    index += 1;
                 }
-                Transformed::ReplaceMany(replacements) => {
-                    if next_block.is_none() {
-                        next_block = Some(block[..i].to_vec());
-                    }
-                    next_block.as_mut().unwrap().extend(replacements);
-                }
+                change => break change,
             }
+        };
+
+        let mut tail = block.split_off(index).into_iter();
+        tail.next();
+        match first_change {
+            Transformed::Remove => {}
+            Transformed::ReplaceMany(replacements) => block.extend(replacements),
+            Transformed::Keep | Transformed::Replace(_) => unreachable!(),
         }
-        if let Some(nb) = next_block {
-            *block = nb;
+        for mut statement in tail {
+            match self.transform_statement(&mut statement, state)? {
+                Transformed::Keep => block.push(statement),
+                Transformed::Remove => {}
+                Transformed::Replace(replacement) => block.push(replacement),
+                Transformed::ReplaceMany(replacements) => block.extend(replacements),
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Port Oxc's in-place reactive-block transformation to React's Rust compiler.

- Transform one-for-one statement replacements directly in the existing block.
- Allocate a replacement vector only after the first length-changing transformation.
- Move statements and nested scope instructions while merging invalidation scopes instead of cloning them.

Ported from oxc-project/oxc commit `3fe5c87` by Cameron <cameron.clark@hey.com>:
https://github.com/oxc-project/oxc/commit/3fe5c87bbd926b060be134e0f1d233ad5b8b793c

Original Oxc author: @Boshen.

Criterion full-corpus benchmark (1,809 fixtures, 50 samples, compared with saved main baseline):
- Time: first settled comparison showed no change (`+0.05%`, 95% CI `-0.87%` to `+1.04%`, p=0.93). A repeat measured `+2.06%`, but Criterion classified it within the configured noise threshold. No reliable timing improvement detected.
- Peak RSS: saved main mean 198.4 MiB; this PR mean 191.5 MiB; change `-3.48%`. This PR sample range: 189.1-194.4 MiB.

Benchmark implementation: https://github.com/react/react/pull/37485

Validation:
- `cargo test -p react_compiler_reactive_scopes`
- `cargo fmt --manifest-path compiler/Cargo.toml --all --check`
- `cargo check --manifest-path compiler/Cargo.toml --workspace --all-targets`
- `cd compiler && yarn snap --rust` (1,810 passed)
- `git diff --check`