### PR TITLE
oxc port: [correctness] preserve tagged template semantics

### DIFF
--- a/compiler/crates/react_compiler_ast/src/literals.rs
+++ b/compiler/crates/react_compiler_ast/src/literals.rs
@@ -81,6 +81,6 @@ pub struct TemplateElement {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplateElementValue {
     pub raw: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub cooked: Option<String>,
 }

--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -724,7 +724,8 @@ pub enum InstructionValue {
     },
     TaggedTemplateExpression {
         tag: Place,
-        value: TemplateQuasi,
+        subexprs: Vec<Place>,
+        quasis: Vec<TemplateQuasi>,
         loc: Option<SourceLocation>,
     },
     TemplateLiteral {

--- a/compiler/crates/react_compiler_hir/src/print.rs
+++ b/compiler/crates/react_compiler_hir/src/print.rs
@@ -1268,20 +1268,17 @@ impl<'a> PrintFormatter<'a> {
             }
             InstructionValue::TaggedTemplateExpression {
                 tag,
-                value: val,
+                subexprs,
+                quasis,
                 loc,
             } => {
                 self.line("TaggedTemplateExpression {");
                 self.indent();
                 self.format_place_field("tag", tag);
-                self.line(&format!("raw: {}", format_js_string(&val.raw)));
-                self.line(&format!(
-                    "cooked: {}",
-                    match &val.cooked {
-                        Some(c) => format_js_string(c),
-                        None => "undefined".to_string(),
-                    }
-                ));
+                self.line(&format!("quasis: {quasis:?}"));
+                for subexpr in subexprs {
+                    self.format_place_field("subexpr", subexpr);
+                }
                 self.line(&format!("loc: {}", format_loc(loc)));
                 self.dedent();
                 self.line("}");

--- a/compiler/crates/react_compiler_hir/src/print.rs
+++ b/compiler/crates/react_compiler_hir/src/print.rs
@@ -1275,7 +1275,23 @@ impl<'a> PrintFormatter<'a> {
                 self.line("TaggedTemplateExpression {");
                 self.indent();
                 self.format_place_field("tag", tag);
-                self.line(&format!("quasis: {quasis:?}"));
+                let quasis = quasis
+                    .iter()
+                    .map(|quasi| {
+                        format!(
+                            "{{\"raw\":{},\"cooked\":{}}}",
+                            format_js_string(&quasi.raw),
+                            quasi
+                                .cooked
+                                .as_ref()
+                                .map_or_else(|| "null".to_string(), |cooked| {
+                                    format_js_string(cooked)
+                                }),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",");
+                self.line(&format!("quasis: [{quasis}]"));
                 for subexpr in subexprs {
                     self.format_place_field("subexpr", subexpr);
                 }

--- a/compiler/crates/react_compiler_hir/src/visitors.rs
+++ b/compiler/crates/react_compiler_hir/src/visitors.rs
@@ -320,8 +320,9 @@ pub fn each_instruction_value_operand_with_functions(
                 result.push(ctx_place.clone());
             }
         }
-        InstructionValue::TaggedTemplateExpression { tag, .. } => {
+        InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
             result.push(tag.clone());
+            result.extend(subexprs.iter().cloned());
         }
         InstructionValue::TypeCastExpression { value: val, .. } => {
             result.push(val.clone());
@@ -760,8 +761,9 @@ pub fn map_instruction_value_operands(
             let func = &mut env.functions[lowered_func.func.0 as usize];
             func.context = func.context.iter().map(|d| f(d.clone())).collect();
         }
-        InstructionValue::TaggedTemplateExpression { tag, .. } => {
+        InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
             *tag = f(tag.clone());
+            *subexprs = subexprs.iter().map(|subexpr| f(subexpr.clone())).collect();
         }
         InstructionValue::TypeCastExpression { value: val, .. } => {
             *val = f(val.clone());
@@ -1597,8 +1599,11 @@ pub fn for_each_instruction_value_operand_mut(
         InstructionValue::FunctionExpression { .. } | InstructionValue::ObjectMethod { .. } => {
             // Context places require env access — callers handle separately.
         }
-        InstructionValue::TaggedTemplateExpression { tag, .. } => {
+        InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
             f(tag);
+            for subexpr in subexprs {
+                f(subexpr);
+            }
         }
         InstructionValue::TypeCastExpression { value: val, .. } => {
             f(val);

--- a/compiler/crates/react_compiler_inference/src/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/compiler/crates/react_compiler_inference/src/flatten_scopes_with_hooks_or_use_hir.rs
@@ -28,7 +28,8 @@
 
 use react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
 use react_compiler_hir::environment::Environment;
-use react_compiler_hir::{BlockId, HirFunction, InstructionValue, Terminal, Type};
+use react_compiler_hir::type_config::ValueKind;
+use react_compiler_hir::{BlockId, Effect, HirFunction, InstructionValue, Terminal, Type};
 
 /// Flattens reactive scopes that contain hook calls or `use()` calls.
 ///
@@ -59,6 +60,12 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
                         &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
                     if is_hook_or_use(env, callee_ty)? {
                         // All active scopes must be pruned
+                        prune.extend(active_scopes.iter().map(|s| s.block));
+                        active_scopes.clear();
+                    }
+                }
+                InstructionValue::TaggedTemplateExpression { tag, .. } => {
+                    if !is_known_pure_tagged_template(env, tag)? {
                         prune.extend(active_scopes.iter().map(|s| s.block));
                         active_scopes.clear();
                     }
@@ -134,6 +141,22 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
         block_mut.terminal = new_terminal;
     }
     Ok(())
+}
+
+fn is_known_pure_tagged_template(
+    env: &Environment,
+    tag: &react_compiler_hir::Place,
+) -> Result<bool, CompilerDiagnostic> {
+    let ty = &env.types[env.identifiers[tag.identifier.0 as usize].type_.0 as usize];
+    let Some(signature) = env.get_function_signature(ty)? else {
+        return Ok(false);
+    };
+    Ok(signature.callee_effect == Effect::Read
+        && !signature.impure
+        && matches!(
+            signature.return_value_kind,
+            ValueKind::Frozen | ValueKind::Primitive
+        ))
 }
 
 struct ActiveScope {

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -1182,15 +1182,6 @@ fn infer_block(
             env,
             func,
         )?;
-        if matches!(
-            func.instructions[instr_index].value,
-            InstructionValue::TaggedTemplateExpression { .. }
-        ) {
-            visitors::for_each_instruction_value_operand_mut(
-                &mut func.instructions[instr_index].value,
-                &mut |place| place.effect = Effect::Read,
-            );
-        }
         func.instructions[instr_index].effects = effects;
     }
 

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -2714,11 +2714,22 @@ fn compute_signature_for_instruction(
                 reason: ValueReason::Other,
             });
         }
-        InstructionValue::TaggedTemplateExpression { .. } => {
-            effects.push(AliasingEffect::Create {
+        InstructionValue::TaggedTemplateExpression {
+            tag, subexprs, loc, ..
+        } => {
+            let sig = get_function_call_signature(env, tag.identifier)
+                .ok()
+                .flatten();
+            let mut args = vec![PlaceOrSpreadOrHole::Hole];
+            args.extend(subexprs.iter().cloned().map(PlaceOrSpreadOrHole::Place));
+            effects.push(AliasingEffect::Apply {
+                receiver: tag.clone(),
+                function: tag.clone(),
+                mutates_function: true,
+                args,
                 into: lvalue.clone(),
-                value: ValueKind::Primitive,
-                reason: ValueReason::Other,
+                signature: sig,
+                loc: *loc,
             });
         }
         // All primitive-creating instructions

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -1182,6 +1182,15 @@ fn infer_block(
             env,
             func,
         )?;
+        if matches!(
+            func.instructions[instr_index].value,
+            InstructionValue::TaggedTemplateExpression { .. }
+        ) {
+            visitors::for_each_instruction_value_operand_mut(
+                &mut func.instructions[instr_index].value,
+                &mut |place| place.effect = Effect::Read,
+            );
+        }
         func.instructions[instr_index].effects = effects;
     }
 
@@ -2705,9 +2714,15 @@ fn compute_signature_for_instruction(
                 reason: ValueReason::Other,
             });
         }
+        InstructionValue::TaggedTemplateExpression { .. } => {
+            effects.push(AliasingEffect::Create {
+                into: lvalue.clone(),
+                value: ValueKind::Primitive,
+                reason: ValueReason::Other,
+            });
+        }
         // All primitive-creating instructions
-        InstructionValue::TaggedTemplateExpression { .. }
-        | InstructionValue::BinaryExpression { .. }
+        InstructionValue::BinaryExpression { .. }
         | InstructionValue::Debugger { .. }
         | InstructionValue::JSXText { .. }
         | InstructionValue::MetaProperty { .. }

--- a/compiler/crates/react_compiler_inference/src/infer_reactive_scope_variables.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_reactive_scope_variables.rs
@@ -212,9 +212,11 @@ fn may_allocate(value: &InstructionValue, lvalue_type_is_primitive: bool) -> boo
         | InstructionValue::PropertyLoad { .. }
         | InstructionValue::StoreGlobal { .. } => false,
 
-        InstructionValue::TaggedTemplateExpression { .. }
-        | InstructionValue::CallExpression { .. }
-        | InstructionValue::MethodCall { .. } => !lvalue_type_is_primitive,
+        InstructionValue::TaggedTemplateExpression { .. } => true,
+
+        InstructionValue::CallExpression { .. } | InstructionValue::MethodCall { .. } => {
+            !lvalue_type_is_primitive
+        }
 
         InstructionValue::RegExpLiteral { .. }
         | InstructionValue::PropertyStore { .. }

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -1765,48 +1765,28 @@ fn lower_expression(
         }
         Expression::TaggedTemplateExpression(tagged) => {
             let loc = convert_opt_loc(&tagged.base.loc);
-            if !tagged.quasi.expressions.is_empty() {
-                builder.record_error(CompilerErrorDetail {
-                    category: ErrorCategory::Todo,
-                    reason:
-                        "(BuildHIR::lowerExpression) Handle tagged template with interpolations"
-                            .to_string(),
-                    description: None,
-                    loc: loc.clone(),
-                    suggestions: None,
-                })?;
-                return Ok(InstructionValue::UnsupportedNode {
-                    node_type: Some("TaggedTemplateExpression".to_string()),
-                    original_node: serialize_expression(expr),
-                    loc,
-                });
-            }
-            assert!(
-                tagged.quasi.quasis.len() == 1,
-                "there should be only one quasi as we don't support interpolations yet"
-            );
-            let quasi = &tagged.quasi.quasis[0];
-            // Check if raw and cooked values differ (e.g., graphql tagged templates)
-            if quasi.value.raw != quasi.value.cooked.clone().unwrap_or_default() {
-                builder.record_error(CompilerErrorDetail {
-                    category: ErrorCategory::Todo,
-                    reason: "(BuildHIR::lowerExpression) Handle tagged template where cooked value is different from raw value".to_string(),
-                    description: None,
-                    loc: loc.clone(),
-                    suggestions: None,
-                })?;
-                return Ok(InstructionValue::UnsupportedNode {
-                    node_type: Some("TaggedTemplateExpression".to_string()),
-                    original_node: serialize_expression(expr),
-                    loc,
-                });
-            }
-            let value = TemplateQuasi {
-                raw: quasi.value.raw.clone(),
-                cooked: quasi.value.cooked.clone(),
-            };
             let tag = lower_expression_to_temporary(builder, &tagged.tag)?;
-            Ok(InstructionValue::TaggedTemplateExpression { tag, value, loc })
+            let subexprs = tagged
+                .quasi
+                .expressions
+                .iter()
+                .map(|expression| lower_expression_to_temporary(builder, expression))
+                .collect::<Result<Vec<_>, _>>()?;
+            let quasis = tagged
+                .quasi
+                .quasis
+                .iter()
+                .map(|quasi| TemplateQuasi {
+                    raw: quasi.value.raw.clone(),
+                    cooked: quasi.value.cooked.clone(),
+                })
+                .collect();
+            Ok(InstructionValue::TaggedTemplateExpression {
+                tag,
+                subexprs,
+                quasis,
+                loc,
+            })
         }
         Expression::AwaitExpression(await_expr) => {
             let loc = convert_opt_loc(&await_expr.base.loc);

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -1765,7 +1765,6 @@ fn lower_expression(
         }
         Expression::TaggedTemplateExpression(tagged) => {
             let loc = convert_opt_loc(&tagged.base.loc);
-            let tag = lower_expression_to_temporary(builder, &tagged.tag)?;
             let subexprs = tagged
                 .quasi
                 .expressions
@@ -1781,6 +1780,7 @@ fn lower_expression(
                     cooked: quasi.value.cooked.clone(),
                 })
                 .collect();
+            let tag = lower_expression_to_temporary(builder, &tagged.tag)?;
             Ok(InstructionValue::TaggedTemplateExpression {
                 tag,
                 subexprs,

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -2578,23 +2578,37 @@ fn codegen_base_instruction_value(
             expr_type,
             ..
         } => codegen_function_expression(cx, name, name_hint, lowered_func, expr_type),
-        InstructionValue::TaggedTemplateExpression { tag, value, .. } => {
+        InstructionValue::TaggedTemplateExpression {
+            tag,
+            subexprs,
+            quasis,
+            ..
+        } => {
             let tag_expr = codegen_place_to_expression(cx, tag)?;
+            let expressions = subexprs
+                .iter()
+                .map(|subexpr| codegen_place_to_expression(cx, subexpr))
+                .collect::<Result<Vec<_>, _>>()?;
+            let quasis = quasis
+                .iter()
+                .enumerate()
+                .map(|(index, quasi)| TemplateElement {
+                    base: BaseNode::typed("TemplateElement"),
+                    value: TemplateElementValue {
+                        raw: quasi.raw.clone(),
+                        cooked: quasi.cooked.clone(),
+                    },
+                    tail: index == quasis.len() - 1,
+                })
+                .collect();
             Ok(ExpressionOrJsxText::Expression(
                 Expression::TaggedTemplateExpression(ast_expr::TaggedTemplateExpression {
                     base: BaseNode::typed("TaggedTemplateExpression"),
                     tag: Box::new(tag_expr),
                     quasi: ast_expr::TemplateLiteral {
                         base: BaseNode::typed("TemplateLiteral"),
-                        quasis: vec![TemplateElement {
-                            base: BaseNode::typed("TemplateElement"),
-                            value: TemplateElementValue {
-                                raw: value.raw.clone(),
-                                cooked: value.cooked.clone(),
-                            },
-                            tail: true,
-                        }],
-                        expressions: Vec::new(),
+                        quasis,
+                        expressions,
                     },
                     type_parameters: None,
                 }),

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -2450,41 +2450,25 @@ function lowerExpression(
     }
     case 'TaggedTemplateExpression': {
       const expr = exprPath as NodePath<t.TaggedTemplateExpression>;
-      if (expr.get('quasi').get('expressions').length !== 0) {
-        builder.recordError(
-          new CompilerErrorDetail({
-            reason:
-              '(BuildHIR::lowerExpression) Handle tagged template with interpolations',
-            category: ErrorCategory.Todo,
-            loc: exprPath.node.loc ?? null,
-            suggestions: null,
-          }),
+      const subexprs = expr
+        .get('quasi')
+        .get('expressions')
+        .map(subexpr =>
+          lowerExpressionToTemporary(
+            builder,
+            subexpr as NodePath<t.Expression>,
+          ),
         );
-        return {kind: 'UnsupportedNode', node: exprNode, loc: exprLoc};
-      }
-      CompilerError.invariant(expr.get('quasi').get('quasis').length == 1, {
-        reason:
-          "there should be only one quasi as we don't support interpolations yet",
-        loc: expr.node.loc ?? GeneratedSource,
-      });
-      const value = expr.get('quasi').get('quasis').at(0)!.node.value;
-      if (value.raw !== value.cooked) {
-        builder.recordError(
-          new CompilerErrorDetail({
-            reason:
-              '(BuildHIR::lowerExpression) Handle tagged template where cooked value is different from raw value',
-            category: ErrorCategory.Todo,
-            loc: exprPath.node.loc ?? null,
-            suggestions: null,
-          }),
-        );
-        return {kind: 'UnsupportedNode', node: exprNode, loc: exprLoc};
-      }
+      const quasis = expr
+        .get('quasi')
+        .get('quasis')
+        .map(quasi => quasi.node.value);
 
       return {
         kind: 'TaggedTemplateExpression',
         tag: lowerExpressionToTemporary(builder, expr.get('tag')),
-        value,
+        subexprs,
+        quasis,
         loc: exprLoc,
       };
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/DebugPrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/DebugPrintHIR.ts
@@ -616,10 +616,10 @@ export class DebugPrinter {
         this.line('TaggedTemplateExpression {');
         this.indent();
         this.formatPlaceField('tag', instrValue.tag);
-        this.line(`raw: ${JSON.stringify(instrValue.value.raw)}`);
-        this.line(
-          `cooked: ${instrValue.value.cooked !== undefined ? JSON.stringify(instrValue.value.cooked) : 'undefined'}`,
-        );
+        this.line(`quasis: ${JSON.stringify(instrValue.quasis)}`);
+        for (const subexpr of instrValue.subexprs) {
+          this.formatPlaceField('subexpr', subexpr);
+        }
         this.line(`loc: ${this.formatLoc(instrValue.loc)}`);
         this.dedent();
         this.line('}');

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -1046,7 +1046,8 @@ export type InstructionValue =
   | {
       kind: 'TaggedTemplateExpression';
       tag: Place;
-      value: {raw: string; cooked?: string};
+      subexprs: Array<Place>;
+      quasis: Array<{raw: string; cooked?: string}>;
       loc: SourceLocation;
     }
   | {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PrintHIR.ts
@@ -567,7 +567,11 @@ export function printInstructionValue(instrValue: ReactiveValue): string {
       break;
     }
     case 'TaggedTemplateExpression': {
-      value = `${printPlace(instrValue.tag)}\`${instrValue.value.raw}\``;
+      const parts = instrValue.quasis.map((quasi, index) => {
+        const subexpr = instrValue.subexprs[index];
+        return `${quasi.raw}${subexpr === undefined ? '' : `\${${printPlace(subexpr)}}`}`;
+      });
+      value = `${printPlace(instrValue.tag)}\`${parts.join('')}\``;
       break;
     }
     case 'LogicalExpression': {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/visitors.ts
@@ -225,6 +225,7 @@ export function* eachInstructionValueOperand(
     }
     case 'TaggedTemplateExpression': {
       yield instrValue.tag;
+      yield* instrValue.subexprs;
       break;
     }
     case 'TypeCastExpression': {
@@ -596,6 +597,7 @@ export function mapInstructionValueOperands(
     }
     case 'TaggedTemplateExpression': {
       instrValue.tag = fn(instrValue.tag);
+      instrValue.subexprs = instrValue.subexprs.map(fn);
       break;
     }
     case 'TypeCastExpression': {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -2280,7 +2280,18 @@ function computeSignatureForInstruction(
       });
       break;
     }
-    case 'TaggedTemplateExpression':
+    case 'TaggedTemplateExpression': {
+      for (const operand of eachInstructionValueOperand(value)) {
+        operand.effect = Effect.Read;
+      }
+      effects.push({
+        kind: 'Create',
+        into: lvalue,
+        value: ValueKind.Primitive,
+        reason: ValueReason.Other,
+      });
+      break;
+    }
     case 'BinaryExpression':
     case 'Debugger':
     case 'JSXText':

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -2281,14 +2281,15 @@ function computeSignatureForInstruction(
       break;
     }
     case 'TaggedTemplateExpression': {
-      for (const operand of eachInstructionValueOperand(value)) {
-        operand.effect = Effect.Read;
-      }
       effects.push({
-        kind: 'Create',
+        kind: 'Apply',
+        receiver: value.tag,
+        function: value.tag,
+        mutatesFunction: true,
+        args: [{kind: 'Hole'}, ...value.subexprs],
         into: lvalue,
-        value: ValueKind.Primitive,
-        reason: ValueReason.Other,
+        signature: getFunctionCallSignature(env, value.tag.identifier.type),
+        loc: value.loc,
       });
       break;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -1912,7 +1912,19 @@ function codegenInstructionValue(
       value = createTaggedTemplateExpression(
         instrValue.loc,
         codegenPlaceToExpression(cx, instrValue.tag),
-        t.templateLiteral([t.templateElement(instrValue.value)], []),
+        t.templateLiteral(
+          instrValue.quasis.map((quasi, index) =>
+            t.templateElement(
+              quasi.cooked === undefined
+                ? {raw: quasi.raw}
+                : {raw: quasi.raw, cooked: quasi.cooked},
+              index === instrValue.quasis.length - 1,
+            ),
+          ),
+          instrValue.subexprs.map(subexpr =>
+            codegenPlaceToExpression(cx, subexpr),
+          ),
+        ),
       );
       break;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts
@@ -10,7 +10,10 @@ import {
   BlockId,
   HIRFunction,
   LabelTerminal,
+  Place,
   PrunedScopeTerminal,
+  Effect,
+  ValueKind,
   getHookKind,
   isUseOperator,
 } from '../HIR';
@@ -58,6 +61,14 @@ export function flattenScopesWithHooksOrUseHIR(fn: HIRFunction): void {
             prune.push(...activeScopes.map(entry => entry.block));
             activeScopes.length = 0;
           }
+          break;
+        }
+        case 'TaggedTemplateExpression': {
+          if (!isKnownPureTaggedTemplate(fn, value.tag)) {
+            prune.push(...activeScopes.map(entry => entry.block));
+            activeScopes.length = 0;
+          }
+          break;
         }
       }
     }
@@ -107,4 +118,18 @@ export function flattenScopesWithHooksOrUseHIR(fn: HIRFunction): void {
       scope: terminal.scope,
     } as PrunedScopeTerminal;
   }
+}
+
+function isKnownPureTaggedTemplate(fn: HIRFunction, tag: Place): boolean {
+  if (tag.identifier.type.kind !== 'Function') {
+    return false;
+  }
+  const signature = fn.env.getFunctionSignature(tag.identifier.type);
+  return (
+    signature !== null &&
+    signature.calleeEffect === Effect.Read &&
+    signature.impure !== true &&
+    (signature.returnValueKind === ValueKind.Frozen ||
+      signature.returnValueKind === ValueKind.Primitive)
+  );
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/InferReactiveScopeVariables.ts
@@ -242,7 +242,9 @@ function mayAllocate(_env: Environment, instruction: Instruction): boolean {
     case 'StoreGlobal': {
       return false;
     }
-    case 'TaggedTemplateExpression':
+    case 'TaggedTemplateExpression': {
+      return true;
+    }
     case 'CallExpression':
     case 'MethodCall': {
       return instruction.lvalue.identifier.type.kind !== 'Primitive';

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-mixed-scope-and-local-variables-with-default.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-mixed-scope-and-local-variables-with-default.expect.md
@@ -63,60 +63,64 @@ function useFragment(_arg1, _arg2) {
 }
 
 function Component(props) {
-  const $ = _c(8);
-  const post = useFragment(
-    graphql`
+  const $ = _c(9);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = graphql`
       fragment F on T {
         id
       }
-    `,
-    props.post,
-  );
-  let t0;
-  if ($[0] !== post) {
+    `;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const post = useFragment(t0, props.post);
+  let t1;
+  if ($[1] !== post) {
     const allUrls = [];
-    const { media: t1, comments: t2, urls: t3 } = post;
-    const media = t1 === undefined ? null : t1;
-    let t4;
-    if ($[2] !== t2) {
-      t4 = t2 === undefined ? [] : t2;
-      $[2] = t2;
-      $[3] = t4;
-    } else {
-      t4 = $[3];
-    }
-    const comments = t4;
+    const { media: t2, comments: t3, urls: t4 } = post;
+    const media = t2 === undefined ? null : t2;
     let t5;
-    if ($[4] !== t3) {
+    if ($[3] !== t3) {
       t5 = t3 === undefined ? [] : t3;
-      $[4] = t3;
-      $[5] = t5;
+      $[3] = t3;
+      $[4] = t5;
     } else {
-      t5 = $[5];
+      t5 = $[4];
     }
-    const urls = t5;
+    const comments = t5;
     let t6;
-    if ($[6] !== comments.length) {
-      t6 = (e) => {
+    if ($[5] !== t4) {
+      t6 = t4 === undefined ? [] : t4;
+      $[5] = t4;
+      $[6] = t6;
+    } else {
+      t6 = $[6];
+    }
+    const urls = t6;
+    let t7;
+    if ($[7] !== comments.length) {
+      t7 = (e) => {
         if (!comments.length) {
           return;
         }
         console.log(comments.length);
       };
-      $[6] = comments.length;
-      $[7] = t6;
+      $[7] = comments.length;
+      $[8] = t7;
     } else {
-      t6 = $[7];
+      t7 = $[8];
     }
-    const onClick = t6;
+    const onClick = t7;
     allUrls.push(...urls);
-    t0 = <Stringify media={media} allUrls={allUrls} onClick={onClick} />;
-    $[0] = post;
-    $[1] = t0;
+    t1 = <Stringify media={media} allUrls={allUrls} onClick={onClick} />;
+    $[1] = post;
+    $[2] = t1;
   } else {
-    t0 = $[1];
+    t1 = $[2];
   }
-  return t0;
+  return t1;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/memoize-tagged-template-before-consumer.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/memoize-tagged-template-before-consumer.expect.md
@@ -1,0 +1,24 @@
+
+## Input
+
+```javascript
+// @compilationMode:"all" @panicThreshold:"none"
+export function Component({tag, consume}) {
+  return consume(tag`value`);
+}
+
+```
+
+## Code
+
+```javascript
+// @compilationMode:"all" @panicThreshold:"none"
+export function Component(t0) {
+  const { tag, consume } = t0;
+  return consume(tag`value`);
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/memoize-tagged-template-before-consumer.tsx
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/memoize-tagged-template-before-consumer.tsx
@@ -1,0 +1,4 @@
+// @compilationMode:"all" @panicThreshold:"none"
+export function Component({tag, consume}) {
+  return consume(tag`value`);
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-escaped.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-escaped.expect.md
@@ -1,0 +1,31 @@
+
+## Input
+
+```javascript
+function component(value) {
+  return tag`line one\nline two: ${value}\t`;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function component(value) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== value) {
+    t0 = tag`line one\nline two: ${value}\t`;
+    $[0] = value;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-escaped.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-escaped.expect.md
@@ -11,18 +11,8 @@ function component(value) {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime";
 function component(value) {
-  const $ = _c(2);
-  let t0;
-  if ($[0] !== value) {
-    t0 = tag`line one\nline two: ${value}\t`;
-    $[0] = value;
-    $[1] = t0;
-  } else {
-    t0 = $[1];
-  }
-  return t0;
+  return tag`line one\nline two: ${value}\t`;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-escaped.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-escaped.js
@@ -1,0 +1,3 @@
+function component(value) {
+  return tag`line one\nline two: ${value}\t`;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-invalid-escape.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-invalid-escape.expect.md
@@ -11,17 +11,8 @@ function component() {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime";
 function component() {
-  const $ = _c(1);
-  let t0;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = tag`\unicode`;
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  return t0;
+  return tag`\unicode`;
 }
 
 ```

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-invalid-escape.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-invalid-escape.expect.md
@@ -1,0 +1,30 @@
+
+## Input
+
+```javascript
+function component() {
+  return tag`\unicode`;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function component() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = tag`\unicode`;
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-invalid-escape.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-invalid-escape.js
@@ -1,0 +1,3 @@
+function component() {
+  return tag`\unicode`;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-literal.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-literal.expect.md
@@ -17,21 +17,12 @@ function component() {
 ## Code
 
 ```javascript
-import { c as _c } from "react/compiler-runtime";
 function component() {
-  const $ = _c(1);
-  let t0;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = graphql`
-      fragment F on T {
-        id
-      }
-    `;
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  const t = t0;
+  const t = graphql`
+    fragment F on T {
+      id
+    }
+  `;
 
   return t;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-primitive-result-mutation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-primitive-result-mutation.expect.md
@@ -1,0 +1,53 @@
+
+## Input
+
+```javascript
+// @compilationMode:"annotation"
+function Component({initial}) {
+  'use memo';
+  const object = {value: initial};
+  function tag() {
+    object.value++;
+    return 0;
+  }
+  tag`value`;
+  return object.value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{initial: 0}],
+  sequentialRenders: [{initial: 0}, {initial: 0}],
+};
+
+```
+
+## Code
+
+```javascript
+// @compilationMode:"annotation"
+function Component(t0) {
+  "use memo";
+  const { initial } = t0;
+
+  const object = { value: initial };
+  const tag = function tag() {
+    object.value = object.value + 1;
+    return 0;
+  };
+
+  tag`value`;
+  return object.value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ initial: 0 }],
+  sequentialRenders: [{ initial: 0 }, { initial: 0 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 1
+1

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-primitive-result-mutation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/tagged-template-primitive-result-mutation.js
@@ -1,0 +1,17 @@
+// @compilationMode:"annotation"
+function Component({initial}) {
+  'use memo';
+  const object = {value: initial};
+  function tag() {
+    object.value++;
+    return 0;
+  }
+  tag`value`;
+  return object.value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{initial: 0}],
+  sequentialRenders: [{initial: 0}, {initial: 0}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-tagged-template-expression.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/type-provider-tagged-template-expression.expect.md
@@ -37,13 +37,13 @@ import { graphql } from "shared-runtime";
 
 export function Component(t0) {
   const $ = _c(1);
-  const fragment = graphql`
-    fragment Foo on User {
-      name
-    }
-  `;
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    const fragment = graphql`
+      fragment Foo on User {
+        name
+      }
+    `;
     t1 = <div>{fragment}</div>;
     $[0] = t1;
   } else {
@@ -51,7 +51,6 @@ export function Component(t0) {
   }
   return t1;
 }
-
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
   params: [{ a: 0, b: 0 }],


### PR DESCRIPTION
## Summary

- support tagged templates with interpolations, escaped values, and invalid escapes in TypeScript and Rust
- model tagged templates as calls during mutation and alias inference
- preserve opaque tag execution, mutation, and result identity while allowing configured pure tags to remain memoized

This PR preserves the three source changes as separate React commits:

1. oxc-project/oxc@fd3980e91be69334253ff34bff665a7535ab7300
2. oxc-project/oxc@93c83d3d9b5e78ca330eab9fec0c82059b4bdd19
3. oxc-project/oxc@48e917fcba7d320e0b594dd8f5440e4d28eaf0e7

Original Oxc author: @Boshen.

## Benchmark

Criterion full-corpus benchmark using the two commits from #37485 cherry-picked with `--no-commit` onto both revisions. Both binaries compiled the same fixed branch-head corpus of 1813 fixtures and 755,929 source bytes. Timing runs used the same Criterion invocation (`--sample-size 20 --warm-up-time 2 --measurement-time 10 --noplot`); Criterion collected 50 samples.

| Revision | Time | Throughput |
| --- | ---: | ---: |
| Main base (`0bbf02475c`) | 520.41-539.70 ms (529.35 ms estimate) | 1.3358-1.3853 MiB/s |
| PR head (`975a1a45bc`) | 541.19-564.82 ms (552.12 ms estimate) | 1.2764-1.3321 MiB/s |

Criterion measured a +4.30% timing estimate with a 95% confidence interval of +1.52% to +7.31% (`p < 0.005`, reported by Criterion as `p = 0.00`; significance threshold `0.05`). The regression is statistically significant.

Separate branch-native peak-RSS runs used 20 fresh processes per revision:

| Revision | Fixtures | Source bytes | Peak RSS mean | Peak RSS median | Peak RSS 95% sample range |
| --- | ---: | ---: | ---: | ---: | ---: |
| Main base (`0bbf02475c`) | 1809 | 755,335 | 188.9 MiB | 188.8 MiB | 186.4-192.1 MiB |
| PR head (`975a1a45bc`) | 1813 | 755,929 | 188.8 MiB | 188.4 MiB | 187.5-191.9 MiB |

Mean peak RSS was 0.05% lower. The PR corpus adds four fixtures and 594 source bytes.

## Test Plan

- focused TypeScript and Rust snapshots for escaped, invalid, interpolated, mutation, opaque-consumer, and configured-pure tagged templates
- `cd compiler && yarn snap --rust` (1814/1814)
- `cd compiler && yarn workspace babel-plugin-react-compiler lint`
- `cd compiler && cargo fmt --manifest-path Cargo.toml --all --check`
- `cd compiler && cargo check --manifest-path Cargo.toml --workspace --all-targets`
- `cd compiler && ./scripts/test-babel-ast.sh`
- `git diff --check`