### PR TITLE
oxc port: [correctness] support destructured context parameters

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -3094,13 +3094,14 @@ fn lower_statement(
                 let stmt_loc = convert_opt_loc(&var_decl.base.loc);
                 if let Some(init) = &declarator.init {
                     let value = lower_expression_to_temporary(builder, init)?;
-                    let assign_style = match &declarator.id {
-                        PatternLike::ObjectPattern(_) | PatternLike::ArrayPattern(_) => {
-                            AssignmentStyle::Destructure
-                        }
-                        _ => AssignmentStyle::Assignment,
-                    };
-                    lower_assignment(builder, stmt_loc, kind, &declarator.id, value, assign_style)?;
+                    lower_assignment(
+                        builder,
+                        stmt_loc,
+                        kind,
+                        &declarator.id,
+                        value,
+                        AssignmentStyle::for_binding_pattern(&declarator.id),
+                    )?;
                 } else if let PatternLike::Identifier(id) = &declarator.id {
                     // No init: emit DeclareLocal or DeclareContext
                     let id_loc = convert_opt_loc(&id.base.loc);
@@ -6156,7 +6157,7 @@ fn lower_inner(
                     InstructionKind::Let,
                     &rest.argument,
                     place,
-                    AssignmentStyle::Assignment,
+                    AssignmentStyle::for_binding_pattern(&rest.argument),
                 )?;
             }
             react_compiler_ast::patterns::PatternLike::ObjectPattern(_)
@@ -6172,7 +6173,7 @@ fn lower_inner(
                     InstructionKind::Let,
                     param,
                     place,
-                    AssignmentStyle::Assignment,
+                    AssignmentStyle::for_binding_pattern(param),
                 )?;
             }
             react_compiler_ast::patterns::PatternLike::MemberExpression(member) => {
@@ -6935,6 +6936,16 @@ pub enum AssignmentStyle {
     Assignment,
     /// Destructuring assignment
     Destructure,
+}
+
+impl AssignmentStyle {
+    fn for_binding_pattern(pattern: &react_compiler_ast::patterns::PatternLike) -> Self {
+        match pattern {
+            react_compiler_ast::patterns::PatternLike::ObjectPattern(_)
+            | react_compiler_ast::patterns::PatternLike::ArrayPattern(_) => Self::Destructure,
+            _ => Self::Assignment,
+        }
+    }
 }
 
 /// Collect locations of fbt:enum, fbt:plural, fbt:pronoun sub-tags

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -147,7 +147,7 @@ export function lower(
         InstructionKind.Let,
         param,
         place,
-        'Assignment',
+        assignmentKindForBindingPattern(param),
       );
     } else if (param.isRestElement()) {
       const place: Place = {
@@ -167,7 +167,7 @@ export function lower(
         InstructionKind.Let,
         param.get('argument'),
         place,
-        'Assignment',
+        assignmentKindForBindingPattern(param.get('argument')),
       );
     } else {
       builder.recordError(
@@ -936,9 +936,7 @@ function lowerStatement(
             kind,
             id,
             value,
-            id.isObjectPattern() || id.isArrayPattern()
-              ? 'Destructure'
-              : 'Assignment',
+            assignmentKindForBindingPattern(id),
           );
         } else if (id.isIdentifier()) {
           const binding = builder.resolveIdentifier(id);
@@ -4408,6 +4406,14 @@ function lowerAssignment(
       return {kind: 'UnsupportedNode', node: lvalueNode, loc};
     }
   }
+}
+
+function assignmentKindForBindingPattern(
+  pattern: NodePath<t.LVal>,
+): 'Destructure' | 'Assignment' {
+  return pattern.isObjectPattern() || pattern.isArrayPattern()
+    ? 'Destructure'
+    : 'Assignment';
 }
 
 function captureScopes({from, to}: {from: Scope; to: Scope}): Set<Scope> {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-array-param-to-context-var.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-array-param-to-context-var.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+import {identity} from 'shared-runtime';
+
+function Component([x]) {
+  x = identity(x);
+  const read = () => x;
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [[42]],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { identity } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(2);
+  let t1;
+  if ($[0] !== t0) {
+    const [t2] = t0;
+    let x = t2;
+    x = identity(x);
+    const read = () => x;
+    t1 = read();
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [[42]],
+};
+
+```
+      
+### Eval output
+(kind: ok) 42

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-array-param-to-context-var.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-array-param-to-context-var.js
@@ -1,0 +1,12 @@
+import {identity} from 'shared-runtime';
+
+function Component([x]) {
+  x = identity(x);
+  const read = () => x;
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [[42]],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-object-param-to-context-var.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-object-param-to-context-var.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+import {identity} from 'shared-runtime';
+
+function Component({x}) {
+  x = identity(x);
+  const read = () => x;
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: 42}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { identity } from "shared-runtime";
+
+function Component(t0) {
+  const $ = _c(2);
+  let t1;
+  if ($[0] !== t0) {
+    const { x: t2 } = t0;
+    let x = t2;
+    x = identity(x);
+    const read = () => x;
+    t1 = read();
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ x: 42 }],
+};
+
+```
+      
+### Eval output
+(kind: ok) 42

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-object-param-to-context-var.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-object-param-to-context-var.js
@@ -1,0 +1,12 @@
+import {identity} from 'shared-runtime';
+
+function Component({x}) {
+  x = identity(x);
+  const read = () => x;
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{x: 42}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-rest-param-to-context-var.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-rest-param-to-context-var.expect.md
@@ -1,0 +1,51 @@
+
+## Input
+
+```javascript
+import {identity} from 'shared-runtime';
+
+function Component(...[x]) {
+  x = identity(x);
+  const read = () => x;
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [42],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { identity } from "shared-runtime";
+
+function Component(...t0) {
+  const $ = _c(2);
+  let t1;
+  if ($[0] !== t0) {
+    const [t2] = t0;
+    let x = t2;
+    x = identity(x);
+    const read = () => x;
+    t1 = read();
+    $[0] = t0;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  return t1;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [42],
+};
+
+```
+      
+### Eval output
+(kind: ok) 42

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-rest-param-to-context-var.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructure-rest-param-to-context-var.js
@@ -1,0 +1,12 @@
+import {identity} from 'shared-runtime';
+
+function Component(...[x]) {
+  x = identity(x);
+  const read = () => x;
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [42],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reassign-const.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.todo-reassign-const.expect.md
@@ -21,39 +21,43 @@ function Component({foo}) {
 ## Error
 
 ```
-Found 3 errors:
+Found 2 errors:
 
-Todo: Support destructuring of context variables
+Error: Cannot reassign variable after render completes
 
-error.todo-reassign-const.ts:3:20
-  1 | import {Stringify} from 'shared-runtime';
-  2 |
-> 3 | function Component({foo}) {
-    |                     ^^^
-  4 |   let bar = foo.bar;
-  5 |   return (
-  6 |     <Stringify
-
-Todo: Support destructuring of context variables
-
-error.todo-reassign-const.ts:3:20
-  1 | import {Stringify} from 'shared-runtime';
-  2 |
-> 3 | function Component({foo}) {
-    |                     ^^^
-  4 |   let bar = foo.bar;
-  5 |   return (
-  6 |     <Stringify
-
-Error: This value cannot be modified
-
-Modifying component props or hook arguments is not allowed. Consider using a local variable instead.
+Reassigning `foo` after render has completed can cause inconsistent behavior on subsequent renders. Consider using state instead.
 
 error.todo-reassign-const.ts:8:8
    6 |     <Stringify
    7 |       handler={() => {
 >  8 |         foo = true;
-     |         ^^^ `foo` cannot be modified
+     |         ^^^ Cannot reassign `foo` after render completes
+   9 |       }}
+  10 |     />
+  11 |   );
+
+Error: Cannot modify local variables after render completes
+
+This argument is a function which may reassign or mutate `foo` after render, which can cause inconsistent behavior on subsequent renders. Consider using state instead.
+
+error.todo-reassign-const.ts:7:15
+   5 |   return (
+   6 |     <Stringify
+>  7 |       handler={() => {
+     |                ^^^^^^^
+>  8 |         foo = true;
+     | ^^^^^^^^^^^^^^^^^^^
+>  9 |       }}
+     | ^^^^^^^^ This function may (indirectly) reassign or modify `foo` after render
+  10 |     />
+  11 |   );
+  12 | }
+
+error.todo-reassign-const.ts:8:8
+   6 |     <Stringify
+   7 |       handler={() => {
+>  8 |         foo = true;
+     |         ^^^ This modifies `foo`
    9 |       }}
   10 |     />
   11 |   );


### PR DESCRIPTION
Support object, array, and rest parameters whose bindings are captured by nested functions. Destructured parameters now lower through temporaries before storing context bindings, avoiding invalid destructure/context HIR.

Ported from oxc-project/oxc@4e591ed4ed82be2835c81b08dbf097efd905b60e by @Boshen.

## Benchmark

Compared exact `main` base `0bbf02475c7b61a618551f1cf10c9bebf336f285` against PR commit `a5c027c288` using the Criterion harness from `wbinnssmith/rust-compiler-criterion-benchmark` (`ed9ff959b7`, `3a63fa30b9`). Both binaries compiled the same fixed PR-head corpus: 1,812 fixtures, 755,951 source bytes.

Parameters: 20 samples, 2 s warm-up, 10 s measurement, 20 peak-RSS samples.

- `main`: 6.2096-6.2205 ms, peak RSS 7.34 MiB
- PR: 6.1979-6.2254 ms, peak RSS 7.36 MiB
- Relative change: -0.2834% to +0.1955% (95% CI)
- p-value: 0.76, significance threshold 0.05

No statistically significant performance change detected.

## Test plan

- `yarn snap -p destructure-array-param-to-context-var`
- `yarn snap -p destructure-object-param-to-context-var`
- `yarn snap -p destructure-rest-param-to-context-var`
- Rust variants of all three focused fixtures
- `yarn snap --rust` (1,813 passed)
- `cargo check --manifest-path compiler/crates/react_compiler_lowering/Cargo.toml`
- `cargo fmt --check --manifest-path compiler/crates/react_compiler_lowering/Cargo.toml`
- `yarn prettier`
- `yarn linc`
- `git diff --check`