### PR TITLE
[rust-compiler] Preserve the invariant error shape through lowering

### DIFF
--- a/compiler/crates/react_compiler_lowering/src/build_hir.rs
+++ b/compiler/crates/react_compiler_lowering/src/build_hir.rs
@@ -1669,16 +1669,14 @@ fn lower_expression(
             );
             Ok(InstructionValue::LoadLocal { place, loc })
         }
-        Expression::ArrowFunctionExpression(_) => Ok(lower_function_to_value(
+        Expression::ArrowFunctionExpression(_) => lower_function_to_value(
             builder,
             expr,
             FunctionExpressionType::ArrowFunctionExpression,
-        )?),
-        Expression::FunctionExpression(_) => Ok(lower_function_to_value(
-            builder,
-            expr,
-            FunctionExpressionType::FunctionExpression,
-        )?),
+        ),
+        Expression::FunctionExpression(_) => {
+            lower_function_to_value(builder, expr, FunctionExpressionType::FunctionExpression)
+        }
         Expression::ObjectExpression(obj) => {
             let loc = convert_opt_loc(&obj.base.loc);
             let mut properties: Vec<ObjectPropertyOrSpread> = Vec::new();
@@ -2588,12 +2586,7 @@ fn lower_block_statement(
     block: &react_compiler_ast::statements::BlockStatement,
     parent_scope: Option<react_compiler_ast::scope::ScopeId>,
 ) -> Result<(), CompilerError> {
-    Ok(lower_block_statement_inner(
-        builder,
-        block,
-        None,
-        parent_scope,
-    )?)
+    lower_block_statement_inner(builder, block, None, parent_scope)
 }
 
 fn lower_block_statement_with_scope(
@@ -2601,12 +2594,7 @@ fn lower_block_statement_with_scope(
     block: &react_compiler_ast::statements::BlockStatement,
     scope_override: react_compiler_ast::scope::ScopeId,
 ) -> Result<(), CompilerError> {
-    Ok(lower_block_statement_inner(
-        builder,
-        block,
-        Some(scope_override),
-        None,
-    )?)
+    lower_block_statement_inner(builder, block, Some(scope_override), None)
 }
 
 fn lower_block_statement_inner(
@@ -2614,7 +2602,7 @@ fn lower_block_statement_inner(
     block: &react_compiler_ast::statements::BlockStatement,
     scope_override: Option<react_compiler_ast::scope::ScopeId>,
     parent_scope: Option<react_compiler_ast::scope::ScopeId>,
-) -> Result<(), CompilerDiagnostic> {
+) -> Result<(), CompilerError> {
     use react_compiler_ast::scope::BindingKind as AstBindingKind;
     use react_compiler_ast::statements::Statement;
 
@@ -2995,7 +2983,7 @@ fn lower_statement(
     stmt: &react_compiler_ast::statements::Statement,
     label: Option<&str>,
     parent_scope: Option<react_compiler_ast::scope::ScopeId>,
-) -> Result<(), CompilerDiagnostic> {
+) -> Result<(), CompilerError> {
     use react_compiler_ast::statements::Statement;
 
     match stmt {
@@ -5528,7 +5516,7 @@ fn lower_function_to_value(
     builder: &mut HirBuilder,
     expr: &react_compiler_ast::expressions::Expression,
     expr_type: FunctionExpressionType,
-) -> Result<InstructionValue, CompilerDiagnostic> {
+) -> Result<InstructionValue, CompilerError> {
     use react_compiler_ast::expressions::Expression;
     let loc = match expr {
         Expression::ArrowFunctionExpression(arrow) => convert_opt_loc(&arrow.base.loc),
@@ -5552,7 +5540,7 @@ fn lower_function_to_value(
 fn lower_function(
     builder: &mut HirBuilder,
     expr: &react_compiler_ast::expressions::Expression,
-) -> Result<LoweredFunction, CompilerDiagnostic> {
+) -> Result<LoweredFunction, CompilerError> {
     use react_compiler_ast::expressions::Expression;
 
     // Extract function parts from the AST node
@@ -5595,7 +5583,8 @@ fn lower_function(
                     ErrorCategory::Invariant,
                     "lower_function called with non-function expression",
                     None,
-                ));
+                )
+                .into());
             }
         };
 

--- a/compiler/crates/react_compiler_lowering/tests/catch_binding_invariant.rs
+++ b/compiler/crates/react_compiler_lowering/tests/catch_binding_invariant.rs
@@ -1,0 +1,111 @@
+use react_compiler_ast::scope::ScopeInfo;
+use react_compiler_ast::statements::FunctionDeclaration;
+use react_compiler_diagnostics::{CompilerErrorOrDiagnostic, ErrorCategory};
+use react_compiler_hir::environment::Environment;
+use react_compiler_lowering::{FunctionNode, lower};
+use serde_json::json;
+
+/// A destructured catch binding is not registered in Babel's scope, so lowering
+/// records an invariant error. The error propagates as a flat `CompilerErrorDetail`,
+/// which the logger serializes as `detail.loc` like the TS reference does, rather
+/// than as a diagnostic with nested `detail.details`.
+#[test]
+fn destructured_catch_binding_keeps_flat_error_detail() {
+    let catch_param = json!({
+        "type": "ObjectPattern",
+        "start": 34,
+        "end": 42,
+        "properties": [{
+            "type": "ObjectProperty",
+            "start": 35,
+            "end": 41,
+            "computed": false,
+            "shorthand": true,
+            "key": { "type": "Identifier", "name": "status", "start": 35, "end": 41 },
+            "value": {
+                "type": "Identifier",
+                "name": "status",
+                "start": 35,
+                "end": 41,
+                "loc": {
+                    "start": { "line": 3, "column": 11, "index": 35 },
+                    "end": { "line": 3, "column": 17, "index": 41 }
+                }
+            }
+        }]
+    });
+    let try_stmt = json!({
+        "type": "TryStatement",
+        "start": 19,
+        "end": 58,
+        "block": { "type": "BlockStatement", "start": 23, "end": 26, "body": [], "directives": [] },
+        "handler": {
+            "type": "CatchClause",
+            "start": 27,
+            "end": 58,
+            "param": catch_param,
+            "body": {
+                "type": "BlockStatement", "start": 44, "end": 58, "body": [], "directives": []
+            }
+        },
+        "finalizer": null
+    });
+    let func: FunctionDeclaration = serde_json::from_value(json!({
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 60,
+        "id": { "type": "Identifier", "name": "Foo", "start": 9, "end": 12 },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+            "type": "BlockStatement",
+            "start": 15,
+            "end": 60,
+            "directives": [],
+            "body": [try_stmt]
+        }
+    }))
+    .unwrap();
+
+    let scope_info: ScopeInfo = serde_json::from_value(json!({
+        "scopes": [
+            { "id": 0, "parent": null, "kind": "program", "bindings": { "Foo": 0 } },
+            { "id": 1, "parent": 0, "kind": "function", "bindings": {} }
+        ],
+        "bindings": [
+            {
+                "id": 0,
+                "name": "Foo",
+                "kind": "hoisted",
+                "scope": 0,
+                "declarationType": "FunctionDeclaration"
+            }
+        ],
+        "nodeToScope": { "0": 1 },
+        "referenceToBinding": {},
+        "programScope": 0
+    }))
+    .unwrap();
+
+    let mut env = Environment::new();
+    let err = lower(
+        &FunctionNode::FunctionDeclaration(&func),
+        None,
+        &scope_info,
+        &mut env,
+    )
+    .expect_err("expected lowering to fail on the destructured catch binding");
+
+    match err.details.as_slice() {
+        [CompilerErrorOrDiagnostic::ErrorDetail(detail)] => {
+            assert_eq!(detail.category, ErrorCategory::Invariant);
+            assert_eq!(
+                detail.reason,
+                "(BuildHIR::lowerAssignment) Could not find binding for declaration."
+            );
+            assert!(detail.loc.is_some(), "expected a location on the detail");
+        }
+        other => panic!("expected a single flat ErrorDetail, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

The Rust compiler logs `CompileError` events for lowering invariants in a different shape than the TS reference. For `error.bug-invariant-couldnt-find-binding-for-decl.js` the TS plugin puts the location directly on `detail.loc`, while Rust nests it under `detail.details[0].loc`.

`record_error` hands back the invariant as a `CompilerError` holding a flat `CompilerErrorDetail`, but `lower_statement`, `lower_block_statement_inner`, `lower_function` and `lower_function_to_value` all returned `Result<_, CompilerDiagnostic>`. The `?` operator therefore routed the error through `CompilerDiagnostic::from_detail`, which moves the location into a sub-detail, and it went back into a `CompilerError` in that shape. Returning `CompilerError` from those four functions drops the round trip and leaves the detail alone.

Fixes #37533

## How did you test this change?

Run from the repository root:

- `bash compiler/scripts/test-e2e.sh --variant babel`: events go from 1807/1810 to 1808/1810. The two that still fail (`fbt/error.todo-locally-require-fbt.js` and `todo-hoist-type-alias-before-declaration.js`) were already failing before this change.
- `cargo test --manifest-path compiler/Cargo.toml --workspace`, including a new lowering test that fails without the change.
- `bash compiler/scripts/test-babel-ast.sh`, `bash compiler/scripts/test-rust-port.sh` and `yarn --cwd compiler snap --rust`.
