### PR TITLE
oxc port: [correctness] initialize named function expression bindings

### DIFF
--- a/compiler/crates/react_compiler_hir/src/lib.rs
+++ b/compiler/crates/react_compiler_hir/src/lib.rs
@@ -159,6 +159,7 @@ pub fn format_js_number(n: f64) -> String {
 pub struct HirFunction {
     pub loc: Option<SourceLocation>,
     pub id: Option<String>,
+    pub self_binding: Option<Place>,
     pub name_hint: Option<String>,
     pub fn_type: ReactFunctionType,
     pub params: Vec<ParamPattern>,

--- a/compiler/crates/react_compiler_hir/src/reactive.rs
+++ b/compiler/crates/react_compiler_hir/src/reactive.rs
@@ -28,6 +28,7 @@ use crate::{
 pub struct ReactiveFunction {
     pub loc: Option<SourceLocation>,
     pub id: Option<String>,
+    pub self_binding: Option<Place>,
     pub name_hint: Option<String>,
     pub params: Vec<ParamPattern>,
     pub generator: bool,

--- a/compiler/crates/react_compiler_inference/src/analyse_functions.rs
+++ b/compiler/crates/react_compiler_inference/src/analyse_functions.rs
@@ -195,6 +195,7 @@ fn placeholder_function() -> HirFunction {
     HirFunction {
         loc: None,
         id: None,
+        self_binding: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: Vec::new(),

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -75,6 +75,18 @@ pub fn infer_mutation_aliasing_effects(
         initial_state.define(ctx_place.identifier, value_id);
     }
 
+    if let Some(self_binding) = &func.self_binding {
+        let value_id = ValueId::new();
+        initial_state.initialize(
+            value_id,
+            AbstractValue {
+                kind: ValueKind::Mutable,
+                reason: ValueReasonSet::single(ValueReason::Other),
+            },
+        );
+        initial_state.define(self_binding.identifier, value_id);
+    }
+
     let param_kind: AbstractValue = if is_function_expression {
         AbstractValue {
             kind: ValueKind::Mutable,

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_ranges.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_ranges.rs
@@ -498,6 +498,9 @@ pub fn infer_mutation_aliasing_ranges(
     let should_record_errors = !is_function_expression && env.enable_validations();
 
     // Create nodes for params, context vars, and return
+    if let Some(self_binding) = &func.self_binding {
+        state.create(self_binding, NodeValue::Object);
+    }
     for param in &func.params {
         let place = match param {
             react_compiler_hir::ParamPattern::Place(p) => p,

--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -4356,6 +4356,7 @@ pub fn lower(
         scope_id, // component_scope = function_scope for top-level
         &context_identifiers,
         true, // is_top_level
+        false,
         &identifier_locs,
     )?;
 
@@ -5719,6 +5720,7 @@ fn lower_function(
         component_scope,
         &context_ids,
         false, // nested function
+        matches!(expr, Expression::FunctionExpression(_)),
         ident_locs,
     )?;
 
@@ -5794,6 +5796,7 @@ fn lower_function_declaration(
         component_scope,
         &context_ids,
         false, // nested function
+        false,
         ident_locs,
     )?;
 
@@ -5999,6 +6002,7 @@ fn lower_function_for_object_method(
         component_scope,
         &context_ids,
         false, // nested function
+        false,
         ident_locs,
     )?;
 
@@ -6035,6 +6039,7 @@ fn lower_inner(
     component_scope: react_compiler_ast::scope::ScopeId,
     context_identifiers: &FxHashSet<react_compiler_ast::scope::BindingId>,
     is_top_level: bool,
+    is_function_expression: bool,
     identifier_locs: &IdentifierLocIndex,
 ) -> Result<
     (
@@ -6247,6 +6252,30 @@ fn lower_inner(
     // Build the HIR
     let (hir_body, instructions, used_names, child_bindings) = builder.build()?;
 
+    let self_binding = if is_function_expression {
+        id.and_then(|name| {
+            let binding_id = scope_info.scopes[function_scope.0 as usize]
+                .bindings
+                .get(name)?;
+            let has_references = scope_info
+                .ref_node_id_to_binding
+                .iter()
+                .any(|(&node_id, referenced_binding_id)| {
+                    referenced_binding_id == binding_id
+                        && scope_info.bindings[binding_id.0 as usize].declaration_node_id
+                            != Some(node_id)
+                });
+            has_references.then(|| Place {
+                identifier: child_bindings[binding_id],
+                effect: Effect::Unknown,
+                reactive: false,
+                loc: loc.clone(),
+            })
+        })
+    } else {
+        None
+    };
+
     // Create the returns place
     let returns = crate::hir_builder::create_temporary_place(env, loc.clone());
 
@@ -6254,6 +6283,7 @@ fn lower_inner(
         HirFunction {
             loc,
             id: id.map(|s| s.to_string()),
+            self_binding,
             name_hint: None,
             fn_type: if is_top_level {
                 env.fn_type

--- a/compiler/crates/react_compiler_optimization/src/outline_jsx.rs
+++ b/compiler/crates/react_compiler_optimization/src/outline_jsx.rs
@@ -474,6 +474,7 @@ fn emit_outlined_fn(
 
     let outlined_fn = HirFunction {
         id: None,
+        self_binding: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: vec![ParamPattern::Place(props_obj)],

--- a/compiler/crates/react_compiler_reactive_scopes/src/build_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/build_reactive_function.rs
@@ -39,6 +39,7 @@ pub fn build_reactive_function(
     Ok(ReactiveFunction {
         loc: hir.loc,
         id: hir.id.clone(),
+        self_binding: hir.self_binding.clone(),
         name_hint: hir.name_hint.clone(),
         params: hir.params.clone(),
         generator: hir.generator,

--- a/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
+++ b/compiler/crates/react_compiler_reactive_scopes/src/codegen_reactive_function.rs
@@ -754,6 +754,11 @@ fn codegen_reactive_function(
     cx: &mut Context,
     func: &ReactiveFunction,
 ) -> Result<CodegenFunction, CompilerError> {
+    if let Some(self_binding) = &func.self_binding {
+        let declaration_id = cx.env.identifiers[self_binding.identifier.0 as usize].declaration_id;
+        cx.temp.set(declaration_id, None);
+        cx.declare(self_binding.identifier);
+    }
     // Register parameters
     for param in &func.params {
         let place = match param {
@@ -2814,7 +2819,14 @@ fn codegen_function_expression(
             base: BaseNode::typed("FunctionExpression"),
             params: fn_result.params,
             body: fn_result.body,
-            id: name.as_ref().map(|n| make_identifier(n)),
+            id: if let Some(self_binding) = &reactive_fn_mut.self_binding {
+                Some(convert_identifier(
+                    self_binding.identifier,
+                    inner_cx.env,
+                )?)
+            } else {
+                name.as_ref().map(|n| make_identifier(n))
+            },
             generator: fn_result.generator,
             is_async: fn_result.is_async,
             return_type: None,

--- a/compiler/crates/react_compiler_ssa/src/enter_ssa.rs
+++ b/compiler/crates/react_compiler_ssa/src/enter_ssa.rs
@@ -336,6 +336,9 @@ fn enter_ssa_impl(
                     None,
                 ));
             }
+            if let Some(self_binding) = &func.self_binding {
+                func.self_binding = Some(builder.define_place(self_binding, env)?);
+            }
             let params = std::mem::take(&mut func.params);
             let mut new_params = Vec::with_capacity(params.len());
             for param in params {
@@ -507,6 +510,7 @@ pub fn placeholder_function() -> HirFunction {
     HirFunction {
         loc: None,
         id: None,
+        self_binding: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: Vec::new(),

--- a/compiler/crates/react_compiler_ssa/src/rewrite_instruction_kinds_based_on_reassignment.rs
+++ b/compiler/crates/react_compiler_ssa/src/rewrite_instruction_kinds_based_on_reassignment.rs
@@ -145,6 +145,11 @@ pub fn rewrite_instruction_kinds_based_on_reassignment(
         }
     }
 
+    if let Some(place) = &func.self_binding {
+        let ident = &env.identifiers[place.identifier.0 as usize];
+        declarations.insert(ident.declaration_id, DeclarationLoc::ParamOrContext);
+    }
+
     // Process all blocks
     let block_keys: Vec<_> = func.body.blocks.keys().cloned().collect();
     for (block_index, block_id) in block_keys.iter().enumerate() {

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -246,6 +246,12 @@ export function lower(
 
   return {
     id: validatedId,
+    selfBinding:
+      func.isFunctionExpression() &&
+      func.node.id != null &&
+      func.scope.getBinding(func.node.id.name)?.referenced === true
+        ? lowerIdentifier(builder, func.get('id') as NodePath<t.Identifier>)
+        : null,
     nameHint: null,
     params,
     fnType: bindings == null ? env.fnType : 'Other',
@@ -384,7 +390,10 @@ function lowerStatement(
 
       for (const [, binding] of Object.entries(stmt.scope.bindings)) {
         // refs to params are always valid / never need to be hoisted
-        if (binding.kind !== 'param') {
+        if (
+          binding.kind !== 'param' &&
+          binding.path.node.type !== 'FunctionExpression'
+        ) {
           hoistableIdentifiers.add(binding.identifier);
         }
       }

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIR.ts
@@ -59,6 +59,7 @@ export type SourceLocation = t.SourceLocation | typeof GeneratedSource;
 export type ReactiveFunction = {
   loc: SourceLocation;
   id: ValidIdentifierName | null;
+  selfBinding: Place | null;
   nameHint: string | null;
   params: Array<Place | SpreadPattern>;
   generator: boolean;
@@ -282,6 +283,7 @@ export type ReactiveTryTerminal = {
 export type HIRFunction = {
   loc: SourceLocation;
   id: ValidIdentifierName | null;
+  selfBinding: Place | null;
   nameHint: string | null;
   fnType: ReactFunctionType;
   env: Environment;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -120,6 +120,19 @@ export function inferMutationAliasingEffects(
     initialState.define(ref, value);
   }
 
+  if (fn.selfBinding !== null) {
+    const value: InstructionValue = {
+      kind: 'ObjectExpression',
+      properties: [],
+      loc: fn.selfBinding.loc,
+    };
+    initialState.initialize(value, {
+      kind: ValueKind.Mutable,
+      reason: new Set([ValueReason.Other]),
+    });
+    initialState.define(fn.selfBinding, value);
+  }
+
   const paramKind: AbstractValue = isFunctionExpression
     ? {
         kind: ValueKind.Mutable,

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingRanges.ts
@@ -94,6 +94,9 @@ export function inferMutationAliasingRanges(
    * and values that x flowed into.
    */
   const state = new AliasingState();
+  if (fn.selfBinding !== null) {
+    state.create(fn.selfBinding, {kind: 'Object'});
+  }
   type PendingPhiOperand = {from: Place; into: Place; index: number};
   const pendingPhis = new Map<BlockId, Array<PendingPhiOperand>>();
   const mutations: Array<{

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineJsx.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/OutlineJsx.ts
@@ -364,6 +364,7 @@ function emitOutlinedFn(
   const fn: HIRFunction = {
     loc: GeneratedSource,
     id: null,
+    selfBinding: null,
     nameHint: null,
     fnType: 'Other',
     env,

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/BuildReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/BuildReactiveFunction.ts
@@ -46,6 +46,7 @@ export function buildReactiveFunction(fn: HIRFunction): ReactiveFunction {
   return {
     loc: fn.loc,
     id: fn.id,
+    selfBinding: fn.selfBinding,
     nameHint: fn.nameHint,
     params: fn.params,
     generator: fn.generator,

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -334,6 +334,10 @@ function codegenReactiveFunction(
   cx: Context,
   fn: ReactiveFunction,
 ): CodegenFunction {
+  if (fn.selfBinding !== null) {
+    cx.temp.set(fn.selfBinding.identifier.declarationId, null);
+    cx.declare(fn.selfBinding.identifier);
+  }
   for (const param of fn.params) {
     const place = param.kind === 'Identifier' ? param : param.place;
     cx.temp.set(place.identifier.declarationId, null);
@@ -1886,7 +1890,11 @@ function codegenInstructionValue(
         value = t.arrowFunctionExpression(fn.params, body, fn.async);
       } else {
         value = t.functionExpression(
-          instrValue.name != null ? t.identifier(instrValue.name) : null,
+          reactiveFunction.selfBinding !== null
+            ? convertIdentifier(reactiveFunction.selfBinding.identifier)
+            : instrValue.name != null
+              ? t.identifier(instrValue.name)
+              : null,
           fn.params,
           fn.body,
           fn.generator,

--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/EnterSSA.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/EnterSSA.ts
@@ -278,6 +278,9 @@ function enterSSAImpl(
         reason: `Expected function context to be empty for outer function declarations`,
         loc: func.loc,
       });
+      if (func.selfBinding !== null) {
+        func.selfBinding = builder.definePlace(func.selfBinding);
+      }
       func.params = func.params.map(param => {
         if (param.kind === 'Identifier') {
           return builder.definePlace(param);

--- a/compiler/packages/babel-plugin-react-compiler/src/SSA/RewriteInstructionKindsBasedOnReassignment.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/SSA/RewriteInstructionKindsBasedOnReassignment.ts
@@ -49,6 +49,12 @@ export function rewriteInstructionKindsBasedOnReassignment(
       });
     }
   }
+  if (fn.selfBinding !== null) {
+    declarations.set(fn.selfBinding.identifier.declarationId, {
+      kind: InstructionKind.Let,
+      place: fn.selfBinding,
+    });
+  }
   for (const [, block] of fn.body.blocks) {
     for (const instr of block.instructions) {
       const {value} = instr;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/duplicate-named-function-expression-names.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/duplicate-named-function-expression-names.expect.md
@@ -1,0 +1,60 @@
+
+## Input
+
+```javascript
+export function Component({value}) {
+  const columns = [
+    {
+      render: function Render(input) {
+        const copy = input;
+        return copy + value;
+      },
+    },
+    {
+      render: function Render(input) {
+        const copy = input;
+        return copy + value;
+      },
+    },
+  ];
+  return <div>{columns}</div>;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function Component(t0) {
+  const $ = _c(2);
+  const { value } = t0;
+  let t1;
+  if ($[0] !== value) {
+    const columns = [
+      {
+        render: function Render(input) {
+          const copy = input;
+          return copy + value;
+        },
+      },
+      {
+        render: function Render(input_0) {
+          const copy_0 = input_0;
+          return copy_0 + value;
+        },
+      },
+    ];
+    t1 = <div>{columns}</div>;
+    $[0] = value;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  return t1;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/duplicate-named-function-expression-names.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/duplicate-named-function-expression-names.js
@@ -1,0 +1,17 @@
+export function Component({value}) {
+  const columns = [
+    {
+      render: function Render(input) {
+        const copy = input;
+        return copy + value;
+      },
+    },
+    {
+      render: function Render(input) {
+        const copy = input;
+        return copy + value;
+      },
+    },
+  ];
+  return <div>{columns}</div>;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-infer-mutation-aliasing-effects.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bug-infer-mutation-aliasing-effects.expect.md
@@ -29,18 +29,18 @@ export default function useThunkDispatch(state, dispatch, extraArg) {
 ```
 Found 1 error:
 
-Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized
+Error: Cannot access refs during render
 
-<unknown> thunk$14.
+React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
 
-error.bug-infer-mutation-aliasing-effects.ts:10:22
-   8 |     function thunk(action) {
-   9 |       if (typeof action === 'function') {
-> 10 |         return action(thunk, () => stateRef.current, extraArg);
-     |                       ^^^^^ this is uninitialized
-  11 |       } else {
-  12 |         dispatch(action);
-  13 |         return undefined;
+error.bug-infer-mutation-aliasing-effects.ts:5:2
+  3 | export default function useThunkDispatch(state, dispatch, extraArg) {
+  4 |   const stateRef = useRef(state);
+> 5 |   stateRef.current = state;
+    |   ^^^^^^^^^^^^^^^^ Cannot update ref during render
+  6 |
+  7 |   return useCallback(
+  8 |     function thunk(action) {
 ```
           
       

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/named-function-expression-private-binding.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/named-function-expression-private-binding.expect.md
@@ -1,0 +1,45 @@
+
+## Input
+
+```javascript
+export function Component(recursive) {
+  return function recursive(x) {
+    const read = () => recursive;
+    if (x) {
+      return read;
+    }
+    recursive = null;
+    return read;
+  };
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+export function Component(recursive) {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = function recursive_0(x) {
+      const read = () => recursive_0;
+      if (x) {
+        return read;
+      }
+
+      recursive_0 = null;
+      return read;
+    };
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/named-function-expression-private-binding.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/named-function-expression-private-binding.js
@@ -1,0 +1,10 @@
+export function Component(recursive) {
+  return function recursive(x) {
+    const read = () => recursive;
+    if (x) {
+      return read;
+    }
+    recursive = null;
+    return read;
+  };
+}


### PR DESCRIPTION
Initialize referenced named function-expression bindings as private function-entry bindings. This prevents recursive references from reaching mutation inference uninitialized and keeps renaming consistent through HIR, SSA, alias analysis, reactive lowering, and codegen.

Unreferenced private names remain unchanged, preserving observable `Function.name` values.

Ported from:
- oxc-project/oxc@e3c6c4e7392d004a93f0a913dd5a9dd9adfb9174 by @Boshen
- oxc-project/oxc@33d4ed9dec2cdda9da640e1978fc12138ed25677 by @Boshen

## Benchmark

Compared exact `main` base `0bbf02475c7b61a618551f1cf10c9bebf336f285` against PR commit `03d2abbaea` using the Criterion harness from `wbinnssmith/rust-compiler-criterion-benchmark` (`ed9ff959b7`, `3a63fa30b9`). Both binaries compiled the same fixed PR-head corpus: 1,811 fixtures, 755,856 source bytes.

The harness fixes this benchmark at 50 samples, 3 s warm-up, and 30 s measurement; peak RSS used 20 fresh processes.

- `main`: 616.69-665.16 ms, peak RSS mean 193.8 MiB, 95% sample range 192.1-195.4 MiB
- PR: 585.97-597.83 ms, peak RSS mean 190.3 MiB, 95% sample range 185.7-193.3 MiB
- Relative change: -11.152% to -4.0123% (95% CI)
- p-value: <0.01, significance threshold 0.05

Criterion reports a statistically significant improvement. This likely reflects host noise rather than an expected speedup from the small conditional path; the confidence interval and raw ranges are included for transparency.

## Test plan

- `yarn snap -p named-function-expression-private-binding`
- `yarn snap --rust -p named-function-expression-private-binding`
- `yarn snap -p duplicate-named-function-expression-names`
- `yarn snap --rust -p duplicate-named-function-expression-names`
- `yarn snap -p error.bug-infer-mutation-aliasing-effects`
- `yarn snap --rust -p error.bug-infer-mutation-aliasing-effects`
- `yarn snap --rust` (1,812 passed)
- `cargo check --manifest-path compiler/crates/react_compiler/Cargo.toml`
- `cargo fmt --check --manifest-path compiler/crates/react_compiler/Cargo.toml`
- `yarn prettier`
- `yarn linc`
- `git diff --check`