### PR TITLE
oxc port: support BigInt object keys

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -6559,6 +6559,9 @@ fn lower_object_property_key(
         Expression::NumericLiteral(lit) if !computed => Ok(Some(ObjectPropertyKey::Identifier {
             name: lit.value.to_string(),
         })),
+        Expression::BigIntLiteral(lit) if !computed => Ok(Some(ObjectPropertyKey::String {
+            name: canonicalize_bigint_property_key(&lit.value),
+        })),
         _ if computed => {
             let place = lower_expression_to_temporary(builder, key)?;
             Ok(Some(ObjectPropertyKey::Computed { name: place }))
@@ -6578,6 +6581,45 @@ fn lower_object_property_key(
             Ok(None)
         }
     }
+}
+
+fn canonicalize_bigint_property_key(value: &str) -> String {
+    let (digits, radix) = if let Some(digits) = value.strip_prefix("0x") {
+        (digits, 16)
+    } else if let Some(digits) = value.strip_prefix("0X") {
+        (digits, 16)
+    } else if let Some(digits) = value.strip_prefix("0o") {
+        (digits, 8)
+    } else if let Some(digits) = value.strip_prefix("0O") {
+        (digits, 8)
+    } else if let Some(digits) = value.strip_prefix("0b") {
+        (digits, 2)
+    } else if let Some(digits) = value.strip_prefix("0B") {
+        (digits, 2)
+    } else {
+        return value.to_string();
+    };
+
+    let mut decimal = vec![0_u8];
+    for digit in digits.bytes() {
+        let digit = (digit as char)
+            .to_digit(radix)
+            .expect("valid BigInt literal") as u8;
+        let mut carry = digit;
+        for decimal_digit in decimal.iter_mut().rev() {
+            let value = *decimal_digit * radix as u8 + carry;
+            *decimal_digit = value % 10;
+            carry = value / 10;
+        }
+        while carry != 0 {
+            decimal.insert(0, carry % 10);
+            carry /= 10;
+        }
+    }
+    decimal
+        .into_iter()
+        .map(|digit| char::from(b'0' + digit))
+        .collect()
 }
 
 fn lower_reorderable_expression(

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -1611,6 +1611,11 @@ function lowerObjectPropertyKey(
       kind: 'identifier',
       name: String(key.node.value),
     };
+  } else if (key.isBigIntLiteral()) {
+    return {
+      kind: 'string',
+      name: BigInt(key.node.value).toString(10),
+    };
   }
 
   builder.recordError(

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bigint-object-keys.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bigint-object-keys.expect.md
@@ -1,0 +1,63 @@
+
+## Input
+
+```javascript
+function Component(value) {
+  return {
+    1n: value,
+    0x10n: value + 1,
+    0o10n: value + 2,
+    0b10n: value + 3,
+    9007199254740993n: value + 4,
+  };
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [1],
+  isComponent: false,
+};
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(value) {
+  const $ = _c(6);
+
+  const t0 = value + 1;
+  const t1 = value + 2;
+  const t2 = value + 3;
+  const t3 = value + 4;
+  let t4;
+  if (
+    $[0] !== t0 ||
+    $[1] !== t1 ||
+    $[2] !== t2 ||
+    $[3] !== t3 ||
+    $[4] !== value
+  ) {
+    t4 = { "1": value, "16": t0, "8": t1, "2": t2, "9007199254740993": t3 };
+    $[0] = t0;
+    $[1] = t1;
+    $[2] = t2;
+    $[3] = t3;
+    $[4] = value;
+    $[5] = t4;
+  } else {
+    t4 = $[5];
+  }
+  return t4;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [1],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) {"1":1,"2":4,"8":3,"16":2,"9007199254740993":5}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bigint-object-keys.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/bigint-object-keys.js
@@ -1,0 +1,15 @@
+function Component(value) {
+  return {
+    1n: value,
+    0x10n: value + 1,
+    0o10n: value + 2,
+    0b10n: value + 3,
+    9007199254740993n: value + 4,
+  };
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [1],
+  isComponent: false,
+};


### PR DESCRIPTION
## Summary

- lower noncomputed BigInt object keys to exact decimal property-name strings in TypeScript and Rust
- preserve alternate-base values without converting through JavaScript `Number` or Rust `f64`
- cover decimal, hexadecimal, octal, binary, and above-`Number.MAX_SAFE_INTEGER` keys in a shared runtime fixture

Ported from oxc-project/oxc@c41d2a569eac7faba8dff7f9a00bf4d90774296d by @Boshen.

## Benchmark

Criterion full-corpus benchmark using the two commits from #37485 cherry-picked with `--no-commit` onto both revisions. Both binaries compiled the same fixed PR-head corpus of 1810 fixtures and 755,589 source bytes. Both runs used the same Criterion invocation (`--sample-size 20 --warm-up-time 2 --measurement-time 10 --noplot`); Criterion collected 50 timing samples. Peak RSS used 20 PR samples. The exact-main control run printed 50 RSS samples because the environment override was omitted for that subprocess measurement.

| Revision | Time | Throughput | Peak RSS mean | Peak RSS median | Peak RSS 95% sample range |
| --- | ---: | ---: | ---: | ---: | ---: |
| Main base (`f4e439e198`) | 515.88-524.45 ms (519.68 ms estimate) | 1.3740-1.3968 MiB/s | 190.8 MiB | 190.6 MiB | 188.7-193.8 MiB |
| PR head (`bdd092807e`) | 513.14-525.71 ms (518.69 ms estimate) | 1.3707-1.4043 MiB/s | 190.6 MiB | 190.2 MiB | 188.5-193.0 MiB |

Criterion measured a -0.19% timing estimate with a 95% confidence interval of -1.59% to +1.19% (`p = 0.80`, significance threshold `0.05`). The result is not statistically significant, and Criterion detected no performance change. Mean peak RSS was 0.10% lower.

## Test Plan

- `cd compiler && yarn snap -p bigint-object-keys`
- `cd compiler && yarn snap --rust -p bigint-object-keys`
- `cd compiler && yarn snap --rust`
- `cd compiler && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd compiler && cargo check --manifest-path Cargo.toml --workspace --all-targets`
- `cd compiler && ./scripts/test-babel-ast.sh`