### PR TITLE
[DevTools] Prepare react-devtools-cdt-mcp 0.1.0 for npm

### DIFF
--- a/packages/react-devtools-cdt-mcp/package.json
+++ b/packages/react-devtools-cdt-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-devtools-cdt-mcp",
-  "version": "0.0.0",
-  "description": "Integration of React tools with chrome-devtools-mcp",
+  "version": "0.1.0",
+  "description": "Browser library that registers React inspection and profiling tools with chrome-devtools-mcp",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump `react-devtools-cdt-mcp` from the placeholder `0.0.0` to `0.1.0`.
- Describe the package as a browser library that registers React tools with chrome-devtools-mcp.

Stacked on https://github.com/react/react/pull/37503

## Test plan
- [ ] Confirm `packages/react-devtools-cdt-mcp/package.json` is `0.1.0` before publishing.
- [ ] Dry-run the publish workflow after this PR.