### PR TITLE
[Compiler] Fix refs false positive for obj.prop passed to JSX ref attribute

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -156,6 +156,18 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           ) {
             continue;
           }
+          /*
+           * If the loaded value is itself known to be a ref object (eg an
+           * `obj.prop` passed to a JSX `ref` attribute, which type inference
+           * unifies with the ref type), don't alias it to its base object.
+           * Otherwise the inferred ref type would be attributed to the base
+           * object itself, making every other property load off that object
+           * look like a ref value access during render.
+           * See https://github.com/react/react/issues/37507
+           */
+          if (isUseRefType(lvalue.identifier)) {
+            break;
+          }
           const temp = env.lookup(value.object);
           if (temp != null) {
             env.define(lvalue, temp);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.expect.md
@@ -1,0 +1,85 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+// Regression test for https://github.com/react/react/issues/37507
+// Passing `obj.prop` to a JSX `ref` attribute must not mark every other
+// `obj.*` read as a ref access during render.
+function Component({ctx}) {
+  return (
+    <div ref={ctx.foo}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+function ComponentWithLocal({ctx}) {
+  const r = ctx.inputRef;
+  return (
+    <div ref={r}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+// Regression test for https://github.com/react/react/issues/37507
+// Passing `obj.prop` to a JSX `ref` attribute must not mark every other
+// `obj.*` read as a ref access during render.
+function Component(t0) {
+  const $ = _c(5);
+  const { ctx } = t0;
+  let t1;
+  if ($[0] !== ctx.files.length) {
+    t1 = ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null;
+    $[0] = ctx.files.length;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== ctx.foo || $[3] !== t1) {
+    t2 = <div ref={ctx.foo}>{t1}</div>;
+    $[2] = ctx.foo;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+function ComponentWithLocal(t0) {
+  const $ = _c(5);
+  const { ctx } = t0;
+  const r = ctx.inputRef;
+  let t1;
+  if ($[0] !== ctx.files.length) {
+    t1 = ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null;
+    $[0] = ctx.files.length;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== r || $[3] !== t1) {
+    t2 = <div ref={r}>{t1}</div>;
+    $[2] = r;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.js
@@ -1,0 +1,20 @@
+// @validateRefAccessDuringRender
+// Regression test for https://github.com/react/react/issues/37507
+// Passing `obj.prop` to a JSX `ref` attribute must not mark every other
+// `obj.*` read as a ref access during render.
+function Component({ctx}) {
+  return (
+    <div ref={ctx.foo}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+function ComponentWithLocal({ctx}) {
+  const r = ctx.inputRef;
+  return (
+    <div ref={r}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #37507.

## Summary

Passing `obj.prop` to a JSX `ref` attribute made every other `obj.*` read report `Cannot access refs during render`, in both `babel-plugin-react-compiler` (`validateRefAccessDuringRender`) and the `react-hooks/refs` lint rule.

Root cause: in `ValidateNoRefAccessInRender.ts`, `collectTemporariesSidemap` aliases every `PropertyLoad` temporary (`t = obj.prop`) to its base object, and `Env.set` writes through that alias. Type inference unifies the place passed to a JSX `ref` attribute with the `useRef` object type (`InferTypes.ts`, `JsxExpression` case), so the inferred `Ref` type for `ctx.foo` landed on `ctx` itself instead of the temporary. From then on every `ctx.*` load derived `RefValue`.

Fix: in the `PropertyLoad` case of `collectTemporariesSidemap`, don't alias the temporary when the loaded value is itself known to be a ref object (`isUseRefType(lvalue.identifier)`), mirroring the existing skip for `useRef.current` loads.

## How did you test this change?

- Issue repro (`ref={ctx.foo}` + `ctx.files.length` reads): 3 errors before, 0 after, with correct memoized output. A/B verified by stashing the fix (errors return) and restoring it (errors gone).
- Local-alias (`const r = ctx.inputRef; ref={r}`) and chained (`ref={ctx.a.inputRef}`) variants from the issue: also fixed.
- Genuine violations still error: `ref.current` in render, `props.ref.current`.
- Added regression fixture `allow-jsx-ref-attribute-from-object-prop` (+ snapshot).
- Full compiler fixture suite: 1811/1811 pass. `eslint` and `tsc --noEmit` clean on the changed file.

Known limitation (out of scope): `const ctx = {inputRef, files}` + reading `ctx.files` still errors. That flows through the `ObjectExpression` → `Structure` join, a documented over-approximation ("we don't track types of fields", see fixture `error.invalid-use-ref-added-to-dep-without-type-info` which mandates it). Fixing it would require per-key tracking.