### PR TITLE
[DOM] Respect the submitter's formMethod in useFormStatus

### DIFF
--- a/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js
@@ -45,6 +45,26 @@ function coerceFormActionProp(
   }
 }
 
+// Resolves formMethod the way the DOM does. It's an enumerated attribute with
+// no missing value default, so a value that doesn't render an attribute leaves
+// the form's method alone, while an unknown one is treated as GET.
+function coerceFormMethod(methodProp: mixed): string | null {
+  // This should match the logic in setValueForAttribute
+  if (
+    methodProp == null ||
+    typeof methodProp === 'symbol' ||
+    typeof methodProp === 'boolean' ||
+    typeof methodProp === 'function'
+  ) {
+    return null;
+  }
+  if (__DEV__) {
+    checkAttributeStringCoercion(methodProp, 'formMethod');
+  }
+  const method = ('' + (methodProp as any)).toLowerCase();
+  return method === 'post' || method === 'dialog' ? method : 'get';
+}
+
 /**
  * This plugin invokes action functions on forms, inputs and buttons if
  * the form doesn't prevent default.
@@ -71,6 +91,7 @@ function extractEvents(
   let action = coerceFormActionProp(
     (getFiberCurrentPropsFromNode(form) as any).action,
   );
+  let method = form.method;
   let submitter: null | void | HTMLInputElement | HTMLButtonElement = (
     nativeEvent as any
   ).submitter;
@@ -81,6 +102,18 @@ function extractEvents(
       ? coerceFormActionProp((submitterProps as any).formAction)
       : // The built-in Flow type is ?string, wider than the spec
         (submitter.getAttribute('formAction') as any as string | null);
+    // Resolved from props like the action above. A Server Action button gets a
+    // formMethod attribute from the server that isn't in the user's props and
+    // shouldn't override anything here.
+    const submitterMethod = coerceFormMethod(
+      submitterProps
+        ? (submitterProps as any).formMethod
+        : submitter.getAttribute('formMethod'),
+    );
+    if (submitterMethod !== null) {
+      // The submitter overrides the form method.
+      method = submitterMethod;
+    }
     if (submitterAction !== null) {
       // The submitter overrides the form action.
       action = submitterAction;
@@ -110,7 +143,7 @@ function extractEvents(
         const pendingState: FormStatus = {
           pending: true,
           data: formData,
-          method: form.method,
+          method: method,
           action: action,
         };
         if (__DEV__) {
@@ -139,7 +172,7 @@ function extractEvents(
       const pendingState: FormStatus = {
         pending: true,
         data: formData,
-        method: form.method,
+        method: method,
         action: action,
       };
       if (__DEV__) {

--- a/packages/react-dom/src/__tests__/ReactDOMForm-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMForm-test.js
@@ -945,6 +945,123 @@ describe('ReactDOMForm', () => {
     assertLog(['Async action finished', 'No pending action']);
   });
 
+  it(
+    "useFormStatus reads the submitter's formMethod, which overrides the " +
+      "form's method",
+    async () => {
+      const formRef = React.createRef();
+      const buttonRef = React.createRef();
+      const inputRef = React.createRef();
+      let actionText;
+
+      function Status() {
+        const {pending, method} = useFormStatus();
+        return <Text text={pending ? `Pending ${method}` : 'Not pending'} />;
+      }
+
+      async function myAction() {
+        await getText(actionText);
+      }
+
+      function App() {
+        return (
+          <form action={myAction} ref={formRef}>
+            <button type="submit" formMethod="post" ref={buttonRef} />
+            <input type="submit" formMethod="DIALOG" ref={inputRef} />
+            <Status />
+          </form>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<App />));
+      assertLog(['Not pending']);
+
+      actionText = 'A';
+      await submit(buttonRef.current);
+      assertLog(['Pending post']);
+      await act(() => resolveText('A'));
+      assertLog(['Not pending']);
+
+      // The value is normalized the same way the DOM normalizes it.
+      actionText = 'B';
+      await submit(inputRef.current);
+      assertLog(['Pending dialog']);
+      await act(() => resolveText('B'));
+      assertLog(['Not pending']);
+
+      // A submitter that React doesn't own is read from the DOM instead.
+      const foreignButton = document.createElement('button');
+      foreignButton.type = 'submit';
+      foreignButton.setAttribute('formmethod', 'post');
+      formRef.current.appendChild(foreignButton);
+
+      actionText = 'C';
+      await submit(foreignButton);
+      assertLog(['Pending post']);
+      await act(() => resolveText('C'));
+      assertLog(['Not pending']);
+    },
+  );
+
+  it(
+    "useFormStatus reads the submitter's formMethod if the submit event " +
+      'was preventDefault-ed',
+    async () => {
+      const buttonRef = React.createRef();
+      const overrideRef = React.createRef();
+      const invalidRef = React.createRef();
+      let actionText;
+
+      function Status() {
+        const {pending, method} = useFormStatus();
+        return <Text text={pending ? `Pending ${method}` : 'Not pending'} />;
+      }
+
+      function App() {
+        const [, startFormTransition] = useTransition();
+        function onSubmit(event) {
+          event.preventDefault();
+          startFormTransition(async () => {
+            await getText(actionText);
+          });
+        }
+        return (
+          <form method="dialog" onSubmit={onSubmit}>
+            <button type="submit" ref={buttonRef} />
+            <button type="submit" formMethod="post" ref={overrideRef} />
+            <button type="submit" formMethod="bogus" ref={invalidRef} />
+            <Status />
+          </form>
+        );
+      }
+
+      const root = ReactDOMClient.createRoot(container);
+      await act(() => root.render(<App />));
+      assertLog(['Not pending']);
+
+      // A submitter without a formMethod leaves the form's method alone.
+      actionText = 'A';
+      await submit(buttonRef.current);
+      assertLog(['Pending dialog']);
+      await act(() => resolveText('A'));
+      assertLog(['Not pending']);
+
+      actionText = 'B';
+      await submit(overrideRef.current);
+      assertLog(['Pending post']);
+      await act(() => resolveText('B'));
+      assertLog(['Not pending']);
+
+      // An unknown formMethod uses the attribute's invalid value default.
+      actionText = 'C';
+      await submit(invalidRef.current);
+      assertLog(['Pending get']);
+      await act(() => resolveText('C'));
+      assertLog(['Not pending']);
+    },
+  );
+
   it('should error if submitting a form manually', async () => {
     const ref = React.createRef();
 


### PR DESCRIPTION
## Summary

Per the [HTML spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formmethod), `formmethod` on a submit button overrides the form's `method` for that submission. `useFormStatus()` ignores it and always reports `form.method`:

```jsx
<form action={myAction}>
  {/* useFormStatus().method is "get", should be "post" */}
  <button type="submit" formMethod="post" />
</form>
```

`FormActionEventPlugin` already resolves the submitter's `formAction` override, so this resolves `formMethod` right next to it: from React props when the submitter belongs to this instance, and from the DOM attribute otherwise. Reading props keeps the `formmethod` React emits for a Server Action button from counting as a user override.

The value is normalized the way the DOM normalizes it. Matching is case insensitive, an unknown value falls back to `get` (the attribute's invalid value default), and a value that renders no attribute leaves the form's method alone (it has no missing value default).

Fixes https://github.com/react/react/issues/33361

## How did you test this change?

Two tests in `ReactDOMForm-test.js`, one per pending status path, covering a submitter without `formMethod`, an override on `<button>` and on `<input type="submit">`, case normalization, an unknown value, and a submitter React doesn't own. Both fail on `main`.

- [x] `yarn test packages/react-dom/src/__tests__` and `yarn test --prod packages/react-dom/src/__tests__`
- [x] `yarn test-stable` / `yarn test-www` / `yarn test-classic` on `ReactDOMForm-test.js` and `ReactDOMFizzForm-test.js`
- [x] `yarn test packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMForm-test.js`
- [x] `yarn linc`
- [x] `yarn prettier-check`
- [x] `yarn flow dom-node` and `yarn flow dom-browser`
