### PR TITLE
oxc port: support computed string destructuring keys

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -4957,7 +4957,12 @@ fn lower_assignment(
                     react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(
                         obj_prop,
                     ) => {
-                        if obj_prop.computed {
+                        if obj_prop.computed
+                            && !matches!(
+                                &*obj_prop.key,
+                                react_compiler_ast::expressions::Expression::StringLiteral(_)
+                            )
+                        {
                             builder.record_error(CompilerErrorDetail {
                                 reason: "(BuildHIR::lowerAssignment) Handle computed properties in ObjectPattern".to_string(),
                                 category: ErrorCategory::Todo,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -4204,7 +4204,10 @@ function lowerAssignment(
             );
             continue;
           }
-          if (property.node.computed) {
+          if (
+            property.node.computed &&
+            !property.get('key').isStringLiteral()
+          ) {
             builder.recordError(
               new CompilerErrorDetail({
                 reason: `(BuildHIR::lowerAssignment) Handle computed properties in ObjectPattern`,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-computed-string-literal-property-key.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-computed-string-literal-property-key.expect.md
@@ -1,0 +1,97 @@
+
+## Input
+
+```javascript
+function readParameter({['parameter-key']: parameter}) {
+  return parameter;
+}
+
+function Component(props) {
+  const {['declaration-key']: declared} = props;
+  const {
+    nested: {['nested-key']: nested},
+  } = props;
+  let reassigned;
+  ({['assignment-key']: reassigned} = props);
+
+  return [declared, reassigned, readParameter(props), nested];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [
+    {
+      'declaration-key': 1,
+      'assignment-key': 2,
+      'parameter-key': 3,
+      nested: {'nested-key': 4},
+    },
+  ],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function readParameter(t0) {
+  const { "parameter-key": parameter } = t0;
+  return parameter;
+}
+
+function Component(props) {
+  const $ = _c(7);
+  const { "declaration-key": declared } = props;
+  const { nested: t0 } = props;
+  const { "nested-key": nested } = t0;
+  let reassigned;
+  ({ "assignment-key": reassigned } = props);
+
+  const t1 = reassigned;
+  let t2;
+  if ($[0] !== props) {
+    t2 = readParameter(props);
+    $[0] = props;
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  let t3;
+  if (
+    $[2] !== declared ||
+    $[3] !== nested ||
+    $[4] !== reassigned ||
+    $[5] !== t2
+  ) {
+    t3 = [declared, t1, t2, nested];
+    $[2] = declared;
+    $[3] = nested;
+    $[4] = reassigned;
+    $[5] = t2;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [
+    {
+      "declaration-key": 1,
+      "assignment-key": 2,
+      "parameter-key": 3,
+      nested: { "nested-key": 4 },
+    },
+  ],
+
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) [1,2,3,4]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-computed-string-literal-property-key.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-computed-string-literal-property-key.js
@@ -1,0 +1,27 @@
+function readParameter({['parameter-key']: parameter}) {
+  return parameter;
+}
+
+function Component(props) {
+  const {['declaration-key']: declared} = props;
+  const {
+    nested: {['nested-key']: nested},
+  } = props;
+  let reassigned;
+  ({['assignment-key']: reassigned} = props);
+
+  return [declared, reassigned, readParameter(props), nested];
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [
+    {
+      'declaration-key': 1,
+      'assignment-key': 2,
+      'parameter-key': 3,
+      nested: {'nested-key': 4},
+    },
+  ],
+  isComponent: true,
+};


### PR DESCRIPTION
## Summary

- accept computed string literals as static object-pattern keys in TypeScript and Rust lowering
- preserve the existing bailout for dynamic computed keys
- cover declarations, assignments, parameters, and nested patterns in a shared runtime fixture

Ported from oxc-project/oxc@d5140f192ea3836d401b959f81e3e723c14b809c by @Boshen.

## Benchmark

Criterion full-corpus benchmark using the two commits from #37485 cherry-picked with `--no-commit` onto both revisions. Both runs used 20 peak-RSS samples and the same Criterion invocation (`--sample-size 20 --warm-up-time 2 --measurement-time 10 --noplot`). The benchmark collected 50 timing samples.

| Revision | Fixtures | Source bytes | Time | Throughput | Peak RSS mean | Peak RSS median | Peak RSS 95% sample range |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Main base (`f4e439e198`) | 1809 | 755,335 | 480.68-486.60 ms (483.17 ms estimate) | 1.4804-1.4986 MiB/s | 191.8 MiB | 191.9 MiB | 190.8-192.9 MiB |
| PR head (`97d3a56962`) | 1810 | 755,905 | 482.06-488.89 ms (484.88 ms estimate) | 1.4745-1.4954 MiB/s | 191.2 MiB | 191.4 MiB | 187.2-195.0 MiB |

Criterion measured a +0.23% timing estimate with a 95% confidence interval of -0.76% to +1.25% (`p = 0.68`, significance threshold `0.05`). The result is not statistically significant, and Criterion detected no performance change. Mean peak RSS was 0.31% lower. The PR corpus includes one new fixture and 570 additional source bytes.

## Test Plan

- `cd compiler && yarn snap -p destructure-computed-string-literal-property-key`
- `cd compiler && yarn snap --rust -p destructure-computed-string-literal-property-key`
- `cd compiler && yarn snap -p todo.error.object-pattern-computed-key`
- `cd compiler && yarn snap --rust -p todo.error.object-pattern-computed-key`
- `cd compiler && yarn snap --rust`
- `cd compiler && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd compiler && cargo check --manifest-path Cargo.toml --workspace --all-targets`
- `cd compiler && ./scripts/test-babel-ast.sh`
