### PR TITLE
[compiler] Support destructured defaults under Babel 8

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -4220,7 +4220,13 @@ function lowerAssignment(
             continue;
           }
           const element = property.get('value');
-          if (!element.isLVal()) {
+          /*
+           * Babel 8 removed AssignmentPattern from the LVal alias. In pattern
+           * position the value of `{a = 1}` is an AssignmentPattern, which
+           * isLVal() accepts under Babel 7 and rejects under 8; the recursive
+           * call below dispatches on it either way.
+           */
+          if (!(element.isLVal() || element.isAssignmentPattern())) {
             builder.recordError(
               new CompilerErrorDetail({
                 reason: `(BuildHIR::lowerAssignment) Expected object property value to be an LVal, got: ${element.type}`,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/FindContextIdentifiers.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/FindContextIdentifiers.ts
@@ -181,10 +181,17 @@ function handleAssignment(
       for (const property of path.get('properties')) {
         if (property.isObjectProperty()) {
           const valuePath = property.get('value');
-          CompilerError.invariant(valuePath.isLVal(), {
-            reason: `[FindContextIdentifiers] Expected object property value to be an LVal, got: ${valuePath.type}`,
-            loc: valuePath.node.loc ?? GeneratedSource,
-          });
+          /*
+           * Babel 8 removed AssignmentPattern from the LVal alias; Babel 7's
+           * still includes it, so this check reads as redundant until the bump.
+           */
+          CompilerError.invariant(
+            valuePath.isLVal() || valuePath.isAssignmentPattern(),
+            {
+              reason: `[FindContextIdentifiers] Expected object property value to be an LVal, got: ${valuePath.type}`,
+              loc: valuePath.node.loc ?? GeneratedSource,
+            },
+          );
           handleAssignment(currentFn, identifiers, valuePath);
         } else {
           CompilerError.invariant(property.isRestElement(), {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/babel8LValAlias-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/babel8LValAlias-test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {createRequire} from 'module';
+import type {NodePath as BabelNodePath} from '@babel/traverse';
+import {runBabelPluginReactCompiler} from '../Babel/RunReactCompilerBabelPlugin';
+
+/*
+ * Resolve @babel/traverse from @babel/core's module context so that the patched
+ * NodePath is the implementation transformFromAstSync actually traverses with.
+ */
+const requireFromBabelCore = createRequire(require.resolve('@babel/core'));
+const {NodePath}: typeof import('@babel/traverse') =
+  requireFromBabelCore('@babel/traverse');
+
+/**
+ * Babel 8 removed AssignmentPattern and RestElement from the LVal alias. This
+ * repo pins Babel 7, whose LVal still contains both, so removing those types
+ * from isLVal() for the duration of a call exercises the Babel 8 contract
+ * without adding a second Babel version to the dependency tree.
+ */
+function withoutLValTypes<T>(types: Array<string>, fn: () => T): T {
+  const real = NodePath.prototype.isLVal;
+  NodePath.prototype.isLVal = function (
+    this: BabelNodePath,
+    ...args: Parameters<typeof real>
+  ): boolean {
+    if (this.node != null && types.includes(this.node.type)) {
+      return false;
+    }
+    return real.apply(this, args);
+  } as typeof real;
+  try {
+    return fn();
+  } finally {
+    NodePath.prototype.isLVal = real;
+  }
+}
+
+const REMOVED_FROM_LVAL_IN_BABEL_8 = ['AssignmentPattern', 'RestElement'];
+
+function compile(source: string): string {
+  const result = runBabelPluginReactCompiler(source, 'test.js', 'flow', {
+    compilationMode: 'all',
+    panicThreshold: 'all_errors',
+  });
+  return result.code!;
+}
+
+const cases: Array<[string, string]> = [
+  [
+    'parameter default',
+    'function Component({a = 1}) { return <div>{a}</div>; }',
+  ],
+  [
+    'renamed parameter default',
+    'function Component({a: b = 1}) { return <div>{b}</div>; }',
+  ],
+  [
+    'nested parameter default',
+    'function Component({a: {b = 1}}) { return <div>{b}</div>; }',
+  ],
+  [
+    'default alongside rest',
+    'function Component({a = 1, ...rest}) { return <div>{a}{rest.x}</div>; }',
+  ],
+  [
+    'variable destructuring default',
+    'function Component(props) { const {a = 1} = props; return <div>{a}</div>; }',
+  ],
+  [
+    'destructuring assignment default',
+    'function Component(props) { let a; ({a = 1} = props); return <div>{a}</div>; }',
+  ],
+  [
+    'destructuring without a default',
+    'function Component({a}) { return <div>{a}</div>; }',
+  ],
+];
+
+describe('Babel 8 LVal alias', () => {
+  /*
+   * Guards the cases below against passing vacuously: if the patched prototype
+   * is not the one the plugin traverses with, narrowing Identifier - which
+   * lowerAssignment reaches through the same isLVal() check - has no effect
+   * and this test fails.
+   */
+  it('reaches the NodePath instances the compiler traverses', () => {
+    const source = 'function Component({a}) { return <div>{a}</div>; }';
+    expect(() => compile(source)).not.toThrow();
+    expect(() =>
+      withoutLValTypes(['Identifier'], () => compile(source)),
+    ).toThrow();
+  });
+
+  it.each(cases)('compiles %s', (_name, source) => {
+    expect(
+      withoutLValTypes(REMOVED_FROM_LVAL_IN_BABEL_8, () => compile(source)),
+    ).toContain('_c(');
+  });
+
+  it.each(cases)('emits identical output for %s', (_name, source) => {
+    expect(
+      withoutLValTypes(REMOVED_FROM_LVAL_IN_BABEL_8, () => compile(source)),
+    ).toEqual(compile(source));
+  });
+});


### PR DESCRIPTION
## Summary

Under `@babel/core@8`, React Compiler can silently skip code using object destructuring defaults such as:

```js
function C({a = 1}) {}
const {a = 1} = props;
```

Babel 8 removed `AssignmentPattern` from the `LVal` alias, so two existing `isLVal()` guards reject this syntax even though both paths already handle `AssignmentPattern` downstream.

This changes those guards to accept it explicitly:

```js
isLVal() || isAssignmentPattern()
```

## Relationship to #36956

#36956 fixes the same issue with `isLVal() || isPatternLike()`.

This patch keeps the check narrower. `RestElement` is already handled separately at both sites, and `PatternLike` also includes nodes these paths do not handle, such as `VoidPattern`.

The regression test's `createRequire(require.resolve('@babel/core'))` setup is adapted from #36956.

## Testing

Added a Babel 8 compatibility test that temporarily removes `AssignmentPattern` and `RestElement` from `isLVal()` and covers parameter, variable, nested, rest, and assignment destructuring cases.

It also includes a control that removes `Identifier` from `isLVal()` to verify the test is patching the `NodePath` implementation actually used by Babel core.

Full compiler tests, Jest, lint, snapshots, and Prettier pass.

Fixes #36868
Fixes #37406
