### PR TITLE
[Compiler] Fix JSX ref object property aliasing

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -156,6 +156,9 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           ) {
             continue;
           }
+          if (isUseRefType(lvalue.identifier)) {
+            break;
+          }
           const temp = env.lookup(value.object);
           if (temp != null) {
             env.define(lvalue, temp);

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.expect.md
@@ -1,0 +1,106 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+function Component({ctx}) {
+  return (
+    <div ref={ctx.foo}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+function ComponentWithLocal({ctx}) {
+  const r = ctx.inputRef;
+  return (
+    <div ref={r}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [
+    {
+      ctx: {
+        foo: value => console.log(value?.tagName),
+        files: ['file'],
+      },
+    },
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+function Component(t0) {
+  const $ = _c(5);
+  const { ctx } = t0;
+  let t1;
+  if ($[0] !== ctx.files.length) {
+    t1 = ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null;
+    $[0] = ctx.files.length;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== ctx.foo || $[3] !== t1) {
+    t2 = <div ref={ctx.foo}>{t1}</div>;
+    $[2] = ctx.foo;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+function ComponentWithLocal(t0) {
+  const $ = _c(5);
+  const { ctx } = t0;
+  const r = ctx.inputRef;
+  let t1;
+  if ($[0] !== ctx.files.length) {
+    t1 = ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null;
+    $[0] = ctx.files.length;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== r || $[3] !== t1) {
+    t2 = <div ref={r}>{t1}</div>;
+    $[2] = r;
+    $[3] = t1;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [
+    {
+      ctx: {
+        foo: (value) => {
+          return console.log(value?.tagName);
+        },
+        files: ["file"],
+      },
+    },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div><p>1</p></div>
+logs: ['DIV']

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-from-object-prop.js
@@ -1,0 +1,29 @@
+// @validateRefAccessDuringRender
+function Component({ctx}) {
+  return (
+    <div ref={ctx.foo}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+function ComponentWithLocal({ctx}) {
+  const r = ctx.inputRef;
+  return (
+    <div ref={r}>
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [
+    {
+      ctx: {
+        foo: value => console.log(value?.tagName),
+        files: ['file'],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes #37507.

Passing `obj.prop` to a JSX `ref` attribute caused unrelated reads from the same object to report `Cannot access refs during render`.

`collectTemporariesSidemap` aliases a property-load temporary back to its base object. JSX ref inference correctly marks the loaded property as a ref, but `Env.set` followed that alias and marked the base object as a ref too. Later `obj.*` reads were therefore treated as ref-value accesses.

This change skips that alias when the property-load result is already inferred as a ref. The ref type stays on the loaded value, while the base object remains ordinary. Local aliases still resolve to the ref temporary, and genuine `.current` access validation is unchanged.

The regression fixture covers direct and locally aliased property refs.

## How did you test this change?

- `env -u NO_COLOR yarn snap --sync` — 1811 tests passed, 0 failed
- `yarn eslint packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts` — passed
- `git diff --check` — passed
- The fixture eval renders the unrelated `ctx.files` value and passes a callback through `ctx.foo`; `logs: ['DIV']` verifies React still attaches the rendered DOM node to the original ref.