### PR TITLE
[rust-compiler] Fix non-ASCII panic in ValidateNoSetStateInEffects

### DIFF
--- a/compiler/crates/react_compiler_validation/src/lib.rs
+++ b/compiler/crates/react_compiler_validation/src/lib.rs
@@ -1,3 +1,5 @@
+mod source_offsets;
+
 pub mod validate_context_variable_lvalues;
 pub mod validate_exhaustive_dependencies;
 pub mod validate_hooks_usage;

--- a/compiler/crates/react_compiler_validation/src/source_offsets.rs
+++ b/compiler/crates/react_compiler_validation/src/source_offsets.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Conversion between the UTF-16 code unit offsets carried by Babel/JS
+//! `SourceLocation` and the UTF-8 byte offsets that Rust string slicing uses.
+
+/// Babel/JS `loc` indices are UTF-16 code unit offsets, but Rust strings are
+/// UTF-8. Converts a UTF-16 offset to a byte offset, returning None if the
+/// offset is out of range or splits a surrogate pair.
+pub(crate) fn utf16_offset_to_byte(code: &str, target: usize) -> Option<usize> {
+    let mut utf16 = 0usize;
+    for (byte_idx, ch) in code.char_indices() {
+        if utf16 == target {
+            return Some(byte_idx);
+        }
+        if utf16 > target {
+            return None; // target fell inside a surrogate pair
+        }
+        utf16 += ch.len_utf16();
+    }
+    (utf16 == target).then_some(code.len())
+}
+
+/// Slices `code` by a UTF-16 code unit range, returning None if either offset
+/// is out of range or splits a surrogate pair.
+pub(crate) fn slice_by_utf16_range(
+    code: &str,
+    start_utf16: usize,
+    end_utf16: usize,
+) -> Option<&str> {
+    if start_utf16 >= end_utf16 {
+        return None;
+    }
+    let start = utf16_offset_to_byte(code, start_utf16)?;
+    // The prefix contributes exactly start_utf16 units, so the delta is valid
+    // relative to the remainder — avoids rescanning from byte 0.
+    let end = start + utf16_offset_to_byte(&code[start..], end_utf16 - start_utf16)?;
+    Some(&code[start..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_offsets_are_byte_offsets() {
+        let code = "const setState = 0;";
+        assert_eq!(utf16_offset_to_byte(code, 0), Some(0));
+        assert_eq!(utf16_offset_to_byte(code, 6), Some(6));
+        assert_eq!(slice_by_utf16_range(code, 6, 14), Some("setState"));
+    }
+
+    #[test]
+    fn bmp_characters_take_three_bytes_and_one_unit() {
+        // Each BMP character here is 3 bytes in UTF-8 but 1 UTF-16 code unit.
+        let code = "// 日本語\nsetState";
+        assert_eq!(utf16_offset_to_byte(code, 3), Some(3));
+        assert_eq!(utf16_offset_to_byte(code, 6), Some(12));
+        assert_eq!(slice_by_utf16_range(code, 7, 15), Some("setState"));
+    }
+
+    #[test]
+    fn astral_characters_take_two_units() {
+        // A surrogate pair is 4 bytes in UTF-8 and 2 UTF-16 code units, so an
+        // implementation counting characters instead of code units diverges here.
+        let code = "🎉🎉setState";
+        assert_eq!(utf16_offset_to_byte(code, 2), Some(4));
+        assert_eq!(utf16_offset_to_byte(code, 4), Some(8));
+        assert_eq!(slice_by_utf16_range(code, 4, 12), Some("setState"));
+    }
+
+    #[test]
+    fn offset_inside_a_surrogate_pair_is_rejected() {
+        let code = "🎉setState";
+        assert_eq!(utf16_offset_to_byte(code, 1), None);
+        assert_eq!(slice_by_utf16_range(code, 1, 10), None);
+    }
+
+    #[test]
+    fn offset_at_end_of_string_resolves() {
+        let code = "🎉ab";
+        assert_eq!(utf16_offset_to_byte(code, 4), Some(code.len()));
+        assert_eq!(slice_by_utf16_range(code, 2, 4), Some("ab"));
+    }
+
+    #[test]
+    fn out_of_range_offset_is_rejected() {
+        let code = "ab";
+        assert_eq!(utf16_offset_to_byte(code, 3), None);
+        assert_eq!(slice_by_utf16_range(code, 0, 5), None);
+    }
+
+    #[test]
+    fn empty_and_inverted_ranges_are_rejected() {
+        let code = "setState";
+        assert_eq!(slice_by_utf16_range(code, 3, 3), None);
+        assert_eq!(slice_by_utf16_range(code, 5, 2), None);
+    }
+}

--- a/compiler/crates/react_compiler_validation/src/validate_no_derived_computations_in_effects.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_no_derived_computations_in_effects.rs
@@ -13,6 +13,8 @@
 use indexmap::{IndexMap, IndexSet};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
+use crate::source_offsets::slice_by_utf16_range;
+
 use react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, CompilerErrorDetail, ErrorCategory,
 };
@@ -57,40 +59,19 @@ fn get_identifier_name_with_loc(
             }
         }
     }
-    // Fall back to extracting from source code using UTF-16 code unit indices.
-    // Babel/JS positions use UTF-16 code unit offsets, but Rust strings are UTF-8,
-    // so we need to convert between the two.
+    // Fall back to extracting from source code. Babel/JS positions are UTF-16
+    // code unit offsets, but Rust strings are UTF-8, so they must be converted
+    // before slicing.
     if let (Some(loc), Some(code)) = (loc, source_code) {
         let start_utf16 = loc.start.index? as usize;
         let end_utf16 = loc.end.index? as usize;
-        if start_utf16 < end_utf16 {
-            // Convert UTF-16 code unit offsets to UTF-8 byte offsets
-            let mut utf16_pos = 0usize;
-            let mut byte_start = None;
-            let mut byte_end = None;
-            for (byte_idx, ch) in code.char_indices() {
-                if utf16_pos == start_utf16 {
-                    byte_start = Some(byte_idx);
-                }
-                if utf16_pos == end_utf16 {
-                    byte_end = Some(byte_idx);
-                    break;
-                }
-                utf16_pos += ch.len_utf16();
-            }
-            // Handle end at the very end of string
-            if utf16_pos == end_utf16 && byte_end.is_none() {
-                byte_end = Some(code.len());
-            }
-            if let (Some(start), Some(end)) = (byte_start, byte_end) {
-                let slice = &code[start..end];
-                if !slice.is_empty()
-                    && slice
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-                {
-                    return Some(slice.to_string());
-                }
+        if let Some(slice) = slice_by_utf16_range(code, start_utf16, end_utf16) {
+            if !slice.is_empty()
+                && slice
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+            {
+                return Some(slice.to_string());
             }
         }
     }

--- a/compiler/crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs
@@ -160,18 +160,40 @@ fn get_identifier_name_with_loc(
     if let Some(IdentifierName::Named(name)) = &ident.name {
         return Some(name.clone());
     }
-    // Fall back to extracting from source code
+    // Fall back to extracting from source code using UTF-16 code unit indices.
+    // Babel/JS positions use UTF-16 code unit offsets, but Rust strings are UTF-8,
+    // so we need to convert between the two.
     if let (Some(loc), Some(code)) = (loc, source_code) {
-        let start_idx = loc.start.index? as usize;
-        let end_idx = loc.end.index? as usize;
-        if start_idx < code.len() && end_idx <= code.len() && start_idx < end_idx {
-            let slice = &code[start_idx..end_idx];
-            if !slice.is_empty()
-                && slice
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-            {
-                return Some(slice.to_string());
+        let start_utf16 = loc.start.index? as usize;
+        let end_utf16 = loc.end.index? as usize;
+        if start_utf16 < end_utf16 {
+            // Convert UTF-16 code unit offsets to UTF-8 byte offsets
+            let mut utf16_pos = 0usize;
+            let mut byte_start = None;
+            let mut byte_end = None;
+            for (byte_idx, ch) in code.char_indices() {
+                if utf16_pos == start_utf16 {
+                    byte_start = Some(byte_idx);
+                }
+                if utf16_pos == end_utf16 {
+                    byte_end = Some(byte_idx);
+                    break;
+                }
+                utf16_pos += ch.len_utf16();
+            }
+            // Handle end at the very end of string
+            if utf16_pos == end_utf16 && byte_end.is_none() {
+                byte_end = Some(code.len());
+            }
+            if let (Some(start), Some(end)) = (byte_start, byte_end) {
+                let slice = &code[start..end];
+                if !slice.is_empty()
+                    && slice
+                        .chars()
+                        .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+                {
+                    return Some(slice.to_string());
+                }
             }
         }
     }

--- a/compiler/crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs
+++ b/compiler/crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs
@@ -14,6 +14,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::source_offsets::slice_by_utf16_range;
 use react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, ErrorCategory,
 };
@@ -160,40 +161,19 @@ fn get_identifier_name_with_loc(
     if let Some(IdentifierName::Named(name)) = &ident.name {
         return Some(name.clone());
     }
-    // Fall back to extracting from source code using UTF-16 code unit indices.
-    // Babel/JS positions use UTF-16 code unit offsets, but Rust strings are UTF-8,
-    // so we need to convert between the two.
+    // Fall back to extracting from source code. Babel/JS positions are UTF-16
+    // code unit offsets, but Rust strings are UTF-8, so they must be converted
+    // before slicing.
     if let (Some(loc), Some(code)) = (loc, source_code) {
         let start_utf16 = loc.start.index? as usize;
         let end_utf16 = loc.end.index? as usize;
-        if start_utf16 < end_utf16 {
-            // Convert UTF-16 code unit offsets to UTF-8 byte offsets
-            let mut utf16_pos = 0usize;
-            let mut byte_start = None;
-            let mut byte_end = None;
-            for (byte_idx, ch) in code.char_indices() {
-                if utf16_pos == start_utf16 {
-                    byte_start = Some(byte_idx);
-                }
-                if utf16_pos == end_utf16 {
-                    byte_end = Some(byte_idx);
-                    break;
-                }
-                utf16_pos += ch.len_utf16();
-            }
-            // Handle end at the very end of string
-            if utf16_pos == end_utf16 && byte_end.is_none() {
-                byte_end = Some(code.len());
-            }
-            if let (Some(start), Some(end)) = (byte_start, byte_end) {
-                let slice = &code[start..end];
-                if !slice.is_empty()
-                    && slice
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-                {
-                    return Some(slice.to_string());
-                }
+        if let Some(slice) = slice_by_utf16_range(code, start_utf16, end_utf16) {
+            if !slice.is_empty()
+                && slice
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+            {
+                return Some(slice.to_string());
             }
         }
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-astral-source.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-astral-source.expect.md
@@ -1,0 +1,44 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+export function useThing({paused}) {
+  const [count, setCount] = useState(0);
+  // 🎉🎉 surrogate pairs: len_utf16() == 2 but len_utf8() == 4 per character
+  useEffect(() => {
+    setCount(1);
+  }, [paused]);
+  return count;
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useEffect, useState } from "react";
+
+export function useThing({ paused }) {
+  const [count, setCount] = useState(0);
+  // 🎉🎉 surrogate pairs: len_utf16() == 2 but len_utf8() == 4 per character
+  useEffect(() => {
+    setCount(1);
+  }, [paused]);
+  return count;
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileError","detail":{"category":"EffectSetState","reason":"Calling setState synchronously within an effect can trigger cascading renders","description":"Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)","severity":"Error","suggestions":null,"details":[{"kind":"error","loc":{"start":{"line":8,"column":4,"index":291},"end":{"line":8,"column":12,"index":299},"filename":"repro-setState-in-effect-astral-source.ts","identifierName":"setCount"},"message":"Avoid calling setState() directly within an effect"}]},"fnLoc":null}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":7,"index":118},"end":{"line":11,"column":1,"index":337},"filename":"repro-setState-in-effect-astral-source.ts"},"fnName":"useThing","memoSlots":3,"memoBlocks":2,"memoValues":2,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-astral-source.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-astral-source.ts
@@ -1,0 +1,11 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useEffect, useState} from 'react';
+
+export function useThing({paused}) {
+  const [count, setCount] = useState(0);
+  // 🎉🎉 surrogate pairs: len_utf16() == 2 but len_utf8() == 4 per character
+  useEffect(() => {
+    setCount(1);
+  }, [paused]);
+  return count;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.expect.md
@@ -1,0 +1,65 @@
+
+## Input
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useCallback, useEffect, useState} from 'react';
+
+export function useOnlineStatus({paused = false}) {
+  const [isOnline, setIsOnline] = useState(true);
+
+  // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
+  useEffect(() => {
+    if (paused) return;
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('offline', handleOffline);
+    return () => window.removeEventListener('offline', handleOffline);
+  }, [paused]);
+
+  // このsetStateはSSAで名前を失うため、ソースコードから名前を復元する経路に入る
+  const reset = useCallback(() => {
+    if (paused) return;
+    setIsOnline(true);
+  }, [paused]);
+
+  return {isOnline, reset};
+}
+
+```
+
+## Code
+
+```javascript
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import { useCallback, useEffect, useState } from "react";
+
+export function useOnlineStatus({ paused = false }) {
+  const [isOnline, setIsOnline] = useState(true);
+
+  // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
+  useEffect(() => {
+    if (paused) return;
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("offline", handleOffline);
+    return () => window.removeEventListener("offline", handleOffline);
+  }, [paused]);
+
+  // このsetStateはSSAで名前を失うため、ソースコードから名前を復元する経路に入る
+  const reset = useCallback(() => {
+    if (paused) return;
+    setIsOnline(true);
+  }, [paused]);
+
+  return { isOnline, reset };
+}
+
+```
+
+## Logs
+
+```
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":7,"index":131},"end":{"line":22,"column":1,"index":702},"filename":"repro-setState-in-effect-non-ascii-source.ts"},"fnName":"useOnlineStatus","memoSlots":8,"memoBlocks":3,"memoValues":4,"prunedMemoBlocks":0,"prunedMemoValues":0}
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.expect.md
@@ -3,26 +3,15 @@
 
 ```javascript
 // @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
-export function useOnlineStatus({paused = false}) {
+export function useThing({paused}) {
   const [isOnline, setIsOnline] = useState(true);
-
-  // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
+  // 非ASCII文字を含むコメント。これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
   useEffect(() => {
-    if (paused) return;
-    const handleOffline = () => setIsOnline(false);
-    window.addEventListener('offline', handleOffline);
-    return () => window.removeEventListener('offline', handleOffline);
-  }, [paused]);
-
-  // このsetStateはSSAで名前を失うため、ソースコードから名前を復元する経路に入る
-  const reset = useCallback(() => {
-    if (paused) return;
     setIsOnline(true);
   }, [paused]);
-
-  return {isOnline, reset};
+  return isOnline;
 }
 
 ```
@@ -31,26 +20,15 @@ export function useOnlineStatus({paused = false}) {
 
 ```javascript
 // @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
-export function useOnlineStatus({ paused = false }) {
+export function useThing({ paused }) {
   const [isOnline, setIsOnline] = useState(true);
-
-  // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
+  // 非ASCII文字を含むコメント。これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
   useEffect(() => {
-    if (paused) return;
-    const handleOffline = () => setIsOnline(false);
-    window.addEventListener("offline", handleOffline);
-    return () => window.removeEventListener("offline", handleOffline);
-  }, [paused]);
-
-  // このsetStateはSSAで名前を失うため、ソースコードから名前を復元する経路に入る
-  const reset = useCallback(() => {
-    if (paused) return;
     setIsOnline(true);
   }, [paused]);
-
-  return { isOnline, reset };
+  return isOnline;
 }
 
 ```
@@ -58,7 +36,8 @@ export function useOnlineStatus({ paused = false }) {
 ## Logs
 
 ```
-{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":7,"index":131},"end":{"line":22,"column":1,"index":702},"filename":"repro-setState-in-effect-non-ascii-source.ts"},"fnName":"useOnlineStatus","memoSlots":8,"memoBlocks":3,"memoValues":4,"prunedMemoBlocks":0,"prunedMemoValues":0}
+{"kind":"CompileError","detail":{"category":"EffectSetState","reason":"Calling setState synchronously within an effect can trigger cascading renders","description":"Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:\n* Update external systems with the latest state from React.\n* Subscribe for updates from some external system, calling setState in a callback function when external state changes.\n\nCalling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect)","severity":"Error","suggestions":null,"details":[{"kind":"error","loc":{"start":{"line":8,"column":4,"index":277},"end":{"line":8,"column":15,"index":288},"filename":"repro-setState-in-effect-non-ascii-source.ts","identifierName":"setIsOnline"},"message":"Avoid calling setState() directly within an effect"}]},"fnLoc":null}
+{"kind":"CompileSuccess","fnLoc":{"start":{"line":4,"column":7,"index":118},"end":{"line":11,"column":1,"index":332},"filename":"repro-setState-in-effect-non-ascii-source.ts"},"fnName":"useThing","memoSlots":3,"memoBlocks":2,"memoValues":2,"prunedMemoBlocks":0,"prunedMemoValues":0}
 ```
       
 ### Eval output

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.ts
@@ -1,22 +1,11 @@
 // @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
-export function useOnlineStatus({paused = false}) {
+export function useThing({paused}) {
   const [isOnline, setIsOnline] = useState(true);
-
-  // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
+  // 非ASCII文字を含むコメント。これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
   useEffect(() => {
-    if (paused) return;
-    const handleOffline = () => setIsOnline(false);
-    window.addEventListener('offline', handleOffline);
-    return () => window.removeEventListener('offline', handleOffline);
-  }, [paused]);
-
-  // このsetStateはSSAで名前を失うため、ソースコードから名前を復元する経路に入る
-  const reset = useCallback(() => {
-    if (paused) return;
     setIsOnline(true);
   }, [paused]);
-
-  return {isOnline, reset};
+  return isOnline;
 }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.ts
@@ -1,0 +1,22 @@
+// @loggerTestOnly @validateNoSetStateInEffects @outputMode:"lint"
+import {useCallback, useEffect, useState} from 'react';
+
+export function useOnlineStatus({paused = false}) {
+  const [isOnline, setIsOnline] = useState(true);
+
+  // 非ASCII文字を含むコメントなので、これ以降はUTF-16のオフセットとUTF-8のバイト位置がずれる
+  useEffect(() => {
+    if (paused) return;
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('offline', handleOffline);
+    return () => window.removeEventListener('offline', handleOffline);
+  }, [paused]);
+
+  // このsetStateはSSAで名前を失うため、ソースコードから名前を復元する経路に入る
+  const reset = useCallback(() => {
+    if (paused) return;
+    setIsOnline(true);
+  }, [paused]);
+
+  return {isOnline, reset};
+}


### PR DESCRIPTION
## Summary

`get_identifier_name_with_loc` reads an identifier's name out of the source when SSA has dropped it. `SourceLocation.index` is a Babel position and counts UTF-16 code units, but the fallback used it to slice a Rust `&str`, which indexes UTF-8 bytes:

```rust
let slice = &code[start_idx..end_idx];
```

These agree only while the source is ASCII. After any non-ASCII character, later offsets are short by the extra bytes, so the slice reads the wrong span, or panics when it lands inside a character:

```
panicked at crates/react_compiler_validation/src/validate_no_set_state_in_effects.rs:168:30:
start byte index 637 is not a char boundary; it is inside 'う' (bytes 636..639 of string)
```

The panic aborts validation for the whole file, so every diagnostic in it is lost.

`validate_no_derived_computations_in_effects.rs` already converts correctly in its own copy of this function. Both were added in #36173 and only one got the UTF-16 handling, so this ports that logic over.

Found through Biome, which embeds these crates for its `useReactCompiler` rule.

## How did you test this change?

Added `repro-setState-in-effect-non-ascii-source.ts`, which panics before this change and compiles cleanly after:

```
bash scripts/test-rust-port.sh ValidateNoSetStateInEffects \
  packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/repro-setState-in-effect-non-ascii-source.ts
```

The non-ASCII comments in it are test input, not documentation; removing them realigns the offsets and the crash disappears.

Everything `compiler_rust.yml` runs is green on macOS arm64, including `scripts/test-rust-port.sh` (1811 passed) and `yarn snap --rust` (1812 passed).
