### PR TITLE
[DevTools] Fix inspect highlight overlay misalignment with CSS zoom

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import {getElementDimensions, getNestedBoundingClientRect} from '../utils';
+import {
+  getCumulativeZoom,
+  getElementDimensions,
+  getNestedBoundingClientRect,
+} from '../utils';
 
 import type {Rect} from '../utils';
 import type Agent from 'react-devtools-shared/src/backend/agent';
@@ -56,31 +60,33 @@ class OverlayRect {
     }
   }
 
-  update(box: Rect, dims: any) {
-    boxWrap(dims, 'margin', this.node);
-    boxWrap(dims, 'border', this.border);
-    boxWrap(dims, 'padding', this.padding);
+  update(box: Rect, dims: any, zoom: number = 1) {
+    boxWrap(dims, 'margin', this.node, zoom);
+    boxWrap(dims, 'border', this.border, zoom);
+    boxWrap(dims, 'padding', this.padding, zoom);
 
     assign(this.content.style, {
       height:
-        box.height -
-        dims.borderTop -
-        dims.borderBottom -
-        dims.paddingTop -
-        dims.paddingBottom +
+        (box.height -
+          dims.borderTop -
+          dims.borderBottom -
+          dims.paddingTop -
+          dims.paddingBottom) /
+          zoom +
         'px',
       width:
-        box.width -
-        dims.borderLeft -
-        dims.borderRight -
-        dims.paddingLeft -
-        dims.paddingRight +
+        (box.width -
+          dims.borderLeft -
+          dims.borderRight -
+          dims.paddingLeft -
+          dims.paddingRight) /
+          zoom +
         'px',
     });
 
     assign(this.node.style, {
-      top: box.top - dims.marginTop + 'px',
-      left: box.left - dims.marginLeft + 'px',
+      top: (box.top - dims.marginTop) / zoom + 'px',
+      left: (box.left - dims.marginLeft) / zoom + 'px',
     });
   }
 }
@@ -137,13 +143,16 @@ class OverlayTip {
       Math.round(width) + 'px × ' + Math.round(height) + 'px';
   }
 
-  updatePosition(dims: Box, bounds: Box) {
+  updatePosition(dims: Box, bounds: Box, zoom: number = 1) {
     const tipRect = this.tip.getBoundingClientRect();
     const tipPos = findTipPos(dims, bounds, {
       width: tipRect.width,
       height: tipRect.height,
     });
-    assign(this.tip.style, tipPos.style);
+    assign(this.tip.style, {
+      top: tipPos.top / zoom + 'px',
+      left: tipPos.left / zoom + 'px',
+    });
   }
 }
 
@@ -208,6 +217,15 @@ export default class Overlay {
       this.rects.push(new OverlayRect(this.window.document, this.container));
     }
 
+    // CSS `zoom` scales `position: fixed` overlays a second time (unlike
+    // `transform`), so the coordinates we measure below need to be
+    // compensated by the cumulative zoom before being applied to our
+    // injected overlay elements. We use the first element's ancestor chain
+    // as a representative sample: `zoom` is typically applied once, high up
+    // the tree (e.g. on `<html>`), so all inspected elements share the same
+    // effective zoom in practice.
+    const zoom = getCumulativeZoom(elements[0]);
+
     const outerBox = {
       top: Number.POSITIVE_INFINITY,
       right: Number.NEGATIVE_INFINITY,
@@ -230,7 +248,7 @@ export default class Overlay {
       outerBox.left = Math.min(outerBox.left, box.left - dims.marginLeft);
 
       const rect = this.rects[index];
-      rect.update(box, dims);
+      rect.update(box, dims, zoom);
     });
 
     if (!name) {
@@ -266,6 +284,7 @@ export default class Overlay {
         height: this.tipBoundsWindow.innerHeight,
         width: this.tipBoundsWindow.innerWidth,
       },
+      zoom,
     );
   }
 }
@@ -279,7 +298,7 @@ function findTipPos(
   const tipWidth = Math.max(tipSize.width, 60);
   const margin = 5;
 
-  let top: number | string;
+  let top: number;
   if (dims.top + dims.height + tipHeight <= bounds.top + bounds.height) {
     if (dims.top + dims.height < bounds.top + 0) {
       top = bounds.top + margin;
@@ -296,7 +315,7 @@ function findTipPos(
     top = bounds.top + bounds.height - tipHeight - margin;
   }
 
-  let left: number | string = dims.left + margin;
+  let left: number = dims.left + margin;
   if (dims.left < bounds.left) {
     left = bounds.left + margin;
   }
@@ -304,19 +323,15 @@ function findTipPos(
     left = bounds.left + bounds.width - tipWidth - margin;
   }
 
-  top += 'px';
-  left += 'px';
-  return {
-    style: {top, left},
-  };
+  return {top, left};
 }
 
-function boxWrap(dims: any, what: string, node: HTMLElement) {
+function boxWrap(dims: any, what: string, node: HTMLElement, zoom: number = 1) {
   assign(node.style, {
-    borderTopWidth: dims[what + 'Top'] + 'px',
-    borderLeftWidth: dims[what + 'Left'] + 'px',
-    borderRightWidth: dims[what + 'Right'] + 'px',
-    borderBottomWidth: dims[what + 'Bottom'] + 'px',
+    borderTopWidth: dims[what + 'Top'] / zoom + 'px',
+    borderLeftWidth: dims[what + 'Left'] / zoom + 'px',
+    borderRightWidth: dims[what + 'Right'] / zoom + 'px',
+    borderBottomWidth: dims[what + 'Bottom'] / zoom + 'px',
     borderStyle: 'solid',
   });
 }

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -13,6 +13,7 @@ import type {HostInstance} from '../../types';
 import type Agent from '../../agent';
 
 import {isReactNativeEnvironment} from 'react-devtools-shared/src/backend/utils';
+import {getCumulativeZoom} from '../utils';
 
 // Note these colors are in sync with DevTools Profiler chart colors.
 const COLORS = [
@@ -49,10 +50,20 @@ function drawWeb(nodeToData: Map<HostInstance, Data>) {
 
   const dpr = window.devicePixelRatio || 1;
   const canvasFlow: HTMLCanvasElement = canvas as any as HTMLCanvasElement;
+
+  // CSS `zoom` on an ancestor (e.g. `html { zoom: 0.9 }`) scales this
+  // canvas a second time because, unlike `transform`, Chromium still
+  // applies `zoom` to `position: fixed` descendants. Shrinking/growing the
+  // canvas's CSS size by the same factor keeps it covering the full
+  // viewport and, since that also changes the ratio between the canvas's
+  // (unscaled) backing resolution and its CSS size, it keeps everything we
+  // draw using the already zoom-adjusted rects from `measureNode` aligned
+  // with the elements they represent.
+  const zoom = getCumulativeZoom(window.document.documentElement);
   canvasFlow.width = window.innerWidth * dpr;
   canvasFlow.height = window.innerHeight * dpr;
-  canvasFlow.style.width = `${window.innerWidth}px`;
-  canvasFlow.style.height = `${window.innerHeight}px`;
+  canvasFlow.style.width = `${window.innerWidth / zoom}px`;
+  canvasFlow.style.height = `${window.innerHeight / zoom}px`;
 
   const context = canvasFlow.getContext('2d');
   context.scale(dpr, dpr);

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -76,6 +76,32 @@ export function mergeRectOffsets(rects: Array<Rect>): Rect {
   });
 }
 
+// CSS `zoom` is a non-standard (but broadly supported) property that lets a
+// page rescale part of its layout. Unlike `transform: scale`, Chromium keeps
+// applying an ancestor's `zoom` to `position: fixed` descendants, which means
+// the highlighter/trace-updates overlays we inject into the inspected page
+// (also `position: fixed`) get scaled a second time on top of the already
+// zoom-adjusted coordinates we read via `getBoundingClientRect`/
+// `getComputedStyle`. Callers that assign such coordinates back to a
+// `position: fixed` element need to divide them by this cumulative zoom
+// factor to compensate.
+export function getCumulativeZoom(node: HTMLElement): number {
+  const ownerWindow = getOwnerWindow(node) || window;
+
+  let zoom = 1;
+  let currentElement: ?Element = node;
+  while (currentElement != null) {
+    const nodeZoom = parseFloat(
+      ownerWindow.getComputedStyle(currentElement).zoom,
+    );
+    if (!isNaN(nodeZoom) && nodeZoom > 0) {
+      zoom *= nodeZoom;
+    }
+    currentElement = currentElement.parentElement;
+  }
+  return zoom;
+}
+
 // Calculate a boundingClientRect for a node relative to boundaryWindow,
 // taking into account any offsets caused by intermediate iframes.
 export function getNestedBoundingClientRect(


### PR DESCRIPTION
## Summary

Fixes #36904.

When a page uses the non-standard CSS `zoom` property (e.g. `html { zoom: 0.9 }`), the DevTools "inspect element" highlight overlay and the "highlight updates when components render" trace-updates canvas are visibly offset from the actual element, with the offset growing the further the element is from the viewport origin.

## Root cause

Both `Highlighter/Overlay.js` and `TraceUpdates/canvas.js` inject `position: fixed` nodes into the inspected page's DOM and position them using coordinates from `getBoundingClientRect()`/`getComputedStyle()`.

Those coordinates are already relative to the zoomed viewport, but in Chromium, CSS `zoom` on an ancestor (unlike `transform: scale`) also rescales `position: fixed` descendants. So when `body { zoom: 0.9 }`:

- `getBoundingClientRect()` returns e.g. `top: 450px` (already zoom-adjusted, viewport-relative)
- Our overlay element sets `position: fixed; top: 450px` *inside* the zoomed page
- Chromium renders it at `450 * 0.9 = 405px`, i.e. 45px off

The browser's native element inspector isn't affected because it renders outside the page's CSS coordinate system entirely.

## Fix

- Added `getCumulativeZoom(node)` to `views/utils.js`, which walks the element's ancestor chain and multiplies together each ancestor's computed `zoom` value (defaulting to `1` when zoom is not used).
- `Highlighter/Overlay.js`: compute the cumulative zoom once per `inspect()` call (from the first inspected element's ancestor chain) and divide all coordinates/sizes assigned to the `position: fixed` overlay elements (rect, borders, tooltip position) by it, compensating for Chromium's double-scaling.
- `TraceUpdates/canvas.js`: adjust the trace-updates canvas's CSS width/height (but not its backing-store resolution, which stays keyed off `devicePixelRatio`) by the same cumulative zoom factor, since the canvas element is also `position: fixed` and gets rescaled the same way; the rects drawn onto it are left untouched since they already come from zoom-adjusted `getBoundingClientRect()` values that match the (pre-rescale) canvas coordinate space.

This is a targeted fix for zoom scoped to these two files, per the discussion in #36904. It does not attempt the broader highlighting-system unification tracked in #36787; if that unification lands, this zoom handling should move there.

## How I tested

- `yarn prettier` / `yarn lint` — clean.
- `yarn flow dom-browser` — no new errors (pre-existing unrelated `react-devtools-facade` module-resolution errors are present on `main` as well, verified via `git stash`).
- Manually reasoned through the coordinate math for both nested `iframe` and non-`iframe` cases; `getCumulativeZoom` defaults to `1` (no-op) when `zoom` isn't set anywhere in the ancestor chain, so pages without CSS `zoom` are unaffected.