### PR TITLE
[compiler] Preserve JSX pragmas before generated imports

### DIFF
--- a/compiler/crates/react_compiler/src/entrypoint/imports.rs
+++ b/compiler/crates/react_compiler/src/entrypoint/imports.rs
@@ -6,7 +6,7 @@
  */
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use react_compiler_ast::common::BaseNode;
+use react_compiler_ast::common::{BaseNode, Comment};
 use react_compiler_ast::declarations::{
     ImportDeclaration, ImportKind, ImportSpecifier, ImportSpecifierData, ModuleExportName,
 };
@@ -440,10 +440,43 @@ pub fn add_imports_to_program(program: &mut Program, context: &ProgramContext) {
 
     // Prepend new import statements to the program body
     if !stmts.is_empty() {
+        if let Some(first_statement) = program.body.first_mut() {
+            // Downstream JSX transforms only read pragmas before the first statement.
+            // Keep other annotations attached to their original statement.
+            let pragmas = first_statement.take_leading_comments_if(is_jsx_pragma);
+            let base = match &mut stmts[0] {
+                Statement::ImportDeclaration(s) => &mut s.base,
+                Statement::VariableDeclaration(s) => &mut s.base,
+                _ => unreachable!("generated imports are import or require declarations"),
+            };
+            base.leading_comments = Some(pragmas);
+        }
         let mut new_body = stmts;
         new_body.append(&mut program.body);
         program.body = new_body;
     }
+}
+
+fn is_jsx_pragma(comment: &Comment) -> bool {
+    let (Comment::CommentBlock(data) | Comment::CommentLine(data)) = comment;
+    // Match /@jsx(?:ImportSource|Runtime|Frag)?\s/ in Imports.ts, including JS whitespace.
+    data.value.match_indices("@jsx").any(|(index, _)| {
+        ["ImportSource", "Runtime", "Frag", ""]
+            .iter()
+            .any(|suffix| {
+                data.value[index + 4..]
+                    .strip_prefix(suffix)
+                    .is_some_and(|rest| {
+                        rest.starts_with(|c| {
+                            matches!(c,
+                                '\u{9}'..='\u{d}' | ' ' | '\u{a0}' | '\u{1680}' |
+                                '\u{2000}'..='\u{200a}' | '\u{2028}' | '\u{2029}' |
+                                '\u{202f}' | '\u{205f}' | '\u{3000}' | '\u{feff}'
+                            )
+                        })
+                    })
+            })
+    })
 }
 
 /// Create an ImportSpecifier AST node from a NonLocalImportSpecifier.
@@ -506,5 +539,76 @@ pub fn get_react_compiler_runtime_module(target: &CompilerTarget) -> String {
         CompilerTarget::MetaInternal { runtime_module, .. } => runtime_module.clone(),
         // Default to React 19 runtime for unrecognized versions
         CompilerTarget::Version(_) => "react/compiler-runtime".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn preserves_jsx_pragmas_before_generated_imports() {
+        let pragmas = json!([
+            {"type": "CommentBlock", "value": "* @jsxImportSource custom-jsx "},
+            {"type": "CommentLine", "value": " @jsxRuntime\tautomatic"},
+            {"type": "CommentBlock", "value": "* @jsx customJsx "},
+            {"type": "CommentBlock", "value": "* @jsxFrag\u{feff}CustomFragment "}
+        ]);
+        let annotations = json!([
+            {"type": "CommentLine", "value": " Keep this annotation with the statement."},
+            {"type": "CommentBlock", "value": " @jsxImportSourceSuffix custom-jsx "},
+            {"type": "CommentBlock", "value": " @jsx"},
+            {"type": "CommentBlock", "value": " @jsx\u{85}customJsx "}
+        ]);
+        for source_type in ["module", "script"] {
+            for statement in [
+                json!({"type": "EmptyStatement"}),
+                json!({"type": "ExportDefaultDeclaration", "declaration": {"type": "Identifier", "name": "Component"}}),
+                json!({"type": "TSNamespaceExportDeclaration", "id": {"type": "Identifier", "name": "Library"}}),
+                json!({"type": "ImportDeclaration", "specifiers": [], "source": {"type": "StringLiteral", "value": "react/compiler-runtime"}}),
+            ] {
+                let mut statement = statement;
+                let comments: Vec<_> = pragmas
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .zip(annotations.as_array().unwrap())
+                    .flat_map(|(a, b)| [a.clone(), b.clone()])
+                    .collect();
+                statement["leadingComments"] = json!(comments);
+                let mut program: Program = serde_json::from_value(json!({
+                    "type": "Program", "sourceType": source_type, "body": [statement]
+                }))
+                .unwrap();
+                let opts = serde_json::from_value(json!({
+                    "shouldCompile": true, "enableReanimated": false, "isDev": false
+                }))
+                .unwrap();
+                let mut context = ProgramContext::new(opts, None, None, vec![], false);
+                let original = serde_json::to_value(&program).unwrap();
+                add_imports_to_program(&mut program, &context);
+                assert_eq!(serde_json::to_value(&program).unwrap(), original);
+                context.add_memo_cache_import();
+                add_imports_to_program(&mut program, &context);
+                let output = serde_json::to_value(&program).unwrap();
+                if statement["type"] == "ImportDeclaration" {
+                    assert_eq!(output["body"][0]["leadingComments"], json!(comments));
+                    assert_eq!(program.body.len(), 1);
+                } else {
+                    assert_eq!(output["body"][0]["leadingComments"], pragmas);
+                    assert_eq!(output["body"][1]["leadingComments"], annotations);
+                    let mut expected = statement.clone();
+                    expected["leadingComments"] = annotations.clone();
+                    assert_eq!(
+                        output["body"][1],
+                        serde_json::to_value(
+                            serde_json::from_value::<Statement>(expected).unwrap()
+                        )
+                        .unwrap()
+                    );
+                }
+            }
+        }
     }
 }

--- a/compiler/crates/react_compiler_ast/src/statements.rs
+++ b/compiler/crates/react_compiler_ast/src/statements.rs
@@ -5,6 +5,7 @@ use serde::Serializer;
 use serde::de::Error as _;
 
 use crate::common::BaseNode;
+use crate::common::Comment;
 use crate::common::RawNode;
 use crate::expressions::Expression;
 use crate::expressions::Identifier;
@@ -218,6 +219,39 @@ macro_rules! known_statements {
             fn from(value: KnownStatement) -> Self {
                 match value {
                     $(KnownStatement::$variant(s) => Statement::$variant(s),)+
+                }
+            }
+        }
+
+        impl Statement {
+            /// Remove matching leading comments, preserving their order.
+            pub fn take_leading_comments_if(
+                &mut self,
+                mut predicate: impl FnMut(&Comment) -> bool,
+            ) -> Vec<Comment> {
+                let mut take = |comments: &mut Option<Vec<Comment>>| {
+                    comments.as_mut().map_or_else(Vec::new, |comments| {
+                        let (taken, kept) = std::mem::take(comments)
+                            .into_iter().partition(&mut predicate);
+                        *comments = kept;
+                        taken
+                    })
+                };
+                match self {
+                    $(Statement::$variant(s) => take(&mut s.base.leading_comments),)+
+                    Statement::Unknown(s) => {
+                        let mut comments = s.base().leading_comments.clone();
+                        let taken = take(&mut comments);
+                        if !taken.is_empty() {
+                            s.with_raw_mut(|raw| {
+                                let mut value = raw.parse_value();
+                                value["leadingComments"] = serde_json::to_value(comments)
+                                    .expect("comments serialize to JSON");
+                                *raw = RawNode::from_value(&value);
+                            }).expect("updating comments preserves the statement type");
+                        }
+                        taken
+                    }
                 }
             }
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Imports.ts
@@ -313,6 +313,20 @@ export function addImportsToProgram(
       }
     }
   }
+  const firstStatement = path.node.body[0];
+  if (stmts.length !== 0 && firstStatement?.leadingComments != null) {
+    /*
+     * Downstream JSX transforms only read pragmas before the first statement.
+     * Keep them ahead of generated imports without moving statement annotations.
+     */
+    const jsxPragma = /@jsx(?:ImportSource|Runtime|Frag)?\s/;
+    stmts[0].leadingComments = firstStatement.leadingComments.filter(comment =>
+      jsxPragma.test(comment.value),
+    );
+    firstStatement.leadingComments = firstStatement.leadingComments.filter(
+      comment => !jsxPragma.test(comment.value),
+    );
+  }
   path.unshiftContainer('body', stmts);
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Imports-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Imports-test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {transformSync} from '@babel/core';
+import * as ts from 'typescript';
+import BabelPluginReactCompiler from '../Babel/BabelPlugin';
+
+function compile(source: string): string {
+  return transformSync(source, {
+    filename: 'test.tsx',
+    configFile: false,
+    babelrc: false,
+    parserOpts: {plugins: ['jsx', 'typescript']},
+    plugins: [[BabelPluginReactCompiler, {panicThreshold: 'all_errors'}]],
+  })!.code!;
+}
+
+describe('generated imports', () => {
+  it('preserves the JSX import source for downstream TypeScript compilation', () => {
+    const output = compile(`
+      /** @jsxImportSource custom-jsx */
+      export default function Component({children}) {
+        return <div>{children}</div>;
+      }
+    `);
+    expect(output).toContain('react/compiler-runtime');
+    const transformed = ts.transpileModule(output, {
+      compilerOptions: {jsx: ts.JsxEmit.ReactJSX},
+      fileName: 'test.tsx',
+    }).outputText;
+    expect(transformed).toContain('custom-jsx/jsx-runtime');
+  });
+
+  it('preserves classic JSX and fragment factories', () => {
+    const output = compile(`
+      /** @jsx customJsx */
+      /** @jsxFrag CustomFragment */
+      export default function Component({children}) {
+        return <><div>{children}</div></>;
+      }
+    `);
+    expect(output).toContain('react/compiler-runtime');
+    const transformed = ts.transpileModule(output, {
+      compilerOptions: {jsx: ts.JsxEmit.React},
+      fileName: 'test.tsx',
+    }).outputText;
+    expect(transformed).toContain('customJsx(CustomFragment');
+    expect(transformed).not.toContain('React.createElement');
+  });
+
+  it('keeps statement annotations on the original statement', () => {
+    const output = compile(`
+      /** @jsxImportSource custom-jsx */
+      // Keep this annotation with the component.
+      export default function Component({children}) {
+        return <div>{children}</div>;
+      }
+    `);
+    expect(output).toMatch(
+      /\/\/ Keep this annotation with the component\.\nexport default function Component/,
+    );
+    expect(output).toContain('react/compiler-runtime');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #36460.

React Compiler inserts generated imports before leading JSX pragma comments. Downstream TypeScript JSX transforms then ignore those comments, selecting the default runtime or factories instead of the ones requested by the source file.

Move leading JSX pragma comments onto the first generated import so they remain before code. Keep unrelated statement annotations on their original statement.

## How did you test this change?

Added three regression tests: two pass React Compiler output through TypeScript's JSX transform and check the requested runtime and factories; the third checks that unrelated statement annotations stay attached. The two behavioral tests fail against the original implementation and pass with the fix.

Validation in `compiler/packages/babel-plugin-react-compiler`:

- `node node_modules/jest/bin/jest.js --selectProjects main --runInBand`
- `yarn ts-node node_modules/.bin/jest --runInBand --selectProjects 'e2e no forget' 'e2e with forget'` (16 tests passed)
- `node ../snap/dist/main.js --sync` (1,811 fixtures passed)
- `yarn build` and `yarn lint`

After simplifying the implementation and tests, reran `Imports-test` (all three passed), ESLint on `src/Entrypoint/Imports.ts`, Prettier on both changed files, and `git diff --check`.
