### PR TITLE
fix: detect setState in useEffect for anonymous component callbacks passed to HOFs

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -1236,6 +1236,13 @@ function getFunctionName(
     // const useHook = () => {};
     id = parent.get('id');
   } else if (
+    parent.isCallExpression() &&
+    parent.parentPath.isVariableDeclarator() &&
+    parent.parentPath.get('init').node === parent.node
+  ) {
+    // const MyComponent = wrap(() => {});
+    id = parent.parentPath.get('id');
+  } else if (
     parent.isAssignmentExpression() &&
     parent.get('right').node === path.node &&
     parent.get('operator') === '='

--- a/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
+++ b/packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
@@ -192,6 +192,22 @@ const tests: CompilerTestCases = {
         },
       ],
     },
+    {
+      name: '[Heuristic] Compiles HOF-wrapped PascalCase component - detects prop mutation',
+      filename: 'component.tsx',
+      code: normalizeIndent`
+        const wrap = (value) => value;
+        const MyComponent = wrap(({a}) => {
+          a.key = 'value';
+          return <div />;
+        });
+      `,
+      errors: [
+        {
+          message: /Modifying component props/,
+        },
+      ],
+    },
   ],
 };
 
@@ -199,3 +215,71 @@ const eslintTester = new ESLintTesterV8({
   parser: require.resolve('@typescript-eslint/parser-v5'),
 });
 eslintTester.run('react-compiler', allRules['immutability'].rule, tests);
+
+// Tests for set-state-in-effect rule with HOF-wrapped components
+// Reproduction test for https://github.com/facebook/react/issues/35910
+const setStateInEffectTests: CompilerTestCases = {
+  valid: [
+    {
+      name: 'Direct component with no setState in effect',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        import { useEffect, useState } from 'react';
+        function DirectComponent() {
+          const [value, setValue] = useState(0);
+          useEffect(() => {
+            console.log(value);
+          }, []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'Direct component with setState in effect',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        import { useEffect, useState } from 'react';
+        function DirectComponent() {
+          const [value, setValue] = useState(0);
+          useEffect(() => {
+            setValue(1);
+          }, []);
+          return <div>{value}</div>;
+        }
+      `,
+      errors: [
+        {
+          message: /Calling setState synchronously within an effect/,
+        },
+      ],
+    },
+    {
+      name: 'Anonymous component callback passed to HOF has setState in effect',
+      filename: 'test.tsx',
+      code: normalizeIndent`
+        import { useEffect, useState } from 'react';
+        const wrap = (value) => value;
+        const WrappedComponent = wrap(() => {
+          const [value, setValue] = useState(0);
+          useEffect(() => {
+            setValue(1);
+          }, []);
+          return <div>{value}</div>;
+        });
+      `,
+      errors: [
+        {
+          message: /Calling setState synchronously within an effect/,
+        },
+      ],
+    },
+  ],
+};
+
+eslintTester.run(
+  'react-compiler-set-state-in-effect',
+  allRules['set-state-in-effect'].rule,
+  setStateInEffectTests,
+);

--- a/packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts
+++ b/packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts
@@ -99,6 +99,7 @@ function checkTopLevelNode(node: ESTree.Node): boolean {
   }
 
   // Handle: const MyComponent = () => {} or const useHook = function() {}
+  // Also handles: const MyComponent = wrap(() => {})
   if (node.type === 'VariableDeclaration') {
     for (const decl of (node as ESTree.VariableDeclaration).declarations) {
       if (decl.id.type === 'Identifier') {
@@ -106,7 +107,8 @@ function checkTopLevelNode(node: ESTree.Node): boolean {
         if (
           init != null &&
           (init.type === 'ArrowFunctionExpression' ||
-            init.type === 'FunctionExpression')
+            init.type === 'FunctionExpression' ||
+            init.type === 'CallExpression')
         ) {
           const name = decl.id.name;
           if (


### PR DESCRIPTION
## Summary

The `react-hooks/set-state-in-effect` ESLint rule was not detecting `setState` calls inside `useEffect` when the component was an anonymous callback passed to a higher-order function (e.g. `const MyComponent = wrap(() => { ... })`).

## Root Cause

`getFunctionName()` in the compiler's `Program.ts` did not handle the HOF pattern where the parent is a `CallExpression` whose parent is a `VariableDeclarator`. This meant the anonymous function was never identified as a component and never compiled/validated by the lint rules.

## Changes

- **`compiler/.../Entrypoint/Program.ts`**: Add HOF pattern handling to `getFunctionName()` so `const MyComponent = wrap(() => {})` resolves the function name to `MyComponent`
- **`packages/eslint-plugin-react-hooks/src/shared/RunReactCompiler.ts`**: Add `CallExpression` to the `mayContainReactCode` heuristic so files with HOF-wrapped components are not skipped
- **`packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts`**: Add test cases for both `set-state-in-effect` and prop mutation detection in HOF-wrapped components

## Test Plan

Ran `packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts` — all 15 tests pass (11 existing + 4 new):
- HOF-wrapped component prop mutation detection (immutability rule)
- Direct component setState in effect detection (set-state-in-effect rule)
- HOF-wrapped component setState in effect detection (set-state-in-effect rule)
- Direct component without setState in effect (valid case)

Also ran `yarn workspace babel-plugin-react-compiler lint` — passes clean.

Fixes https://github.com/facebook/react/issues/35910

Note: This reopens the approach from #35943, which was auto-closed for staleness after being left unreviewed (never rejected on merits). Re-submitting the same fix with the same tests.