### PR TITLE
Warn when textarea switches from uncontrolled to controlled

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -82,6 +82,7 @@ import {
 
 let didWarnControlledToUncontrolled = false;
 let didWarnUncontrolledToControlled = false;
+let didWarnTextareaUncontrolledToControlled = false;
 let didWarnFormActionType = false;
 let didWarnFormActionName = false;
 let didWarnFormActionTarget = false;
@@ -1849,6 +1850,22 @@ export function updateProperties(
                 );
             }
           }
+        }
+      }
+      if (__DEV__) {
+        if (
+          lastProps.value == null &&
+          nextProps.value != null &&
+          !didWarnTextareaUncontrolledToControlled
+        ) {
+          console.error(
+            'A component is changing an uncontrolled textarea to be controlled. ' +
+              'This is likely caused by the value changing from undefined to ' +
+              'a defined value, which should not happen. ' +
+              'Decide between using a controlled or uncontrolled textarea ' +
+              'element for the lifetime of the component. More info: https://react.dev/link/controlled-components',
+          );
+          didWarnTextareaUncontrolledToControlled = true;
         }
       }
       updateTextarea(domElement, value, defaultValue);

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -520,6 +520,25 @@ describe('ReactDOMTextarea', () => {
     expect(node.value).toEqual('kitten');
   });
 
+  it('should warn if uncontrolled textarea switches to controlled', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(() => {
+      root.render(<textarea />);
+    });
+    await act(() => {
+      root.render(<textarea value="controlled" onChange={emptyFunction} />);
+    });
+    assertConsoleErrorDev([
+      'A component is changing an uncontrolled textarea to be controlled. ' +
+        'This is likely caused by the value changing from undefined to a defined value, which should not happen. ' +
+        'Decide between using a controlled or uncontrolled textarea element for the lifetime of the component. ' +
+        'More info: https://react.dev/link/controlled-components\n' +
+        '    in textarea (at **)',
+    ]);
+  });
+
   it('should keep value when switching to uncontrolled element if changed', async () => {
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);


### PR DESCRIPTION
## Summary

Adds a development warning when a textarea changes from uncontrolled to controlled, matching the existing input behavior. This catches cases where `value` starts as `undefined` and becomes defined later.

Fixes #16342.

## How did you test this change?

Using Node v20.19.0 from `.nvmrc`:

`yarn test ReactDOMTextarea ReactDOMInput ReactDOMComponent --runInBand` passed 4 suites and 347 tests.

`yarn test --prod --runInBand` passed 325 suites, 6,919 tests, and 195 snapshots.

`yarn prettier`, `yarn lint`, and `yarn flow dom-browser` passed.

`yarn test --runInBand` passed 324 of 325 suites and 6,946 tests. `ReactMultiChildText-test.js` hit its existing 30-second timeout under full-suite load. Rerunning `yarn test ReactMultiChildText --runInBand` passed all 4 tests in 4.1 seconds.