### PR TITLE
[Flight] Keep an element pending while a referenced row is resolving

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1144,46 +1144,104 @@ function initializeModelChunk<T>(chunk: ResolvedModelChunk<T>): void {
 
   try {
     const value: T = parseModel(response, resolvedModel);
-    // Invoke any listeners added while resolving this model. I.e. cyclic
-    // references. This may or may not fully resolve the model depending on
-    // if they were blocked.
-    const resolveListeners = cyclicChunk.value;
-    if (resolveListeners !== null) {
-      cyclicChunk.value = null;
-      cyclicChunk.reason = null;
-      for (let i = 0; i < resolveListeners.length; i++) {
-        const listener = resolveListeners[i];
-        if (typeof listener === 'function') {
-          listener(value);
+    const handler = initializingHandler;
+    if (handler !== null) {
+      if (handler.errored) {
+        // The handler errored during the parse, so `cyclicChunk` errors with
+        // the same reason. `triggerErrorOnChunk` also rejects the references
+        // that nested parses queued on `cyclicChunk` during the parse. No value
+        // will arrive for them. `initializeDebugChunk` can have errored
+        // `cyclicChunk` before the parse. That error stays.
+        if ((cyclicChunk as any).status === BLOCKED) {
+          triggerErrorOnChunk(response, cyclicChunk, handler.reason);
+        }
+        return;
+      }
+      // Record on the handler which chunk it completes, and with what value,
+      // before the listeners below are examined. `resolveBlockedCycle` walks
+      // from a reference to its handler and on to that handler's chunk. A cycle
+      // that closes through `cyclicChunk` is only found once `handler.chunk` is
+      // `cyclicChunk`.
+      handler.value = value;
+      handler.chunk = cyclicChunk;
+    }
+
+    const listeners = cyclicChunk.value;
+    const rejectListeners = cyclicChunk.reason;
+    cyclicChunk.value = null;
+    cyclicChunk.reason = null;
+    if (listeners !== null) {
+      // These listeners were added to `cyclicChunk` while its model was
+      // parsing. They come from models that were parsed nested inside that
+      // parse and that pointed back at `cyclicChunk`. They fall in two groups.
+      //
+      // A reference whose handler is transitively waiting on `cyclicChunk` is a
+      // cycle. Neither side can complete before the other, so one of them has
+      // to accept the value as it is now. The reference receives the current
+      // object, and the outstanding references fill it in place.
+      //
+      // Every other listener waits. Its handler is not waiting on
+      // `cyclicChunk`, so it can receive the value once the model has resolved
+      // its own references, like any reference into a blocked chunk does.
+      // Handing it the value now would complete that handler with an object
+      // that still has references outstanding. Function listeners have no
+      // handler and always wait.
+      let cyclic: null | Array<InitializationReference> = null;
+      let deferred: null | Array<InitializationReference | (T => mixed)> = null;
+      for (let i = 0; i < listeners.length; i++) {
+        const listener = listeners[i];
+        if (
+          typeof listener !== 'function' &&
+          resolveBlockedCycle(cyclicChunk, listener) !== null
+        ) {
+          if (cyclic === null) {
+            cyclic = [];
+          }
+          cyclic.push(listener);
+          // A reference is queued for rejection as the same object that is
+          // queued for resolution. It is fulfilled below, so its rejection
+          // entry goes.
+          if (rejectListeners !== null) {
+            const rejectionIdx = rejectListeners.indexOf(listener);
+            if (rejectionIdx !== -1) {
+              rejectListeners.splice(rejectionIdx, 1);
+            }
+          }
         } else {
-          fulfillReference(response, listener, value, cyclicChunk);
+          if (deferred === null) {
+            deferred = [];
+          }
+          deferred.push(listener);
+        }
+      }
+      // Put the deferred listeners back on `cyclicChunk` before any cyclic
+      // reference is fulfilled. Fulfilling one can complete `cyclicChunk`, and
+      // completion wakes what is queued on it at that moment.
+      if (deferred !== null) {
+        cyclicChunk.value = deferred;
+        cyclicChunk.reason = rejectListeners;
+      }
+      if (cyclic !== null) {
+        for (let i = 0; i < cyclic.length; i++) {
+          fulfillReference(response, cyclic[i], value, cyclicChunk);
         }
       }
     }
-    if (initializingHandler !== null) {
-      if (initializingHandler.errored) {
-        throw initializingHandler.reason;
-      }
-      if (initializingHandler.deps > 0) {
-        // We discovered new dependencies on modules that are not yet resolved.
-        // We have to keep the BLOCKED state until they're resolved.
-        initializingHandler.value = value;
-        initializingHandler.chunk = cyclicChunk;
-        return;
-      }
-    }
-    if (__DEV__) {
-      // Only a blocked chunk receives debug info, so release the set here.
-      cyclicChunk._receivedDebugInfo = null;
-    }
-    const initializedChunk: InitializedChunk<T> = chunk as any;
-    initializedChunk.status = INITIALIZED;
-    initializedChunk.value = value;
-    initializedChunk.reason = null;
 
-    if (__DEV__) {
-      processChunkDebugInfo(response, initializedChunk, value);
+    if ((cyclicChunk as any).status !== BLOCKED) {
+      // Fulfilling a cyclic reference completed `cyclicChunk`, or failed and
+      // errored it. A failure rejects the reference's handler. The rejection
+      // reaches `cyclicChunk`, directly or through the cycle, because
+      // `handler.chunk` is set.
+      return;
     }
+    if (handler !== null && handler.deps > 0) {
+      // The model references chunks that have not resolved yet. `cyclicChunk`
+      // stays BLOCKED, with the deferred listeners queued on it, until the last
+      // of those resolves.
+      return;
+    }
+    initializeBlockedChunk(response, cyclicChunk, value, null);
   } catch (error) {
     const erroredChunk: ErroredChunk<T> = chunk as any;
     erroredChunk.status = ERRORED;
@@ -1622,6 +1680,50 @@ function getWeakChunk(response: Response, id: number): SomeChunk<any> {
   return chunk;
 }
 
+// Moves a blocked chunk to INITIALIZED and wakes whatever is waiting on it. The
+// other `initialize*Chunk` functions start from a resolved chunk and parse it.
+// This one starts from a chunk whose model is already parsed and whose
+// references have all resolved.
+function initializeBlockedChunk<T>(
+  response: Response,
+  chunk: BlockedChunk<T>,
+  value: T,
+  reason: any,
+): void {
+  const resolveListeners = chunk.value;
+  if (__DEV__) {
+    // Only a blocked chunk receives debug info, so release the set here.
+    chunk._receivedDebugInfo = null;
+  }
+  const initializedChunk: InitializedChunk<T> = chunk as any;
+  initializedChunk.status = INITIALIZED;
+  initializedChunk.value = value;
+  initializedChunk.reason = reason;
+  if (resolveListeners !== null) {
+    wakeChunk(response, resolveListeners, value, initializedChunk);
+  } else if (__DEV__) {
+    processChunkDebugInfo(response, initializedChunk, value);
+  }
+}
+
+// Initializes the handler's chunk once the handler has no references left to
+// wait on. `handler.chunk` is null while the handler's model is still parsing.
+// `initializeModelChunk` handles that case when the parse ends.
+function initializeChunkIfUnblocked(
+  response: Response,
+  handler: InitializationHandler,
+): void {
+  if (handler.deps !== 0 || handler.errored) {
+    return;
+  }
+  const chunk = handler.chunk;
+  if (chunk === null || chunk.status !== BLOCKED) {
+    return;
+  }
+  // For a stream chunk, `handler.reason` holds its controller.
+  initializeBlockedChunk(response, chunk, handler.value, handler.reason);
+}
+
 function fulfillReference(
   response: Response,
   reference: InitializationReference,
@@ -1809,29 +1911,7 @@ function fulfillReference(
   }
 
   handler.deps--;
-
-  if (handler.deps === 0) {
-    const chunk = handler.chunk;
-    if (chunk === null || chunk.status !== BLOCKED) {
-      return;
-    }
-    const resolveListeners = chunk.value;
-    if (__DEV__) {
-      // Only a blocked chunk receives debug info, so release the set here.
-      chunk._receivedDebugInfo = null;
-    }
-    const initializedChunk: InitializedChunk<any> = chunk as any;
-    initializedChunk.status = INITIALIZED;
-    initializedChunk.value = handler.value;
-    initializedChunk.reason = handler.reason; // Used by streaming chunks
-    if (resolveListeners !== null) {
-      wakeChunk(response, resolveListeners, handler.value, initializedChunk);
-    } else {
-      if (__DEV__) {
-        processChunkDebugInfo(response, initializedChunk, handler.value);
-      }
-    }
-  }
+  initializeChunkIfUnblocked(response, handler);
 }
 
 function rejectReference(
@@ -2067,25 +2147,7 @@ function loadServerReference<A: Iterable<any>, T>(
     }
 
     handler.deps--;
-
-    if (handler.deps === 0) {
-      const chunk = handler.chunk;
-      if (chunk === null || chunk.status !== BLOCKED) {
-        return;
-      }
-      const resolveListeners = chunk.value;
-      const initializedChunk: InitializedChunk<T> = chunk as any;
-      initializedChunk.status = INITIALIZED;
-      initializedChunk.value = handler.value;
-      initializedChunk.reason = null;
-      if (resolveListeners !== null) {
-        wakeChunk(response, resolveListeners, handler.value, initializedChunk);
-      } else {
-        if (__DEV__) {
-          processChunkDebugInfo(response, initializedChunk, handler.value);
-        }
-      }
-    }
+    initializeChunkIfUnblocked(response, handler);
   }
 
   function reject(error: mixed): void {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1021,14 +1021,28 @@ type InitializationReference = {
   path: Array<string>,
   isDebug?: boolean, // DEV-only
 };
-type InitializationHandler = {
+type PendingInitializationHandler = {
   parent: null | InitializationHandler,
   chunk: null | BlockedChunk<any>,
   value: any,
-  reason: any,
+  // The controller of a stream whose chunk is blocked on its debug info. Null
+  // for every other model.
+  reason: null | FlightStreamController,
   deps: number,
-  errored: boolean,
+  errored: false,
 };
+type ErroredInitializationHandler = {
+  parent: null | InitializationHandler,
+  chunk: null | BlockedChunk<any>,
+  value: null,
+  // The error the handler was rejected with.
+  reason: mixed,
+  deps: number,
+  errored: true,
+};
+type InitializationHandler =
+  | PendingInitializationHandler
+  | ErroredInitializationHandler;
 let initializingHandler: null | InitializationHandler = null;
 let initializingChunk: null | BlockedChunk<any> = null;
 let isInitializingDebugInfo: boolean = false;
@@ -1688,7 +1702,7 @@ function initializeBlockedChunk<T>(
   response: Response,
   chunk: BlockedChunk<T>,
   value: T,
-  reason: any,
+  reason: InitializedChunk<T>['reason'],
 ): void {
   const resolveListeners = chunk.value;
   if (__DEV__) {
@@ -1717,10 +1731,18 @@ function initializeChunkIfUnblocked(
     return;
   }
   const chunk = handler.chunk;
-  if (chunk === null || chunk.status !== BLOCKED) {
+  if (chunk === null) {
     return;
   }
-  // For a stream chunk, `handler.reason` holds its controller.
+  // `BlockedChunk` is the chunk's type at the time the handler recorded it.
+  // The chunk can have errored since, or a cyclic reference can have completed
+  // it, so its status is read again here.
+  if ((chunk as SomeChunk<any>).status !== BLOCKED) {
+    return;
+  }
+  // `handler.reason` is the controller of a stream whose chunk was blocked on
+  // its debug info, and null otherwise. It becomes the initialized chunk's
+  // `reason` either way.
   initializeBlockedChunk(response, chunk, handler.value, handler.reason);
 }
 
@@ -1926,9 +1948,10 @@ function rejectReference(
     return;
   }
   const blockedValue = handler.value;
-  handler.errored = true;
-  handler.value = null;
-  handler.reason = error;
+  const erroredHandler: ErroredInitializationHandler = handler as any;
+  erroredHandler.errored = true;
+  erroredHandler.value = null;
+  erroredHandler.reason = error;
   const chunk = handler.chunk;
   if (chunk === null || chunk.status !== BLOCKED) {
     return;
@@ -2158,9 +2181,10 @@ function loadServerReference<A: Iterable<any>, T>(
       return;
     }
     const blockedValue = handler.value;
-    handler.errored = true;
-    handler.value = null;
-    handler.reason = error;
+    const erroredHandler: ErroredInitializationHandler = handler as any;
+    erroredHandler.errored = true;
+    erroredHandler.value = null;
+    erroredHandler.reason = error;
     const chunk = handler.chunk;
     if (chunk === null || chunk.status !== BLOCKED) {
       return;
@@ -2346,9 +2370,11 @@ function getOutlinedModel<T>(
               // This is an error. Instead of erroring directly, we're going to encode this on
               // an initialization handler so that we can catch it at the nearest Element.
               if (initializingHandler) {
-                initializingHandler.errored = true;
-                initializingHandler.value = null;
-                initializingHandler.reason = referencedChunk.reason;
+                const erroredHandler: ErroredInitializationHandler =
+                  initializingHandler as any;
+                erroredHandler.errored = true;
+                erroredHandler.value = null;
+                erroredHandler.reason = referencedChunk.reason;
               } else {
                 initializingHandler = {
                   parent: null,
@@ -2455,9 +2481,11 @@ function getOutlinedModel<T>(
       // This is an error. Instead of erroring directly, we're going to encode this on
       // an initialization handler so that we can catch it at the nearest Element.
       if (initializingHandler) {
-        initializingHandler.errored = true;
-        initializingHandler.value = null;
-        initializingHandler.reason = chunk.reason;
+        const erroredHandler: ErroredInitializationHandler =
+          initializingHandler as any;
+        erroredHandler.errored = true;
+        erroredHandler.value = null;
+        erroredHandler.reason = chunk.reason;
       } else {
         initializingHandler = {
           parent: null,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -3717,4 +3717,79 @@ describe('ReactFlightDOMBrowser', () => {
       expect(taskWhileRendering).toBe('\n"use client"');
     });
   });
+
+  it('rejects a value that waits on a row that fails to parse', async () => {
+    const foo = {};
+    const x = {};
+    // The server outlines a Set into its own row, and that row refers to foo by
+    // id. The client parses the Set's row nested inside foo's row, and queues a
+    // reference from the Set's row back onto foo's row. x is a member of the
+    // Set, so a later reference to x is a path into the Set's row that does not
+    // go through foo's row.
+    const bar = new Set([foo, x]);
+    foo.bar = bar;
+    // The server cannot serialize a function, so the row it outlines for
+    // `foo.broken` is an error row. foo's row refers to that error row.
+    foo.broken = new Set([() => {}]);
+    const object = {
+      foo: Promise.resolve(foo),
+      x: Promise.resolve(x),
+    };
+
+    const stream = await serverAct(() =>
+      ReactServerDOMServer.renderToReadableStream(object, webpackMap, {
+        onError() {},
+      }),
+    );
+    // Error rows come last in the stream. The client parses foo's row when foo
+    // is first read, so the whole stream is delivered as one Uint8Array to make
+    // sure the error row has been processed by then.
+    const reader = stream.getReader();
+    const parts = [];
+    for (;;) {
+      const {done, value} = await reader.read();
+      if (done) {
+        break;
+      }
+      parts.push(value);
+    }
+    const total = parts.reduce((sum, part) => sum + part.byteLength, 0);
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (let i = 0; i < parts.length; i++) {
+      bytes.set(parts[i], offset);
+      offset += parts[i].byteLength;
+    }
+
+    const response = await ReactServerDOMClient.createFromReadableStream(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      }),
+    );
+
+    // Reading foo first parses foo's row, and the nested Set row along with it.
+    // The Set row then waits on foo's row, and foo's row fails on the error
+    // row. The client must reject the reference the Set row queued on foo's
+    // row, so that the Set row errors as well and x errors with the Set row.
+    const fooError = await Promise.resolve(response.foo).then(
+      () => null,
+      error => error,
+    );
+    expect(fooError).toBeInstanceOf(Error);
+    if (__DEV__) {
+      expect(fooError.message).toContain(
+        'Functions cannot be passed directly to Client Components',
+      );
+    }
+    // The error object travels by identity from the error row into every row it
+    // errors, so x rejects with the same object that rejected foo.
+    const xError = await Promise.resolve(response.x).then(
+      () => null,
+      error => error,
+    );
+    expect(xError).toBe(fooError);
+  });
 });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -2485,4 +2485,222 @@ describe('ReactFlightDOMNode', () => {
 
     expect(getEventListeners(composite, 'abort')).toHaveLength(0);
   });
+
+  // Runs an action that makes a Node stream emit, and flushes the ticks inside
+  // the act scope so that act sees the work the delivery triggers. Node streams
+  // hand data over through `process.nextTick`, which the fake timers mock.
+  //
+  // The tests above assert on source line numbers. A definition above them
+  // would shift those, so these helpers stay below them.
+  function actOnStream(action: () => mixed): Promise<void> {
+    return serverAct(() => {
+      action();
+      jest.runAllTicks();
+    });
+  }
+
+  // The Node client resolves client references through a server consumer
+  // manifest, which maps each client module id to the module the SSR bundle
+  // loads for it. These tests use the same module on both sides.
+  function createIdentityServerConsumerManifest(...clientReferences) {
+    const moduleMap = {};
+    for (let i = 0; i < clientReferences.length; i++) {
+      const metadata = webpackMap[clientReferences[i].$$id];
+      moduleMap[metadata.id] = {'*': metadata};
+    }
+    return {moduleMap, moduleLoading: webpackModuleLoading};
+  }
+
+  // @gate __DEV__
+  it('does not expose a debug-tree element whose props still hold an unresolved reference', async () => {
+    // Regression test for facebook/react#37361.
+    //
+    // A server component element sits in its parent's componentInfo. Its props
+    // object is shared with its own componentInfo, so the debug channel
+    // outlines the props into a separate row. The client parses the props row
+    // nested inside the parent's componentInfo row, and registers the element's
+    // reference to the props row while that parse is still running.
+    //
+    // The client must not hand the element the props object at that point. The
+    // props row still waits on a client module reference, and the element is
+    // not part of that wait, so it has to stay a lazy until the props row
+    // completes. An element initialized early carries the null placeholder
+    // where `ClientModule` belongs, which is what DevTools reads. In DEV its
+    // props are also frozen, so the module write that lands later throws, and
+    // the response rejects.
+    //
+    // The Suspense boundary inside PassthroughServerComponent keeps
+    // PassthroughServerComponent's componentInfo on row 0 and moves
+    // AsyncServerComponent's to the outlined row. Row 0 then resolves before
+    // the module loads, and the element is observable through the root's debug
+    // info while its props row is still waiting.
+    const received = [];
+    let resolveClientModuleChunk;
+    const ClientModule = clientExports(
+      {label: 'module'},
+      '43',
+      '/client-module.js',
+      new Promise(resolve => (resolveClientModuleChunk = resolve)),
+    );
+    const ClientComponent = clientExports(function ClientComponent(props) {
+      received.push({
+        module:
+          props.module === null
+            ? 'null'
+            : props.module === undefined
+              ? 'undefined'
+              : 'object',
+        shared:
+          props.shared === null
+            ? 'null'
+            : props.shared === undefined
+              ? 'undefined'
+              : 'object',
+      });
+      return React.createElement('span', null, 'client');
+    });
+
+    const shared = {};
+    const longText = 'a'.repeat(4000);
+
+    let resolveIo;
+    async function AsyncServerComponent(props) {
+      await new Promise(resolve => {
+        resolveIo = resolve;
+      });
+      return ReactServer.createElement(
+        'div',
+        null,
+        longText,
+        ReactServer.createElement(ClientComponent, {
+          shared: props.shared,
+          module: props.ClientModule,
+        }),
+      );
+    }
+
+    function PassthroughServerComponent({children}) {
+      return ReactServer.createElement(
+        ReactServer.Suspense,
+        {fallback: 'loading'},
+        children,
+      );
+    }
+
+    function App() {
+      return ReactServer.createElement(PassthroughServerComponent, {
+        shared,
+        children: ReactServer.createElement(AsyncServerComponent, {
+          shared,
+          ClientModule,
+        }),
+      });
+    }
+
+    let debugText = '';
+    const rscStream = await serverAct(() =>
+      ReactServerDOMServer.renderToPipeableStream(
+        ReactServer.createElement(App, null),
+        webpackMap,
+        {
+          debugChannel: new Stream.Writable({
+            write(chunk, encoding, callback) {
+              debugText += Buffer.from(chunk).toString('utf8');
+              callback();
+            },
+          }),
+        },
+      ),
+    );
+
+    const rscChunks = [];
+    rscStream.pipe(
+      new Stream.Writable({
+        write(chunk, encoding, callback) {
+          rscChunks.push(Buffer.from(chunk));
+          callback();
+        },
+      }),
+    );
+    await actOnStream(() => resolveIo('io'));
+
+    const debugReadable = new Stream.PassThrough(streamOptions);
+    const rscReadable = new Stream.PassThrough(streamOptions);
+    const response = ReactServerDOMClient.createFromNodeStream(
+      rscReadable,
+      createIdentityServerConsumerManifest(ClientComponent, ClientModule),
+      {debugChannel: debugReadable},
+    );
+
+    function ClientRoot() {
+      return use(response);
+    }
+
+    // The SSR render runs ClientComponent, which records the props it receives.
+    const ssrErrors = [];
+    const ssrStream = ReactDOMServer.renderToPipeableStream(
+      React.createElement(ClientRoot),
+      {
+        onError(error) {
+          ssrErrors.push(String(error).slice(0, 80));
+        },
+      },
+    );
+    await actOnStream(() =>
+      ssrStream.pipe(new Stream.PassThrough(streamOptions)),
+    );
+
+    const debugRows = debugText.split('\n');
+    for (let i = 0; i < debugRows.length; i++) {
+      if (debugRows[i].length > 0) {
+        await actOnStream(() => debugReadable.write(debugRows[i] + '\n'));
+      }
+    }
+    await actOnStream(() => debugReadable.end());
+
+    for (let i = 0; i < rscChunks.length; i++) {
+      await actOnStream(() => rscReadable.write(rscChunks[i]));
+    }
+    await actOnStream(() => rscReadable.end());
+
+    // Row 0 resolves before the module loads, because the boundary keeps
+    // AsyncServerComponent's blocked debug chain off it.
+    await expect(response).resolves.toBeDefined();
+    const root = await response;
+
+    const getDebugInfoWithProps =
+      require('internal-test-utils').getDebugInfo.bind(null, {
+        ignoreProps: false,
+        useFixedTime: true,
+      });
+    const unwrap = node => {
+      let current = node;
+      while (
+        current !== null &&
+        typeof current === 'object' &&
+        current.$$typeof === Symbol.for('react.lazy') &&
+        current._payload.status === 'fulfilled'
+      ) {
+        current = current._payload.value;
+      }
+      return current;
+    };
+    const passthroughInfo = getDebugInfoWithProps(root).find(
+      entry => entry.name === 'PassthroughServerComponent',
+    );
+    const asyncServerElement = unwrap(passthroughInfo.props.children);
+
+    // The props row still waits on the module, so the element must still be a
+    // lazy. Without the fix it is already initialized here, with the null
+    // placeholder where `ClientModule` belongs.
+    expect(asyncServerElement.$$typeof).toBe(Symbol.for('react.lazy'));
+
+    await actOnStream(() => resolveClientModuleChunk());
+
+    expect(ssrErrors).toEqual([]);
+    expect(received).toEqual([{module: 'object', shared: 'object'}]);
+    expect(unwrap(passthroughInfo.props.children).props.ClientModule).toEqual({
+      label: 'module',
+    });
+  });
 });

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -30,6 +30,7 @@ let Stream;
 let use;
 let assertConsoleErrorDev;
 let serverAct;
+let getDebugInfo;
 
 // We test pass-through without encoding strings but it should work without it too.
 const streamOptions = {
@@ -77,6 +78,10 @@ describe('ReactFlightDOMNode', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     assertConsoleErrorDev = InternalTestUtils.assertConsoleErrorDev;
+    getDebugInfo = InternalTestUtils.getDebugInfo.bind(null, {
+      ignoreProps: false,
+      useFixedTime: true,
+    });
   });
 
   function filterStackFrame(filename, functionName) {
@@ -202,6 +207,28 @@ describe('ReactFlightDOMNode', () => {
       },
     });
     return {delayedStream, resolveDelayedStream};
+  }
+
+  // Runs an action that makes a Node stream emit, and flushes the ticks inside
+  // the act scope so that act sees the work the delivery triggers. Node streams
+  // hand data over through `process.nextTick`, which the fake timers mock.
+  function actOnStream(action: () => mixed): Promise<void> {
+    return serverAct(() => {
+      action();
+      jest.runAllTicks();
+    });
+  }
+
+  // The Node client resolves client references through a server consumer
+  // manifest, which maps each client module id to the module the SSR bundle
+  // loads for it. These tests use the same module on both sides.
+  function createIdentityServerConsumerManifest(...clientReferences) {
+    const moduleMap = {};
+    for (let i = 0; i < clientReferences.length; i++) {
+      const metadata = webpackMap[clientReferences[i].$$id];
+      moduleMap[metadata.id] = {'*': metadata};
+    }
+    return {moduleMap, moduleLoading: webpackModuleLoading};
   }
 
   it('should support web streams in node', async () => {
@@ -980,10 +1007,10 @@ describe('ReactFlightDOMNode', () => {
           // The concrete location may change as this test is updated.
           // Just make sure they still point at React.use(p2)
           (gate(flags => flags.enableAsyncDebugInfo)
-            ? '\n    at SharedComponent (./ReactFlightDOMNode-test.js:838:7)'
+            ? '\n    at SharedComponent (./ReactFlightDOMNode-test.js:865:7)'
             : '') +
-          '\n    at ServerComponent (file://./ReactFlightDOMNode-test.js:860:26)' +
-          '\n    at App (file://./ReactFlightDOMNode-test.js:877:25)',
+          '\n    at ServerComponent (file://./ReactFlightDOMNode-test.js:887:26)' +
+          '\n    at App (file://./ReactFlightDOMNode-test.js:904:25)',
       );
     } else {
       expect(ownerStack).toBeNull();
@@ -1567,12 +1594,12 @@ describe('ReactFlightDOMNode', () => {
           '\n' +
             '    in Dynamic' +
             (gate(flags => flags.enableAsyncDebugInfo)
-              ? ' (file://ReactFlightDOMNode-test.js:1441:27)\n'
+              ? ' (file://ReactFlightDOMNode-test.js:1468:27)\n'
               : '\n') +
             '    in body\n' +
             '    in html\n' +
-            '    in App (file://ReactFlightDOMNode-test.js:1454:25)\n' +
-            '    in ClientRoot (ReactFlightDOMNode-test.js:1529:16)',
+            '    in App (file://ReactFlightDOMNode-test.js:1481:25)\n' +
+            '    in ClientRoot (ReactFlightDOMNode-test.js:1556:16)',
         );
       } else {
         expect(
@@ -1581,7 +1608,7 @@ describe('ReactFlightDOMNode', () => {
           '\n' +
             '    in body\n' +
             '    in html\n' +
-            '    in ClientRoot (ReactFlightDOMNode-test.js:1529:16)',
+            '    in ClientRoot (ReactFlightDOMNode-test.js:1556:16)',
         );
       }
 
@@ -1591,8 +1618,8 @@ describe('ReactFlightDOMNode', () => {
             normalizeCodeLocInfo(ownerStack, {preserveLocation: true}),
           ).toBe(
             '\n' +
-              '    in Dynamic (file://ReactFlightDOMNode-test.js:1441:27)\n' +
-              '    in App (file://ReactFlightDOMNode-test.js:1454:25)',
+              '    in Dynamic (file://ReactFlightDOMNode-test.js:1468:27)\n' +
+              '    in App (file://ReactFlightDOMNode-test.js:1481:25)',
           );
         } else {
           expect(
@@ -1600,7 +1627,7 @@ describe('ReactFlightDOMNode', () => {
           ).toBe(
             '' +
               '\n' +
-              '    in App (file://ReactFlightDOMNode-test.js:1454:25)',
+              '    in App (file://ReactFlightDOMNode-test.js:1481:25)',
           );
         }
       } else {
@@ -1757,7 +1784,7 @@ describe('ReactFlightDOMNode', () => {
           normalizeCodeLocInfo(componentStack, {preserveLocation: true}),
         ).toBe(
           '\n' +
-            '    in ClientDynamic (ReactFlightDOMNode-test.js:1704:9)\n' +
+            '    in ClientDynamic (ReactFlightDOMNode-test.js:1731:9)\n' +
             '    in Suspense\n' +
             '    in body\n' +
             '    in html\n' +
@@ -1768,7 +1795,7 @@ describe('ReactFlightDOMNode', () => {
           normalizeCodeLocInfo(componentStack, {preserveLocation: true}),
         ).toBe(
           '\n' +
-            '    in ClientDynamic (ReactFlightDOMNode-test.js:1704:9)\n' +
+            '    in ClientDynamic (ReactFlightDOMNode-test.js:1731:9)\n' +
             '    in Suspense\n' +
             '    in body\n' +
             '    in html\n' +
@@ -1781,10 +1808,10 @@ describe('ReactFlightDOMNode', () => {
           '\n' +
             gate(flags =>
               flags.enableAsyncDebugInfo
-                ? '    at ClientDynamic (./ReactFlightDOMNode-test.js:1705:9)\n'
+                ? '    at ClientDynamic (./ReactFlightDOMNode-test.js:1732:9)\n'
                 : '',
             ) +
-            '    at ClientRoot (./ReactFlightDOMNode-test.js:1718:21)',
+            '    at ClientRoot (./ReactFlightDOMNode-test.js:1745:21)',
         );
       } else {
         expect(ownerStack).toBeNull();
@@ -2486,31 +2513,6 @@ describe('ReactFlightDOMNode', () => {
     expect(getEventListeners(composite, 'abort')).toHaveLength(0);
   });
 
-  // Runs an action that makes a Node stream emit, and flushes the ticks inside
-  // the act scope so that act sees the work the delivery triggers. Node streams
-  // hand data over through `process.nextTick`, which the fake timers mock.
-  //
-  // The tests above assert on source line numbers. A definition above them
-  // would shift those, so these helpers stay below them.
-  function actOnStream(action: () => mixed): Promise<void> {
-    return serverAct(() => {
-      action();
-      jest.runAllTicks();
-    });
-  }
-
-  // The Node client resolves client references through a server consumer
-  // manifest, which maps each client module id to the module the SSR bundle
-  // loads for it. These tests use the same module on both sides.
-  function createIdentityServerConsumerManifest(...clientReferences) {
-    const moduleMap = {};
-    for (let i = 0; i < clientReferences.length; i++) {
-      const metadata = webpackMap[clientReferences[i].$$id];
-      moduleMap[metadata.id] = {'*': metadata};
-    }
-    return {moduleMap, moduleLoading: webpackModuleLoading};
-  }
-
   // @gate __DEV__
   it('does not expose a debug-tree element whose props still hold an unresolved reference', async () => {
     // Regression test for facebook/react#37361.
@@ -2668,11 +2670,6 @@ describe('ReactFlightDOMNode', () => {
     await expect(response).resolves.toBeDefined();
     const root = await response;
 
-    const getDebugInfoWithProps =
-      require('internal-test-utils').getDebugInfo.bind(null, {
-        ignoreProps: false,
-        useFixedTime: true,
-      });
     const unwrap = node => {
       let current = node;
       while (
@@ -2685,14 +2682,15 @@ describe('ReactFlightDOMNode', () => {
       }
       return current;
     };
-    const passthroughInfo = getDebugInfoWithProps(root).find(
+    const passthroughInfo = getDebugInfo(root).find(
       entry => entry.name === 'PassthroughServerComponent',
     );
     const asyncServerElement = unwrap(passthroughInfo.props.children);
 
     // The props row still waits on the module, so the element must still be a
-    // lazy. Without the fix it is already initialized here, with the null
-    // placeholder where `ClientModule` belongs.
+    // lazy. An element initialized here would carry the null placeholder that
+    // DevTools reads, whether or not the frozen props make the later module
+    // write throw. Without the fix it is already initialized at this point.
     expect(asyncServerElement.$$typeof).toBe(Symbol.for('react.lazy'));
 
     await actOnStream(() => resolveClientModuleChunk());

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNode-test.js
@@ -2525,11 +2525,11 @@ describe('ReactFlightDOMNode', () => {
     //
     // The client must not hand the element the props object at that point. The
     // props row still waits on a client module reference, and the element is
-    // not part of that wait, so it has to stay a lazy until the props row
-    // completes. An element initialized early carries the null placeholder
-    // where `ClientModule` belongs, which is what DevTools reads. In DEV its
-    // props are also frozen, so the module write that lands later throws, and
-    // the response rejects.
+    // not part of that wait, so the lazy that wraps the element has to stay
+    // pending until the props row completes. An element initialized early
+    // carries the null placeholder where `ClientModule` belongs, which is what
+    // DevTools reads. In DEV its props are also frozen, so the module write
+    // that lands later throws, and the response rejects.
     //
     // The Suspense boundary inside PassthroughServerComponent keeps
     // PassthroughServerComponent's componentInfo on row 0 and moves
@@ -2670,35 +2670,33 @@ describe('ReactFlightDOMNode', () => {
     await expect(response).resolves.toBeDefined();
     const root = await response;
 
-    const unwrap = node => {
-      let current = node;
-      while (
-        current !== null &&
-        typeof current === 'object' &&
-        current.$$typeof === Symbol.for('react.lazy') &&
-        current._payload.status === 'fulfilled'
-      ) {
-        current = current._payload.value;
-      }
-      return current;
-    };
+    // DevTools reads the element from the componentInfo's `children`, through
+    // the payload of the lazy that wraps it. The status is recorded here and
+    // asserted after the module resolves, so that a regression fails on the
+    // frozen-props error first.
     const passthroughInfo = getDebugInfo(root).find(
       entry => entry.name === 'PassthroughServerComponent',
     );
-    const asyncServerElement = unwrap(passthroughInfo.props.children);
-
-    // The props row still waits on the module, so the element must still be a
-    // lazy. An element initialized here would carry the null placeholder that
-    // DevTools reads, whether or not the frozen props make the later module
-    // write throw. Without the fix it is already initialized at this point.
-    expect(asyncServerElement.$$typeof).toBe(Symbol.for('react.lazy'));
+    const asyncServerElementLazy = passthroughInfo.props.children;
+    const payloadStatusBeforeModule = asyncServerElementLazy._payload.status;
 
     await actOnStream(() => resolveClientModuleChunk());
 
+    // Without the fix, the element was initialized before the module arrived,
+    // and writing the module into its frozen props throws. The SSR render
+    // reports the error.
     expect(ssrErrors).toEqual([]);
     expect(received).toEqual([{module: 'object', shared: 'object'}]);
-    expect(unwrap(passthroughInfo.props.children).props.ClientModule).toEqual({
-      label: 'module',
-    });
+
+    // An element initialized before the module arrived carries the null
+    // placeholder that DevTools reads, whether or not the write throws. The
+    // lazy must not have resolved while its props row was waiting.
+    expect(payloadStatusBeforeModule).not.toBe('fulfilled');
+
+    // Resolve the lazy the way a renderer does. It holds the module now.
+    const asyncServerElement = asyncServerElementLazy._init(
+      asyncServerElementLazy._payload,
+    );
+    expect(asyncServerElement.props.ClientModule).toEqual({label: 'module'});
   });
 });


### PR DESCRIPTION
A row that is still parsing can hand its partially built value to references that were registered on it during that parse. `initializeModelChunk` fulfilled every such listener, on the assumption that all of them are cyclic references back into the parsing row. Only some are. A listener from a nested parse that is not part of a cycle belongs to a handler that does not wait on the parsing row, so fulfilling it early completes that handler with an object that still has references outstanding.

When that handler owns an element, `initializeElement` runs on incomplete props. In DEV the props are frozen, so the write that arrives later throws `Cannot assign to read only property`, and `rejectReference` escalates the error into the rows that wait on the element, up to the root. Only the debug tree can produce this shape. The RSC stream writes element props inline, while the debug channel outlines a props object that an element shares with its own componentInfo into a separate row, and that row can still wait on a client module.

`resolveBlockedCycle` already tells a cyclic reference from any other, but it returned `null` for mid-parse listeners because `handler.chunk` was assigned after the drain loop. This change assigns it before the loop and classifies each listener. A reference whose handler is transitively waiting on the parsing row is a genuine cycle and receives the value now, because neither side can complete before the other. Every other listener is queued back on the parsing row and fulfilled when that row completes, like any reference into a blocked row.

A row whose own parse fails used to hand the partial value to its mid-parse listeners before it threw. It now errors through `triggerErrorOnChunk`, which rejects them the same way a reference into any other errored row is rejected. The `if (handler.errored) throw` after the loop is removed. It also caught a rejection during the loop, which now reaches `triggerErrorOnChunk` on its own because `handler.chunk` is set.

One behaviour changes beyond the reported bug. When `initializeDebugChunk` errors a chunk before `parseModel` runs, the old code set `INITIALIZED` over that status if the model had no pending references, and left it `ERRORED` otherwise. The chunk now stays `ERRORED` in both cases. That is what the `triggerErrorOnChunk` call in `initializeDebugChunk` intends, and the TODO above the `parseModel` call already notes that the chunk can be `ERRORED` there.

PR #37398 deferred `Object.freeze(element.props)` until the outstanding references have resolved. That removes the exception but not the cause: the element is still initialized on an incomplete object and is visible through `_debugInfo` with a `null` placeholder until the late write lands. With the early release fixed, the freeze needs no change.

**Alternatives Considered**

- Deferring every listener whose handler is not the parsing row's own deadlocks `foo ↔ bar` in `can deduped outlined references inside promises`. One side of a genuine cycle has to accept the partial object.
- Holding an element back while its props row is `BLOCKED` breaks `should handle deduped props of re-used elements in fragments`, where the row is blocked on an unrelated module and the props object itself is complete.
- A per-object count of pending writes plus a reverse `dependents` edge works, but adds a second dependency graph next to `deps` and special-cases elements.

Fixes #37361
Closes #37398