### PR TITLE
[flags] Enable conditional `use()` warning in React's Canary builds

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -160,7 +160,7 @@ export const enableInfiniteRenderLoopDetection: boolean = false;
  */
 export const enableInfiniteRenderLoopDetectionForceThrow: boolean = false;
 
-export const enableConditionalUseWarning: boolean = __EXPERIMENTAL__;
+export const enableConditionalUseWarning: boolean = true;
 
 export const enableFragmentRefs: boolean = true;
 export const enableFragmentRefsScrollIntoView: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -55,7 +55,7 @@ export const disableClientCache: boolean = true;
 
 export const enableInfiniteRenderLoopDetection: boolean = false;
 export const enableInfiniteRenderLoopDetectionForceThrow: boolean = false;
-export const enableConditionalUseWarning: boolean = __EXPERIMENTAL__;
+export const enableConditionalUseWarning: boolean = true;
 
 export const enableEffectEventMutationPhase: boolean = true;
 


### PR DESCRIPTION
The warning was previously only enabled for experimental builds (`react@experimental`). This enables the warning for `react@canary` as well.

Keep in mind that conditional `use()` is generally supported. This warning only triggers if the condition is based on `promise.status` (or `promise.value`). Let `use()` handle that status. React will not suspend if the `promise.status` is already `'fulfilled'`.

More information can be found in the [`use()` docs under "Don’t skip calling use based on whether a Promise is already settled."](https://react.dev/reference/react/use#conditional-use).

We've tested this at Vercel on the latest version of SWR (which previously had conditional `use()` calls) and found no false-positive warnings or excessive warnings. 