### PR TITLE
[DOM] fix: apply `autofocus` attribute

### DIFF
--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -159,6 +159,11 @@ const attributes = [
     overrideStringValue: 'off',
     read: getAttribute('autocorrect'),
   },
+  {
+    name: 'autoFocus',
+    tagName: 'input',
+    read: getAttribute('autofocus'),
+  },
   {name: 'autoPlay', tagName: 'video', read: getProperty('autoplay')},
   {
     name: 'autoReverse',

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -694,13 +694,6 @@ function setProp(
       // Noop
       break;
     }
-    case 'autoFocus': {
-      // We polyfill it separately on the client during commit.
-      // We could have excluded it in the property list instead of
-      // adding a special case here, but then it wouldn't be emitted
-      // on server rendering (but we *do* want to emit it in SSR).
-      break;
-    }
     case 'xlinkHref': {
       if (
         value == null ||
@@ -771,6 +764,7 @@ function setProp(
     // Fallthrough for boolean props that don't have a warning for empty strings.
     case 'allowFullScreen':
     case 'async':
+    case 'autoFocus':
     case 'autoPlay':
     case 'controls':
     case 'credentialless':

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -905,6 +905,10 @@ export function commitMount(
     case 'input':
     case 'select':
     case 'textarea':
+      // We started applying the native `autofocus` attribute in 2026,
+      // but kept this polyfill (added in 2016, in
+      // a10131304b59abf68a234f0bc75f38a7bb4013a7)
+      // out of conservativity.
       if (newProps.autoFocus) {
         (
           domElement as any as

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -381,6 +381,8 @@ describe('ReactDOM', () => {
 
       expect(inputFocusedAfterMount).toBe(true);
       expect(focusedElement.tagName).toBe('INPUT');
+      // The native attribute should also be present.
+      expect(focusedElement.autofocus).toBe(true);
     } finally {
       HTMLElement.prototype.focus = originalFocus;
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Fixes https://github.com/react/react/issues/23301.
Supersedes https://github.com/react/react/pull/37328 - that one only fixes the issue for dialogs but not for popovers. And overall such an inconsistency in DOM generation is not nice IMO.

Previously, setting `autoFocus={true}` on the client
would only trigger the React's `element.focus()` polyfill,
but it would not apply the actual `autofocus` attribute.
Let's change that.

With `autofocus` getting more widely adopted by browsers
and getting more complex
(e.g. its interactions with the `<dialog>` element),
it's about time to start migrating away from the polyfill.

This was discussed a bit in
https://github.com/react/react/pull/11192 (2017).

As the comment in `ReactFiberConfigDOM.js`,
this commit does not remove the polyfill.
I decided to keep that for a follow-up
in order to not get stuck in discussions.
But yes, ultimately I think it's about time to get rid of the polyfill.

## How did you test this change?

I added a test which fails without the fix and passes with it.
I did not test the code live otherwise.

Note that I haven't managed to run the whole test suite (`yarn test`). They keep timing out for me.