### PR TITLE
[compiler] Recognize optional chains inside try/catch blocks

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectOptionalChainDependencies.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/CollectOptionalChainDependencies.ts
@@ -156,6 +156,42 @@ function traverseFunction(
   }
 }
 /**
+ * `maybe-throw` terminals wrap individual instructions with an edge to the
+ * enclosing try block's exception handler (e.g. every instruction inside a
+ * `try {}` gets its own `maybe-throw`-terminated block). They don't change
+ * the value(s) produced by evaluating the wrapped instruction(s), they just
+ * add a possible early exit to the handler. The structural pattern-matching
+ * below (matching the lowered form of an optional chain, e.g. `a?.b`) was
+ * written assuming instructions are grouped into larger blocks and doesn't
+ * otherwise account for this per-instruction splitting, which previously
+ * caused optional chains inside a `try` block to silently go unrecognized,
+ * losing dependency precision (see
+ * https://github.com/facebook/react/issues/36902). Flatten through any
+ * `maybe-throw` terminals to recover the underlying instruction sequence and
+ * terminal so the existing pattern-matching logic keeps working unchanged
+ * whether or not the code is wrapped in a `try` block.
+ */
+function flattenMaybeThrows(
+  blockId: BlockId,
+  blocks: ReadonlyMap<BlockId, BasicBlock>,
+): BasicBlock | {instructions: Array<Instruction>; terminal: Terminal} {
+  const original = assertNonNull(blocks.get(blockId));
+  if (original.terminal.kind !== 'maybe-throw') {
+    return original;
+  }
+  const instructions: Array<Instruction> = [];
+  let block: BasicBlock = original;
+  const seen = new Set<BlockId>();
+  while (block.terminal.kind === 'maybe-throw' && !seen.has(block.id)) {
+    seen.add(block.id);
+    instructions.push(...block.instructions);
+    block = assertNonNull(blocks.get(block.terminal.continuation));
+  }
+  instructions.push(...block.instructions);
+  return {instructions, terminal: block.terminal};
+}
+
+/**
  * Match the consequent and alternate blocks of an optional.
  * @returns propertyload computed by the consequent block, or null if the
  * consequent block is not a simple PropertyLoad.
@@ -171,7 +207,7 @@ function matchOptionalTestBlock(
   consequentGoto: BlockId;
   propertyLoadLoc: SourceLocation;
 } | null {
-  const consequentBlock = assertNonNull(blocks.get(terminal.consequent));
+  const consequentBlock = flattenMaybeThrows(terminal.consequent, blocks);
   if (
     consequentBlock.instructions.length === 2 &&
     consequentBlock.instructions[0].value.kind === 'PropertyLoad' &&
@@ -204,7 +240,7 @@ function matchOptionalTestBlock(
     ) {
       return null;
     }
-    const alternate = assertNonNull(blocks.get(terminal.alternate));
+    const alternate = flattenMaybeThrows(terminal.alternate, blocks);
 
     CompilerError.invariant(
       alternate.instructions.length === 2 &&
@@ -243,7 +279,7 @@ function traverseOptionalBlock(
   outerAlternate: BlockId | null,
 ): IdentifierId | null {
   context.seenOptionals.add(optional.id);
-  const maybeTest = context.blocks.get(optional.terminal.test)!;
+  const maybeTest = flattenMaybeThrows(optional.terminal.test, context.blocks);
   let test: BranchTerminal;
   let baseObject: ReactiveScopeDependency;
   if (maybeTest.terminal.kind === 'branch') {
@@ -309,7 +345,10 @@ function traverseOptionalBlock(
      * - <inner_optional> <other operation>
      * - a optional base block with a separate nested optional-chain (e.g. a(c?.d)?.d)
      */
-    const testBlock = context.blocks.get(maybeTest.terminal.fallthrough)!;
+    const testBlock = flattenMaybeThrows(
+      maybeTest.terminal.fallthrough,
+      context.blocks,
+    );
     /**
      * Fallthrough of the inner optional should be a block with no
      * instructions, terminating with Test($<temporary written to from

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-optional-chain-in-try-catch.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-optional-chain-in-try-catch.expect.md
@@ -1,0 +1,88 @@
+
+## Input
+
+```javascript
+// @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees
+import {useCallback} from 'react';
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/36902
+ *
+ * Every instruction inside a `try` block is lowered with its own
+ * `maybe-throw` terminal (an edge to the `catch` handler). The optional
+ * chain pattern-matching in CollectOptionalChainDependencies didn't
+ * previously account for this, so a `user?.access_token` read inside a
+ * `try` block failed to be recognized as an optional-chain dependency and
+ * was instead widened to a dependency on the whole `user` object, which
+ * did not match the manually specified `user?.access_token` dependency.
+ */
+function useAccessToken({user}) {
+  const getAccessTokenSilently = useCallback(() => {
+    try {
+      console.log(user?.access_token);
+    } catch (error) {
+      console.error(error);
+    }
+  }, [user?.access_token]);
+
+  return getAccessTokenSilently;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useAccessToken,
+  params: [{user: {access_token: 'abc'}}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees
+import { useCallback } from "react";
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/36902
+ *
+ * Every instruction inside a `try` block is lowered with its own
+ * `maybe-throw` terminal (an edge to the `catch` handler). The optional
+ * chain pattern-matching in CollectOptionalChainDependencies didn't
+ * previously account for this, so a `user?.access_token` read inside a
+ * `try` block failed to be recognized as an optional-chain dependency and
+ * was instead widened to a dependency on the whole `user` object, which
+ * did not match the manually specified `user?.access_token` dependency.
+ */
+function useAccessToken(t0) {
+  const $ = _c(2);
+  const { user } = t0;
+  let t1;
+  if ($[0] !== user?.access_token) {
+    t1 = () => {
+      try {
+        console.log(user?.access_token);
+      } catch (t2) {
+        const error = t2;
+        console.error(error);
+      }
+    };
+    $[0] = user?.access_token;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+
+  user?.access_token;
+  const getAccessTokenSilently = t1;
+
+  return getAccessTokenSilently;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useAccessToken,
+  params: [{ user: { access_token: "abc" } }],
+};
+
+```
+      
+### Eval output
+(kind: ok) "[[ function params=0 ]]"

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-optional-chain-in-try-catch.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/preserve-memo-deps-optional-chain-in-try-catch.js
@@ -1,0 +1,30 @@
+// @enablePreserveExistingMemoizationGuarantees @validatePreserveExistingMemoizationGuarantees
+import {useCallback} from 'react';
+
+/**
+ * Regression test for https://github.com/facebook/react/issues/36902
+ *
+ * Every instruction inside a `try` block is lowered with its own
+ * `maybe-throw` terminal (an edge to the `catch` handler). The optional
+ * chain pattern-matching in CollectOptionalChainDependencies didn't
+ * previously account for this, so a `user?.access_token` read inside a
+ * `try` block failed to be recognized as an optional-chain dependency and
+ * was instead widened to a dependency on the whole `user` object, which
+ * did not match the manually specified `user?.access_token` dependency.
+ */
+function useAccessToken({user}) {
+  const getAccessTokenSilently = useCallback(() => {
+    try {
+      console.log(user?.access_token);
+    } catch (error) {
+      console.error(error);
+    }
+  }, [user?.access_token]);
+
+  return getAccessTokenSilently;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useAccessToken,
+  params: [{user: {access_token: 'abc'}}],
+};


### PR DESCRIPTION
## Summary

Fixes #36902.

React Compiler's dependency inference could infer a *less specific* dependency than the one manually specified whenever an optional-chain read (e.g. `user?.access_token`) occurred inside a `try` block, causing "Existing memoization could not be preserved" compilation errors even though nothing was actually wrong with the source.

## Root cause

Every instruction inside a `try {}` block is lowered to HIR with its own `maybe-throw` terminal — an edge to the enclosing `catch` handler that doesn't change the value produced, but does mean instructions that would otherwise share one basic block each get their own block instead.

`CollectOptionalChainDependencies.ts` recognizes the lowered form of an optional chain (`a?.b`) via structural pattern-matching over specific block shapes (e.g. "the consequent block contains exactly a `PropertyLoad` followed by a `StoreLocal`, terminated by a `goto`"). That matching logic assumed instructions stay grouped into larger blocks and didn't account for the `maybe-throw` splitting that happens inside `try` blocks. So when an optional chain like `user?.access_token` appeared inside a `try` block, the pattern match silently failed, and the read was no longer tracked as an optional-chain dependency at all.

Without that tracking, standard dependency-inference fallback logic in `DeriveMinimalDependenciesHIR.ts` widened the dependency to the whole base object (`user`) instead of the specific property (`user?.access_token`), since it couldn't otherwise prove it was safe to read `.access_token` unconditionally. That's coarser than the manually-specified `[user?.access_token]` dependency, so `ValidatePreservedManualMemoization` correctly (but unnecessarily) flagged it as "Inferred less specific property than source" and skipped optimizing the component.

Confirmed with the reduced repro from the issue:

```jsx
const myCallback = useCallback(() => {
  try {
    console.log(user?.access_token);
  } catch (error) {
    console.error(error);
  }
}, [user?.access_token]);
```

Removing the `try`/`catch` (as noted in the issue) avoids the `maybe-throw` splitting entirely, which is why that "fixed" it — the bug isn't about `try`/`catch` per se, it's that the optional-chain pattern matcher couldn't see through it.

## Fix

Add a small `flattenMaybeThrows` helper in `CollectOptionalChainDependencies.ts` that walks through a chain of `maybe-throw` terminals (as would happen for every instruction inside a `try` block) and returns the concatenated instructions plus the first non-`maybe-throw` terminal reached. Use it wherever the optional-chain matcher inspects a block's instructions/terminal (the test block, and the consequent/alternate blocks), so the existing pattern-matching logic works unchanged whether or not the code is wrapped in a `try` block.

## Testing

- Added `preserve-memo-deps-optional-chain-in-try-catch.js`, a regression test based on the issue's reduced repro. Before this fix it failed to compile with `Existing memoization could not be preserved`; after the fix it compiles with `$[0] !== user?.access_token`, matching the source dependency exactly.
- `yarn workspace babel-plugin-react-compiler lint` — passes.
- `yarn workspace babel-plugin-react-compiler jest` — all 43 tests pass.
- `yarn workspace snap run snap` (full compiler fixture suite) — all 1811 tests pass, no regressions.

## Scope note

This fixes the specific, confirmed mechanism described in the issue and reduced by @MonstraG (an optional-chain read losing precision because it's inside a `try` block). The original issue's fuller repro also re-reads the same property a second time, non-optionally, in a separate statement inside the guarded `if`/`try` body (`user.access_token`, after already checking `user?.access_token`) — that pattern hits a related but distinct and pre-existing imprecision in how dependencies are merged when a property can't be proven safe to read unconditionally, independent of `try`/`catch`. That's a separate, larger change and is not addressed by this PR.