### PR TITLE
[DevTools] Skip tree base duration updates for missing commit-tree fibers

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingCommitTreeBuilder-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCommitTreeBuilder-test.js
@@ -9,6 +9,8 @@
 
 import type Store from 'react-devtools-shared/src/devtools/store';
 
+import {TREE_OPERATION_UPDATE_TREE_BASE_DURATION} from 'react-devtools-shared/src/constants';
+import {invalidateCommitTrees} from 'react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder';
 import {getVersionedRenderImplementation} from './utils';
 
 describe('commit tree', () => {
@@ -259,5 +261,30 @@ describe('commit tree', () => {
         });
       }
     });
+  });
+
+  // @reactVersion >= 16.9
+  it('should ignore tree base duration updates for fibers missing from the commit tree', () => {
+    const MissingDurationFiberID = 731;
+
+    utils.act(() => store.profilerStore.startProfiling());
+    utils.act(() => render(<div />));
+    utils.act(() => store.profilerStore.stopProfiling());
+
+    const rootID = store.roots[0];
+    const dataForRoot = store.profilerStore.getDataForRoot(rootID);
+    const firstCommitOperations = dataForRoot.operations[0];
+    dataForRoot.operations[0] = firstCommitOperations.concat([
+      TREE_OPERATION_UPDATE_TREE_BASE_DURATION,
+      MissingDurationFiberID,
+      500,
+    ]);
+    invalidateCommitTrees();
+
+    const commitTree = store.profilerStore.profilingCache.getCommitTree({
+      commitIndex: 0,
+      rootID,
+    });
+    expect(commitTree.nodes.has(MissingDurationFiberID)).toBe(false);
   });
 });

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -352,9 +352,19 @@ function updateTree(
       }
       case TREE_OPERATION_UPDATE_TREE_BASE_DURATION: {
         id = operations[i + 1];
+        const treeBaseDuration = operations[i + 2] / 1000; // Convert microseconds back to milliseconds
+        i += 3;
+
+        // Imported profiles (and some live sessions) can include duration
+        // updates for fibers that are no longer in this commit snapshot.
+        // Skipping keeps the rest of the commit playable; throwing here
+        // aborts getCommitTree for every later commit as well.
+        if (!nodes.has(id)) {
+          break;
+        }
 
         const node = getClonedNode(id);
-        node.treeBaseDuration = operations[i + 2] / 1000; // Convert microseconds back to milliseconds;
+        node.treeBaseDuration = treeBaseDuration;
 
         // $FlowFixMe[constant-condition]
         if (__DEBUG__) {
@@ -364,7 +374,6 @@ function updateTree(
           );
         }
 
-        i += 3;
         break;
       }
       case TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS: {


### PR DESCRIPTION
Fixes #35640

## Summary
`CommitTreeBuilder.updateTree` threw `Could not clone the node` when a commit carried `TREE_OPERATION_UPDATE_TREE_BASE_DURATION` for a fiber that was already gone from the snapshot. Rebuilding later commits (including imported profiles) aborted at that point.

`#35718` stopped *recording* durations for disconnected subtrees. Profiles exported before that still contain the stale ops. This change skips a missing-id duration update (leave `treeBaseDuration` as-is) and keeps walking the payload. ADD / REMOVE / REORDER are unchanged.

Replayed the `#35640` attachment (136 commits): first abort was commit 50, fiber 731, duration site; after this skip all 136 commits apply.

## Test plan
- [x] `profilingCommitTreeBuilder-test.js`: append duration for missing fiber `731`; `getCommitTree` does not throw and the id is not inserted
- [x] `yarn test` DevTools `profilingCommitTreeBuilder` (not run in this sparse checkout)