### PR TITLE
oxc port: [correctness] preserve caught throw semantics

### DIFF
--- a/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/propagate_scope_dependencies_hir.rs
@@ -1935,6 +1935,25 @@ impl<'a> DependencyCollectionContext<'a> {
         self.visit_dependency(dep, env);
     }
 
+    fn visit_operand_root(&mut self, place: &Place, env: &mut Environment) {
+        let dep = self
+            .temporaries
+            .get(&place.identifier)
+            .map(|dep| ReactiveScopeDependency {
+                identifier: dep.identifier,
+                reactive: dep.reactive,
+                path: vec![],
+                loc: dep.loc,
+            })
+            .unwrap_or_else(|| ReactiveScopeDependency {
+                identifier: place.identifier,
+                reactive: place.reactive,
+                path: vec![],
+                loc: place.loc,
+            });
+        self.visit_dependency(dep, env);
+    }
+
     fn visit_property(
         &mut self,
         object: &Place,
@@ -2048,6 +2067,12 @@ fn visit_inner_function_blocks(
     ctx: &mut DependencyCollectionContext,
     env: &mut Environment,
 ) {
+    let semantic_only_caught_instructions =
+        react_compiler_optimization::find_semantic_only_caught_instructions(
+            &env.functions[func_id.0 as usize],
+            env,
+        );
+
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
     let inner_instrs: Vec<Instruction> = env.functions[func_id.0 as usize].instructions.clone();
@@ -2104,7 +2129,14 @@ fn visit_inner_function_blocks(
                     visit_inner_function_blocks(lowered_func.func, ctx, env);
                 }
                 _ => {
-                    handle_instruction(inner_instr, ctx, env);
+                    handle_instruction(
+                        inner_instr,
+                        semantic_only_caught_instructions
+                            .as_ref()
+                            .is_some_and(|instructions| instructions.contains(&iid)),
+                        ctx,
+                        env,
+                    );
                 }
             }
         }
@@ -2120,6 +2152,7 @@ fn visit_inner_function_blocks(
 
 fn handle_instruction(
     instr: &Instruction,
+    semantic_only_caught_instruction: bool,
     ctx: &mut DependencyCollectionContext,
     env: &mut Environment,
 ) {
@@ -2133,6 +2166,13 @@ fn handle_instruction(
         },
         env,
     );
+
+    if semantic_only_caught_instruction {
+        for operand in visitors::each_instruction_value_operand(&instr.value, env) {
+            ctx.visit_operand_root(&operand, env);
+        }
+        return;
+    }
 
     if ctx.is_deferred_dependency_instr(instr) {
         return;
@@ -2280,6 +2320,8 @@ fn handle_function_deps(
     ctx: &mut DependencyCollectionContext,
     traversal: &mut ScopeBlockTraversal,
 ) {
+    let semantic_only_caught_instructions =
+        react_compiler_optimization::find_semantic_only_caught_instructions(func, env);
     for (block_id, block) in &func.body.blocks {
         // Record scopes
         traversal.record_scopes(block);
@@ -2331,7 +2373,14 @@ fn handle_function_deps(
                     ctx.inner_fn_context = prev_inner;
                 }
                 _ => {
-                    handle_instruction(instr, ctx, env);
+                    handle_instruction(
+                        instr,
+                        semantic_only_caught_instructions
+                            .as_ref()
+                            .is_some_and(|instructions| instructions.contains(&instr_id)),
+                        ctx,
+                        env,
+                    );
                 }
             }
         }

--- a/compiler/crates/react_compiler_optimization/src/dead_code_elimination.rs
+++ b/compiler/crates/react_compiler_optimization/src/dead_code_elimination.rs
@@ -18,8 +18,10 @@ use react_compiler_hir::object_shape::HookKind;
 use react_compiler_hir::visitors;
 use react_compiler_hir::{
     ArrayPatternElement, BlockId, BlockKind, HirFunction, IdentifierId, InstructionKind,
-    InstructionValue, ObjectPropertyOrSpread, Pattern,
+    InstructionValue, ObjectPropertyOrSpread, Pattern, Terminal,
 };
+
+use crate::prune_maybe_throws::value_may_throw;
 
 /// Implements dead-code elimination, eliminating instructions whose values are unused.
 ///
@@ -28,11 +30,11 @@ use react_compiler_hir::{
 /// Corresponds to TS `deadCodeElimination(fn: HIRFunction): void`.
 pub fn dead_code_elimination(func: &mut HirFunction, env: &Environment) {
     // Phase 1: Find/mark all referenced identifiers
-    let state = find_referenced_identifiers(func, env);
+    let state = find_referenced_identifiers(func, env, true);
 
     // Phase 2: Prune / sweep unreferenced identifiers and instructions
     // Collect instructions to rewrite (two-phase: collect then apply to avoid borrow conflicts)
-    let mut instructions_to_rewrite: Vec<react_compiler_hir::InstructionId> = Vec::new();
+    let mut instructions_to_rewrite: Vec<(react_compiler_hir::InstructionId, bool)> = Vec::new();
 
     for (_block_id, block) in &mut func.body.blocks {
         // Remove unused phi nodes
@@ -51,14 +53,23 @@ pub fn dead_code_elimination(func: &mut HirFunction, env: &Environment) {
         for i in 0..retained_count {
             let is_block_value = block.kind != BlockKind::Block && i == retained_count - 1;
             if !is_block_value {
-                instructions_to_rewrite.push(block.instructions[i]);
+                let instr_id = block.instructions[i];
+                let preserve_caught_value =
+                    matches!(
+                        block.terminal,
+                        Terminal::MaybeThrow {
+                            handler: Some(_),
+                            ..
+                        }
+                    ) && value_may_throw(&func.instructions[instr_id.0 as usize].value);
+                instructions_to_rewrite.push((instr_id, preserve_caught_value));
             }
         }
     }
 
     // Apply rewrites
-    for instr_id in instructions_to_rewrite {
-        rewrite_instruction(func, instr_id, &state, env);
+    for (instr_id, preserve_caught_value) in instructions_to_rewrite {
+        rewrite_instruction(func, instr_id, preserve_caught_value, &state, env);
     }
 
     // Remove unused context variables
@@ -124,7 +135,11 @@ fn is_id_used(state: &State, identifier_id: IdentifierId) -> bool {
 }
 
 /// Phase 1: Find all referenced identifiers via fixed-point iteration.
-fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
+fn find_referenced_identifiers(
+    func: &HirFunction,
+    env: &Environment,
+    preserve_caught_throws: bool,
+) -> State {
     let has_loop = has_back_edge(func);
     // Collect block ids in reverse order (postorder - successors before predecessors)
     let reversed_block_ids: Vec<BlockId> = func.body.blocks.keys().rev().copied().collect();
@@ -158,6 +173,20 @@ fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
                         reference(&mut state, &env.identifiers, place.identifier);
                     }
                 } else if is_id_or_name_used(&state, &env.identifiers, instr.lvalue.identifier)
+                    || (preserve_caught_throws
+                        && matches!(
+                            block.terminal,
+                            Terminal::MaybeThrow {
+                                handler: Some(_),
+                                ..
+                            }
+                        )
+                        && value_may_throw(&instr.value)
+                        && !matches!(
+                            &instr.value,
+                            InstructionValue::StoreLocal { lvalue, .. }
+                                if !is_id_used(&state, lvalue.place.identifier)
+                        ))
                     || !pruneable_value(&instr.value, &state, env)
                 {
                     reference(&mut state, &env.identifiers, instr.lvalue.identifier);
@@ -167,6 +196,15 @@ fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
                         // only if the SSA'd lval is also referenced
                         if lvalue.kind == InstructionKind::Reassign
                             || is_id_used(&state, lvalue.place.identifier)
+                            || (preserve_caught_throws
+                                && matches!(
+                                    block.terminal,
+                                    Terminal::MaybeThrow {
+                                        handler: Some(_),
+                                        ..
+                                    }
+                                )
+                                && value_may_throw(&instr.value))
                         {
                             reference(&mut state, &env.identifiers, value.identifier);
                         }
@@ -196,17 +234,57 @@ fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
     state
 }
 
+pub fn find_semantic_only_caught_instructions(
+    func: &HirFunction,
+    env: &Environment,
+) -> Option<FxHashSet<react_compiler_hir::InstructionId>> {
+    let mut candidates = Vec::new();
+    for block in func.body.blocks.values() {
+        if !matches!(
+            block.terminal,
+            Terminal::MaybeThrow {
+                handler: Some(_),
+                ..
+            }
+        ) {
+            continue;
+        }
+        for &instr_id in &block.instructions {
+            if value_may_throw(&func.instructions[instr_id.0 as usize].value) {
+                candidates.push(instr_id);
+            }
+        }
+    }
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let state = find_referenced_identifiers(func, env, false);
+    let semantic_only = candidates
+        .into_iter()
+        .filter(|instr_id| {
+            !is_id_or_name_used(
+                &state,
+                &env.identifiers,
+                func.instructions[instr_id.0 as usize].lvalue.identifier,
+            )
+        })
+        .collect();
+    Some(semantic_only)
+}
+
 /// Rewrite a retained instruction (destructuring cleanup, StoreLocal -> DeclareLocal).
 fn rewrite_instruction(
     func: &mut HirFunction,
     instr_id: react_compiler_hir::InstructionId,
+    preserve_caught_value: bool,
     state: &State,
     env: &Environment,
 ) {
     let instr = &mut func.instructions[instr_id.0 as usize];
 
     match &mut instr.value {
-        InstructionValue::Destructure { lvalue, .. } => {
+        InstructionValue::Destructure { lvalue, .. } if !preserve_caught_value => {
             match &mut lvalue.pattern {
                 Pattern::Array(arr) => {
                     // For arrays, replace unused items with holes, truncate trailing holes
@@ -269,6 +347,10 @@ fn rewrite_instruction(
             if lvalue.kind != InstructionKind::Reassign
                 && !is_id_used(state, lvalue.place.identifier)
             {
+                if preserve_caught_value {
+                    lvalue.kind = InstructionKind::Let;
+                    return;
+                }
                 // This is a const/let declaration where the variable is accessed later,
                 // but where the value is always overwritten before being read.
                 // Rewrite to DeclareLocal so the initializer value can be DCE'd.

--- a/compiler/crates/react_compiler_optimization/src/lib.rs
+++ b/compiler/crates/react_compiler_optimization/src/lib.rs
@@ -12,7 +12,7 @@ pub mod prune_maybe_throws;
 pub mod prune_unused_labels_hir;
 
 pub use constant_propagation::constant_propagation;
-pub use dead_code_elimination::dead_code_elimination;
+pub use dead_code_elimination::{dead_code_elimination, find_semantic_only_caught_instructions};
 pub use drop_manual_memoization::drop_manual_memoization;
 pub use inline_iifes::inline_immediately_invoked_function_expressions;
 pub use name_anonymous_functions::name_anonymous_functions;

--- a/compiler/crates/react_compiler_optimization/src/prune_maybe_throws.rs
+++ b/compiler/crates/react_compiler_optimization/src/prune_maybe_throws.rs
@@ -15,7 +15,10 @@ use rustc_hash::FxHashMap;
 use react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, ErrorCategory, GENERATED_SOURCE,
 };
-use react_compiler_hir::{BlockId, HirFunction, Instruction, InstructionValue, Terminal};
+use react_compiler_hir::{
+    ArrayElement, BlockId, HirFunction, InstructionKind, InstructionValue, ObjectPropertyKey,
+    ObjectPropertyOrSpread, Terminal,
+};
 use react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, remove_dead_do_while_statements,
     remove_unnecessary_try_catch, remove_unreachable_for_updates,
@@ -99,7 +102,7 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
         let can_throw = block
             .instructions
             .iter()
-            .any(|instr_id| instruction_may_throw(&instructions[instr_id.0 as usize]));
+            .any(|instr_id| value_may_throw(&instructions[instr_id.0 as usize].value));
 
         if !can_throw {
             let source = terminal_mapping.get(&block.id).copied().unwrap_or(block.id);
@@ -121,11 +124,33 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<FxHashMap<BlockId, 
     }
 }
 
-fn instruction_may_throw(instr: &Instruction) -> bool {
-    match &instr.value {
-        InstructionValue::Primitive { .. }
-        | InstructionValue::ArrayExpression { .. }
-        | InstructionValue::ObjectExpression { .. } => false,
+pub(crate) fn value_may_throw(value: &InstructionValue) -> bool {
+    match value {
+        InstructionValue::DeclareLocal { .. }
+        | InstructionValue::DeclareContext { .. }
+        | InstructionValue::Primitive { .. }
+        | InstructionValue::JSXText { .. }
+        | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::ObjectMethod { .. }
+        | InstructionValue::FunctionExpression { .. }
+        | InstructionValue::RegExpLiteral { .. }
+        | InstructionValue::MetaProperty { .. }
+        | InstructionValue::Debugger { .. }
+        | InstructionValue::StartMemoize { .. }
+        | InstructionValue::FinishMemoize { .. } => false,
+        InstructionValue::StoreLocal { lvalue, .. }
+        | InstructionValue::StoreContext { lvalue, .. } => lvalue.kind != InstructionKind::Reassign,
+        InstructionValue::ArrayExpression { elements, .. } => elements
+            .iter()
+            .any(|element| matches!(element, ArrayElement::Spread(_))),
+        InstructionValue::ObjectExpression { properties, .. } => {
+            properties.iter().any(|property| match property {
+                ObjectPropertyOrSpread::Property(property) => {
+                    matches!(property.key, ObjectPropertyKey::Computed { .. })
+                }
+                ObjectPropertyOrSpread::Spread(_) => true,
+            })
+        }
         _ => true,
     }
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
@@ -49,6 +49,7 @@ import {CompilerError} from '../CompilerError';
 import {Iterable_some} from '../Utils/utils';
 import {ReactiveScopeDependencyTreeHIR} from './DeriveMinimalDependenciesHIR';
 import {collectOptionalChainSidemap} from './CollectOptionalChainDependencies';
+import {findSemanticOnlyCaughtInstructions} from '../Optimization/DeadCodeElimination';
 
 export function propagateScopeDependenciesHIR(fn: HIRFunction): void {
   const usedOutsideDeclaringScope =
@@ -551,6 +552,20 @@ export class DependencyCollectionContext {
     );
   }
 
+  visitOperandRoot(place: Place): void {
+    const dependency = this.#temporaries.get(place.identifier.id);
+    this.visitDependency(
+      dependency === undefined
+        ? {
+            identifier: place.identifier,
+            reactive: place.reactive,
+            path: [],
+            loc: place.loc,
+          }
+        : {...dependency, path: []},
+    );
+  }
+
   visitProperty(
     object: Place,
     property: PropertyLiteral,
@@ -681,12 +696,19 @@ enum HIRValue {
 export function handleInstruction(
   instr: Instruction,
   context: DependencyCollectionContext,
+  semanticOnlyCaughtInstruction: boolean = false,
 ): void {
   const {id, value, lvalue} = instr;
   context.declare(lvalue.identifier, {
     id,
     scope: context.currentScope,
   });
+  if (semanticOnlyCaughtInstruction) {
+    for (const operand of eachInstructionValueOperand(value)) {
+      context.visitOperandRoot(operand);
+    }
+    return;
+  }
   if (
     context.isDeferredDependency({kind: HIRValue.Instruction, value: instr})
   ) {
@@ -787,6 +809,8 @@ function collectDependencies(
   const scopeTraversal = new ScopeBlockTraversal();
 
   const handleFunction = (fn: HIRFunction): void => {
+    const semanticOnlyCaughtInstructions =
+      findSemanticOnlyCaughtInstructions(fn);
     for (const [blockId, block] of fn.body.blocks) {
       scopeTraversal.recordScopes(block);
       const scopeBlockInfo = scopeTraversal.blockInfos.get(blockId);
@@ -826,7 +850,11 @@ function collectDependencies(
             },
           );
         } else {
-          handleInstruction(instr, context);
+          handleInstruction(
+            instr,
+            context,
+            semanticOnlyCaughtInstructions?.has(instr) === true,
+          );
         }
       }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/DeadCodeElimination.ts
@@ -23,6 +23,7 @@ import {
   eachTerminalOperand,
 } from '../HIR/visitors';
 import {assertExhaustive, retainWhere} from '../Utils/utils';
+import {valueMayThrow} from './PruneMaybeThrows';
 
 /*
  * Implements dead-code elimination, eliminating instructions whose values are unused.
@@ -35,7 +36,7 @@ export function deadCodeElimination(fn: HIRFunction): void {
    * Usages may be visited AFTER declarations if there are circular phi / data dependencies
    * between blocks, so we wait to sweep until after fixed point iteration is complete
    */
-  const state = findReferencedIdentifiers(fn);
+  const state = findReferencedIdentifiers(fn, true);
 
   /**
    * Phase 2: Prune / sweep unreferenced identifiers and instructions
@@ -55,7 +56,13 @@ export function deadCodeElimination(fn: HIRFunction): void {
       const isBlockValue =
         block.kind !== 'block' && i === block.instructions.length - 1;
       if (!isBlockValue) {
-        rewriteInstruction(block.instructions[i], state);
+        rewriteInstruction(
+          block.instructions[i],
+          block.terminal.kind === 'maybe-throw' &&
+            block.terminal.handler !== null &&
+            valueMayThrow(block.instructions[i].value),
+          state,
+        );
       }
     }
   }
@@ -111,7 +118,10 @@ class State {
   }
 }
 
-function findReferencedIdentifiers(fn: HIRFunction): State {
+function findReferencedIdentifiers(
+  fn: HIRFunction,
+  preserveCaughtThrows: boolean,
+): State {
   /*
    * If there are no back-edges the algorithm can terminate after a single iteration
    * of the blocks
@@ -150,6 +160,14 @@ function findReferencedIdentifiers(fn: HIRFunction): State {
           }
         } else if (
           state.isIdOrNameUsed(instr.lvalue.identifier) ||
+          (preserveCaughtThrows &&
+            block.terminal.kind === 'maybe-throw' &&
+            block.terminal.handler !== null &&
+            valueMayThrow(instr.value) &&
+            !(
+              instr.value.kind === 'StoreLocal' &&
+              !state.isIdUsed(instr.value.lvalue.place.identifier)
+            )) ||
           !pruneableValue(instr.value, state)
         ) {
           state.reference(instr.lvalue.identifier);
@@ -161,7 +179,11 @@ function findReferencedIdentifiers(fn: HIRFunction): State {
              */
             if (
               instr.value.lvalue.kind === InstructionKind.Reassign ||
-              state.isIdUsed(instr.value.lvalue.place.identifier)
+              state.isIdUsed(instr.value.lvalue.place.identifier) ||
+              (preserveCaughtThrows &&
+                block.terminal.kind === 'maybe-throw' &&
+                block.terminal.handler !== null &&
+                valueMayThrow(instr.value))
             ) {
               state.reference(instr.value.value.identifier);
             }
@@ -184,8 +206,43 @@ function findReferencedIdentifiers(fn: HIRFunction): State {
   return state;
 }
 
-function rewriteInstruction(instr: Instruction, state: State): void {
-  if (instr.value.kind === 'Destructure') {
+export function findSemanticOnlyCaughtInstructions(
+  fn: HIRFunction,
+): Set<Instruction> | null {
+  const candidates: Array<Instruction> = [];
+  for (const [, block] of fn.body.blocks) {
+    if (
+      block.terminal.kind !== 'maybe-throw' ||
+      block.terminal.handler === null
+    ) {
+      continue;
+    }
+    for (const instr of block.instructions) {
+      if (valueMayThrow(instr.value)) {
+        candidates.push(instr);
+      }
+    }
+  }
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const state = findReferencedIdentifiers(fn, false);
+  const semanticOnly = new Set<Instruction>();
+  for (const instr of candidates) {
+    if (!state.isIdOrNameUsed(instr.lvalue.identifier)) {
+      semanticOnly.add(instr);
+    }
+  }
+  return semanticOnly;
+}
+
+function rewriteInstruction(
+  instr: Instruction,
+  preserveCaughtValue: boolean,
+  state: State,
+): void {
+  if (instr.value.kind === 'Destructure' && !preserveCaughtValue) {
     // Remove unused lvalues
     switch (instr.value.lvalue.pattern.kind) {
       case 'ArrayPattern': {
@@ -255,6 +312,10 @@ function rewriteInstruction(instr: Instruction, state: State): void {
       instr.value.lvalue.kind !== InstructionKind.Reassign &&
       !state.isIdUsed(instr.value.lvalue.place.identifier)
     ) {
+      if (preserveCaughtValue) {
+        instr.value.lvalue.kind = InstructionKind.Let;
+        return;
+      }
       /*
        * This is a const/let declaration where the variable is accessed later,
        * but where the value is always overwritten before being read. Ie the

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/PruneMaybeThrows.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/PruneMaybeThrows.ts
@@ -10,7 +10,8 @@ import {
   BlockId,
   GeneratedSource,
   HIRFunction,
-  Instruction,
+  InstructionKind,
+  InstructionValue,
   assertConsistentIdentifiers,
   assertTerminalSuccessorsExist,
   mergeConsecutiveBlocks,
@@ -82,7 +83,7 @@ function pruneMaybeThrowsImpl(fn: HIRFunction): Map<BlockId, BlockId> | null {
       continue;
     }
     const canThrow = block.instructions.some(instr =>
-      instructionMayThrow(instr),
+      valueMayThrow(instr.value),
     );
     if (!canThrow) {
       const source = terminalMapping.get(block.id) ?? block.id;
@@ -93,12 +94,34 @@ function pruneMaybeThrowsImpl(fn: HIRFunction): Map<BlockId, BlockId> | null {
   return terminalMapping.size > 0 ? terminalMapping : null;
 }
 
-function instructionMayThrow(instr: Instruction): boolean {
-  switch (instr.value.kind) {
+export function valueMayThrow(value: InstructionValue): boolean {
+  switch (value.kind) {
+    case 'DeclareLocal':
+    case 'DeclareContext':
     case 'Primitive':
-    case 'ArrayExpression':
-    case 'ObjectExpression': {
+    case 'JSXText':
+    case 'TypeCastExpression':
+    case 'ObjectMethod':
+    case 'FunctionExpression':
+    case 'RegExpLiteral':
+    case 'MetaProperty':
+    case 'Debugger':
+    case 'StartMemoize':
+    case 'FinishMemoize': {
       return false;
+    }
+    case 'StoreLocal':
+    case 'StoreContext': {
+      return value.lvalue.kind !== InstructionKind.Reassign;
+    }
+    case 'ArrayExpression': {
+      return value.elements.some(element => element.kind === 'Spread');
+    }
+    case 'ObjectExpression': {
+      return value.properties.some(
+        property =>
+          property.kind === 'Spread' || property.key.kind === 'computed',
+      );
     }
     default: {
       return true;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-jsx-in-catch-in-outer-try-with-catch.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/invalid-jsx-in-catch-in-outer-try-with-catch.expect.md
@@ -49,7 +49,7 @@ function Component(props) {
 
 ```
 {"kind":"CompileError","detail":{"category":"ErrorBoundaries","reason":"Avoid constructing JSX within try/catch","description":"React does not immediately render components when JSX is rendered, so any errors from this component will not be caught by the try/catch. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)","severity":"Error","suggestions":null,"details":[{"kind":"error","loc":{"start":{"line":11,"column":11,"index":241},"end":{"line":11,"column":32,"index":262},"filename":"invalid-jsx-in-catch-in-outer-try-with-catch.ts"},"message":"Avoid constructing JSX within try/catch"}]},"fnLoc":null}
-{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":110},"end":{"line":17,"column":1,"index":317},"filename":"invalid-jsx-in-catch-in-outer-try-with-catch.ts"},"fnName":"Component","memoSlots":4,"memoBlocks":2,"memoValues":2,"prunedMemoBlocks":0,"prunedMemoValues":0}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":0,"index":110},"end":{"line":17,"column":1,"index":317},"filename":"invalid-jsx-in-catch-in-outer-try-with-catch.ts"},"fnName":"Component","memoSlots":1,"memoBlocks":1,"memoValues":1,"prunedMemoBlocks":1,"prunedMemoValues":0}
 ```
       
 ### Eval output

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-nested-try-catch-in-usememo.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-nested-try-catch-in-usememo.expect.md
@@ -53,7 +53,7 @@ function useFoo(text) {
   const $ = _c(2);
   let t0;
   try {
-    let formattedText;
+    let formattedText = "";
     try {
       let t2;
       if ($[0] !== text) {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-property-dependency.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-property-dependency.expect.md
@@ -1,0 +1,61 @@
+
+## Input
+
+```javascript
+function Component({name}: {name: string}) {
+  try {
+    const url = new URL(name);
+    return (
+      <div>
+        {url.search}
+        {url.hash}
+      </div>
+    );
+  } catch {
+    return null;
+  }
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+  const $ = _c(5);
+  const { name } = t0;
+  try {
+    let t1;
+    if ($[0] !== name) {
+      t1 = new URL(name);
+      $[0] = name;
+      $[1] = t1;
+    } else {
+      t1 = $[1];
+    }
+    const url = t1;
+    let t2;
+    if ($[2] !== url.hash || $[3] !== url.search) {
+      t2 = (
+        <div>
+          {url.search}
+          {url.hash}
+        </div>
+      );
+      $[2] = url.hash;
+      $[3] = url.search;
+      $[4] = t2;
+    } else {
+      t2 = $[4];
+    }
+    return t2;
+  } catch {
+    return null;
+  }
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-property-dependency.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-property-dependency.tsx
@@ -1,0 +1,13 @@
+function Component({name}: {name: string}) {
+  try {
+    const url = new URL(name);
+    return (
+      <div>
+        {url.search}
+        {url.hash}
+      </div>
+    );
+  } catch {
+    return null;
+  }
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-retry-after-throw.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-retry-after-throw.expect.md
@@ -1,0 +1,105 @@
+
+## Input
+
+```javascript
+// @compilationMode:"annotation" @panicThreshold:"none"
+
+function Component(params) {
+  'use memo';
+  const selectedOptions = (() => {
+    try {
+      const channel = params.parse()?.channel;
+      return channel ? [{label: `#${channel}`, value: channel}] : [];
+    } catch {
+      return [];
+    }
+  })();
+  return selectedOptions;
+}
+
+const input = {
+  value: 'success',
+  shouldThrow: true,
+  parse() {
+    if (this.shouldThrow) {
+      this.shouldThrow = false;
+      throw new Error('oops');
+    }
+    return {channel: this.value};
+  },
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input],
+  sequentialRenders: [input, input],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @compilationMode:"annotation" @panicThreshold:"none"
+
+function Component(params) {
+  "use memo";
+  const $ = _c(5);
+  let t0;
+  try {
+    let t1;
+    if ($[0] !== params) {
+      t1 = params.parse()?.channel;
+      $[0] = params;
+      $[1] = t1;
+    } else {
+      t1 = $[1];
+    }
+    const channel = t1;
+    let t2;
+    if ($[2] !== channel) {
+      t2 = channel ? [{ label: `#${channel}`, value: channel }] : [];
+      $[2] = channel;
+      $[3] = t2;
+    } else {
+      t2 = $[3];
+    }
+    t0 = t2;
+  } catch {
+    let t1;
+    if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+      t1 = [];
+      $[4] = t1;
+    } else {
+      t1 = $[4];
+    }
+    t0 = t1;
+  }
+  const selectedOptions = t0;
+
+  return selectedOptions;
+}
+
+const input = {
+  value: "success",
+  shouldThrow: true,
+  parse() {
+    if (this.shouldThrow) {
+      this.shouldThrow = false;
+      throw new Error("oops");
+    }
+    return { channel: this.value };
+  },
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input],
+  sequentialRenders: [input, input],
+};
+
+```
+      
+### Eval output
+(kind: ok) []
+[{"label":"#success","value":"success"}]

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-retry-after-throw.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-retry-after-throw.js
@@ -1,0 +1,32 @@
+// @compilationMode:"annotation" @panicThreshold:"none"
+
+function Component(params) {
+  'use memo';
+  const selectedOptions = (() => {
+    try {
+      const channel = params.parse()?.channel;
+      return channel ? [{label: `#${channel}`, value: channel}] : [];
+    } catch {
+      return [];
+    }
+  })();
+  return selectedOptions;
+}
+
+const input = {
+  value: 'success',
+  shouldThrow: true,
+  parse() {
+    if (this.shouldThrow) {
+      this.shouldThrow = false;
+      throw new Error('oops');
+    }
+    return {channel: this.value};
+  },
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input],
+  sequentialRenders: [input, input],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-unused-throwing-value.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-unused-throwing-value.expect.md
@@ -1,0 +1,72 @@
+
+## Input
+
+```javascript
+// @compilationMode:"annotation"
+function Component({count, maybe}) {
+  'use memo';
+  const value = {count};
+  try {
+    const unused = maybe.item;
+    value.count++;
+  } catch {
+    value.count += 10;
+  }
+  return value.count;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{count: 1, maybe: null}],
+  sequentialRenders: [
+    {count: 1, maybe: null},
+    {count: 1, maybe: null},
+    {count: 1, maybe: {item: 'ok'}},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @compilationMode:"annotation"
+function Component(t0) {
+  "use memo";
+  const $ = _c(3);
+  const { count, maybe } = t0;
+  let value;
+  if ($[0] !== count || $[1] !== maybe) {
+    value = { count };
+    try {
+      maybe.item;
+      value.count = value.count + 1;
+    } catch {
+      value.count = value.count + 10;
+    }
+    $[0] = count;
+    $[1] = maybe;
+    $[2] = value;
+  } else {
+    value = $[2];
+  }
+
+  return value.count;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ count: 1, maybe: null }],
+  sequentialRenders: [
+    { count: 1, maybe: null },
+    { count: 1, maybe: null },
+    { count: 1, maybe: { item: "ok" } },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) 11
+11
+2

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-unused-throwing-value.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/try-catch-unused-throwing-value.js
@@ -1,0 +1,22 @@
+// @compilationMode:"annotation"
+function Component({count, maybe}) {
+  'use memo';
+  const value = {count};
+  try {
+    const unused = maybe.item;
+    value.count++;
+  } catch {
+    value.count += 10;
+  }
+  return value.count;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{count: 1, maybe: null}],
+  sequentialRenders: [
+    {count: 1, maybe: null},
+    {count: 1, maybe: null},
+    {count: 1, maybe: {item: 'ok'}},
+  ],
+};


### PR DESCRIPTION
## Summary

- retain otherwise-dead operations whose throws are observable by a live `catch`
- keep throwing property paths inside their handlers by collecting root-only dependencies
- preserve same-input retry behavior after transient caught throws
- update TypeScript and Rust together with shared runtime coverage

Ported from:

- oxc-project/oxc@0eac5a0373bea9850f7efbdd56a1d1bfc26208d1
- oxc-project/oxc@d68059a2d824a4807eab7e32ed566c9e0230c1db

Design precursor: oxc-project/oxc@2fe0a0dfd4c150ba9ff26b611556ef12f07664ef.

Original Oxc author: @Boshen.

## Benchmark

Criterion full-corpus benchmark using the two commits from #37485 cherry-picked with `--no-commit` onto both revisions. Both binaries compiled the same fixed PR-head corpus of 1812 fixtures and 756,643 source bytes. Both timing runs used `--sample-size 20 --warm-up-time 2 --measurement-time 10 --noplot`; Criterion collected 50 samples.

| Revision | Time | Throughput |
| --- | ---: | ---: |
| Main base (`f4e439e198`) | 520.07-533.41 ms (526.59 ms estimate) | 1.3528-1.3875 MiB/s |
| PR head (`74c14f7498`) | 489.04-494.08 ms (491.43 ms estimate) | 1.4605-1.4755 MiB/s |

Criterion measured a -6.68% timing estimate with a 95% confidence interval of -7.95% to -5.43% (`p < 0.005`, reported by Criterion as `p = 0.00`; significance threshold `0.05`). The improvement is statistically significant.

Separate peak-RSS runs used the branch-native corpora and 20 fresh processes per revision:

| Revision | Fixtures | Source bytes | Peak RSS mean | Peak RSS median | Peak RSS 95% sample range |
| --- | ---: | ---: | ---: | ---: | ---: |
| Main base (`f4e439e198`) | 1809 | 755,335 | 191.7 MiB | 192.0 MiB | 189.9-194.0 MiB |
| PR head (`74c14f7498`) | 1812 | 756,643 | 191.0 MiB | 191.3 MiB | 187.5-193.2 MiB |

Mean peak RSS was 0.37% lower despite three additional fixtures and 1,308 additional source bytes.

## Test Plan

- focused TypeScript and Rust snapshots for `try-catch-unused-throwing-value`, `try-catch-property-dependency`, and `try-catch-retry-after-throw`
- `cd compiler && yarn snap --rust` (1813/1813)
- `cd compiler && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd compiler && cargo check --manifest-path Cargo.toml --workspace --all-targets`
- `cd compiler && ./scripts/test-babel-ast.sh`
- `git diff --check`