### PR TITLE
[DevTools] Stop advertising hooks on react_get_component_by_dom_element

### DIFF
--- a/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
+++ b/packages/react-devtools-cdt-mcp/src/DevToolsCdtMcp.js
@@ -118,10 +118,11 @@ const TOOL_DEFINITIONS: Array<ToolDefinition> = [
   {
     name: 'react_get_component_by_dom_element',
     description:
-      'Detailed info for one React DOM component by DOM element reference: ' +
-      '{uid, type, name, key?, props?, hooks?}. The element is an opaque ' +
-      'page-side reference, such as the currently selected Chrome DevTools ' +
-      'element.',
+      'Detailed info for the React host component of a DOM element: ' +
+      '{uid, type, name, key?, props?}. This is the host node (e.g. a ' +
+      'button or div), not the function component that rendered it. The ' +
+      'element is an opaque page-side reference, such as the currently ' +
+      'selected Chrome DevTools element.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
+++ b/packages/react-devtools-cdt-mcp/src/__tests__/DevToolsCdtMcp-test.js
@@ -271,6 +271,9 @@ describe('react-devtools-cdt-mcp', () => {
     expect(getTool('react_get_owner_stack').description).toEqual(
       expect.stringContaining('Owners describe'),
     );
+    expect(
+      getTool('react_get_component_by_dom_element').description,
+    ).not.toContain('hooks');
   });
 
   it('declares JSON-Schema input with required params', () => {


### PR DESCRIPTION
## Summary
- `react_get_component_by_dom_element` returns the host node for a DOM element, which never has hooks.
- Stop advertising `hooks?` in the tool description so agents do not request a field that is never returned.

## Test plan
- [ ] `yarn test --build --project=devtools -r=experimental DevToolsCdtMcp`