### PR TITLE
oxc port: [correctness] support for loops without test expressions

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -3386,15 +3386,7 @@ fn lower_statement(
                     continuation_block,
                 );
             } else {
-                builder.record_error(CompilerErrorDetail {
-                    category: ErrorCategory::Todo,
-                    reason: "(BuildHIR::lowerStatement) Handle empty test in ForStatement"
-                        .to_string(),
-                    description: None,
-                    loc: loc.clone(),
-                    suggestions: None,
-                })?;
-                // Treat `for(;;)` as `while(true)` to keep the builder state consistent
+                // Treat `for(;;)` as `while(true)`.
                 let true_val = InstructionValue::Primitive {
                     value: PrimitiveValue::Boolean(true),
                     loc: loc.clone(),

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -1580,6 +1580,20 @@ fn codegen_for_init(
     init: &ReactiveValue,
 ) -> Result<Option<ForInit>, CompilerError> {
     if let ReactiveValue::SequenceExpression { instructions, .. } = init {
+        // An omitted initializer is represented by a synthetic `undefined`
+        // instruction so the HIR block is not empty.
+        if instructions.len() == 1
+            && matches!(
+                &instructions[0].value,
+                ReactiveValue::Instruction(InstructionValue::Primitive {
+                    value: PrimitiveValue::Undefined,
+                    ..
+                })
+            )
+        {
+            return Ok(None);
+        }
+
         let block_items: Vec<ReactiveStatement> = instructions
             .iter()
             .map(|i| ReactiveStatement::Instruction(i.clone()))

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -660,15 +660,7 @@ function lowerStatement(
 
       const test = stmt.get('test');
       if (test.node == null) {
-        builder.recordError(
-          new CompilerErrorDetail({
-            reason: `(BuildHIR::lowerStatement) Handle empty test in ForStatement`,
-            category: ErrorCategory.Todo,
-            loc: stmt.node.loc ?? null,
-            suggestions: null,
-          }),
-        );
-        // Treat `for(;;)` as `while(true)` to keep the builder state consistent
+        // Treat `for(;;)` as `while(true)`.
         builder.terminateWithContinuation(
           {
             kind: 'branch',

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -1196,6 +1196,18 @@ function codegenForInit(
   init: ReactiveValue,
 ): t.Expression | t.VariableDeclaration | null {
   if (init.kind === 'SequenceExpression') {
+    /*
+     * An omitted initializer is represented by a synthetic `undefined`
+     * instruction so the HIR block is not empty.
+     */
+    if (
+      init.instructions.length === 1 &&
+      init.instructions[0].value.kind === 'Primitive' &&
+      init.instructions[0].value.value === undefined
+    ) {
+      return null;
+    }
+
     const body = codegenBlock(
       cx,
       init.instructions.map(instruction => ({

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-kitchensink.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-kitchensink.expect.md
@@ -79,24 +79,141 @@ let moduleLocal = false;
 ## Error
 
 ```
-Found 1 error:
+Found 10 errors:
 
-Invariant: Expected a variable declaration
+Todo: (BuildHIR::lowerStatement) Handle var kinds in VariableDeclaration
 
-Got ExpressionStatement.
+error.todo-kitchensink.ts:3:2
+  1 | function foo([a, b], {c, d, e = 'e'}, f = 'f', ...args) {
+  2 |   let i = 0;
+> 3 |   var x = [];
+    |   ^^^^^^^^^^^ (BuildHIR::lowerStatement) Handle var kinds in VariableDeclaration
+  4 |
+  5 |   class Bar {
+  6 |     #secretSauce = 42;
 
-error.todo-kitchensink.ts:20:2
-  18 |   const j = function bar([quz, qux], ...args) {};
-  19 |
-> 20 |   for (; i < 3; i += 1) {
-     |   ^^^^^^^^^^^^^^^^^^^^^^^
-> 21 |     x.push(i);
-     | ^^^^^^^^^^^^^^
-> 22 |   }
-     | ^^^^ Expected a variable declaration
-  23 |   for (; i < 3; ) {
-  24 |     break;
-  25 |   }
+Compilation Skipped: Inline `class` declarations are not supported
+
+Move class declarations outside of components/hooks.
+
+error.todo-kitchensink.ts:5:2
+   3 |   var x = [];
+   4 |
+>  5 |   class Bar {
+     |   ^^^^^^^^^^^
+>  6 |     #secretSauce = 42;
+     | ^^^^^^^^^^^^^^^^^^^^^^
+>  7 |     constructor() {
+     | ^^^^^^^^^^^^^^^^^^^^^^
+>  8 |       console.log(this.#secretSauce);
+     | ^^^^^^^^^^^^^^^^^^^^^^
+>  9 |     }
+     | ^^^^^^^^^^^^^^^^^^^^^^
+> 10 |   }
+     | ^^^^ Inline `class` declarations are not supported
+  11 |
+  12 |   const g = {b() {}, c: () => {}};
+  13 |   const {z, aa = 'aa'} = useCustom();
+
+Todo: (BuildHIR::lowerExpression) Handle tagged template with interpolations
+
+error.todo-kitchensink.ts:30:2
+  28 |   }
+  29 |
+> 30 |   graphql`
+     |   ^^^^^^^^
+> 31 |     ${g}
+     | ^^^^^^^^
+> 32 |   `;
+     | ^^^^ (BuildHIR::lowerExpression) Handle tagged template with interpolations
+  33 |
+  34 |   graphql`\\t\n`;
+  35 |
+
+Todo: (BuildHIR::lowerExpression) Handle tagged template where cooked value is different from raw value
+
+error.todo-kitchensink.ts:34:2
+  32 |   `;
+  33 |
+> 34 |   graphql`\\t\n`;
+     |   ^^^^^^^^^^^^^^ (BuildHIR::lowerExpression) Handle tagged template where cooked value is different from raw value
+  35 |
+  36 |   for (c of [1, 2]) {
+  37 |   }
+
+Todo: (BuildHIR::node.lowerReorderableExpression) Expression type `MemberExpression` cannot be safely reordered
+
+error.todo-kitchensink.ts:57:9
+  55 |     case foo(): {
+  56 |     }
+> 57 |     case x.y: {
+     |          ^^^ (BuildHIR::node.lowerReorderableExpression) Expression type `MemberExpression` cannot be safely reordered
+  58 |     }
+  59 |     default: {
+  60 |     }
+
+Todo: (BuildHIR::node.lowerReorderableExpression) Expression type `BinaryExpression` cannot be safely reordered
+
+error.todo-kitchensink.ts:53:9
+  51 |
+  52 |   switch (i) {
+> 53 |     case 1 + 1: {
+     |          ^^^^^ (BuildHIR::node.lowerReorderableExpression) Expression type `BinaryExpression` cannot be safely reordered
+  54 |     }
+  55 |     case foo(): {
+  56 |     }
+
+Error: Cannot reassign variables declared outside of the component/hook
+
+Variable `v` is declared outside of the component/hook. Reassigning this value during render is a form of side effect, which can cause unpredictable behavior depending on when the component happens to re-render. If this variable is used in rendering, use useState instead. Otherwise, consider updating it in an effect. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render).
+
+error.todo-kitchensink.ts:38:8
+  36 |   for (c of [1, 2]) {
+  37 |   }
+> 38 |   for ([v] of [[1], [2]]) {
+     |         ^ `v` cannot be reassigned
+  39 |   }
+  40 |   for ({v} of [{v: 1}, {v: 2}]) {
+  41 |   }
+
+Error: Cannot reassign variables declared outside of the component/hook
+
+Variable `v` is declared outside of the component/hook. Reassigning this value during render is a form of side effect, which can cause unpredictable behavior depending on when the component happens to re-render. If this variable is used in rendering, use useState instead. Otherwise, consider updating it in an effect. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render).
+
+error.todo-kitchensink.ts:40:8
+  38 |   for ([v] of [[1], [2]]) {
+  39 |   }
+> 40 |   for ({v} of [{v: 1}, {v: 2}]) {
+     |         ^ `v` cannot be reassigned
+  41 |   }
+  42 |
+  43 |   for (let x in {a: 1}) {
+
+Todo: Support non-trivial for..of inits
+
+error.todo-kitchensink.ts:38:2
+  36 |   for (c of [1, 2]) {
+  37 |   }
+> 38 |   for ([v] of [[1], [2]]) {
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^
+> 39 |   }
+     | ^^^^ Support non-trivial for..of inits
+  40 |   for ({v} of [{v: 1}, {v: 2}]) {
+  41 |   }
+  42 |
+
+Todo: Support non-trivial for..of inits
+
+error.todo-kitchensink.ts:40:2
+  38 |   for ([v] of [[1], [2]]) {
+  39 |   }
+> 40 |   for ({v} of [{v: 1}, {v: 2}]) {
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+> 41 |   }
+     | ^^^^ Support non-trivial for..of inits
+  42 |
+  43 |   for (let x in {a: 1}) {
+  44 |   }
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-empty-test.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-empty-test.expect.md
@@ -1,0 +1,62 @@
+
+## Input
+
+```javascript
+function Component(props) {
+  let index = 0;
+  let total = 0;
+
+  for (;;) {
+    index++;
+    if (index < props.start) {
+      continue;
+    }
+    total += index;
+    if (index >= props.end) {
+      break;
+    }
+  }
+
+  return total;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{start: 2, end: 4}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+function Component(props) {
+  let index = 0;
+  let total = 0;
+
+  for (; true; ) {
+    index++;
+    if (index < props.start) {
+      continue;
+    }
+
+    total = total + index;
+    if (index >= props.end) {
+      break;
+    }
+  }
+
+  return total;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ start: 2, end: 4 }],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) 9

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-empty-test.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/for-empty-test.js
@@ -1,0 +1,23 @@
+function Component(props) {
+  let index = 0;
+  let total = 0;
+
+  for (;;) {
+    index++;
+    if (index < props.start) {
+      continue;
+    }
+    total += index;
+    if (index >= props.end) {
+      break;
+    }
+  }
+
+  return total;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{start: 2, end: 4}],
+  isComponent: true,
+};


### PR DESCRIPTION
## Summary

- lower omitted `for` tests as the existing synthetic `true` condition without bailing out
- omit the synthetic `undefined` initializer during TypeScript and Rust codegen
- add shared runtime coverage for omitted initializer, test, and update with `continue` and `break`

Ported from oxc-project/oxc@b1201f1c8f509abd4667ef86a0caf3678a4f8a46 by @Boshen.

## Benchmark

Criterion full-corpus benchmark using the two commits from #37485 cherry-picked with `--no-commit` onto both revisions. Both runs used 20 peak-RSS samples and the same Criterion invocation (`--sample-size 20 --warm-up-time 2 --measurement-time 10 --noplot`). The benchmark currently collects 50 timing samples despite the requested sample-size argument.

| Revision | Fixtures | Source bytes | Time | Throughput | Peak RSS mean | Peak RSS median | Peak RSS 95% sample range |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Main base (`f4e439e198`) | 1809 | 755,335 | 478.93-482.73 ms (480.66 ms estimate) | 1.4922-1.5041 MiB/s | 191.0 MiB | 191.4 MiB | 188.6-193.7 MiB |
| PR head (`ee6201e130`) | 1810 | 755,679 | 480.95-487.49 ms (483.75 ms estimate) | 1.4783-1.4984 MiB/s | 190.4 MiB | 190.5 MiB | 187.6-192.6 MiB |

Relative to its exact main base, the PR timing estimate is 0.64% slower and mean peak RSS is 0.31% lower. The PR corpus includes the new fixture, adding one fixture and 344 source bytes. Criterion classified the timing change as within its noise threshold. Correctness does not depend on a performance improvement.

## Test Plan

- `cd compiler && yarn snap -p for-empty-test`
- `cd compiler && yarn snap --rust -p for-empty-test`
- `cd compiler && yarn snap -p error.todo-kitchensink`
- `cd compiler && yarn snap --rust`
- `cd compiler && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd compiler && cargo check --manifest-path Cargo.toml --workspace --all-targets`
- `cd compiler && ./scripts/test-babel-ast.sh`

