### PR TITLE
 [rust-compiler] Fix js_to_int32 to match js semantics

### DIFF
--- a/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
+++ b/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
@@ -1098,14 +1098,9 @@ fn js_to_int32(n: f64) -> i32 {
     if n.is_nan() || n.is_infinite() || n == 0.0 {
         return 0;
     }
-    // Truncate, then wrap to 32 bits
-    let int64 = (n.trunc() as i64) & 0xFFFFFFFF;
-    // Reinterpret as signed i32
-    if int64 >= 0x80000000 {
-        (int64 as u32) as i32
-    } else {
-        int64 as i32
-    }
+    // Rust saturates f64-to-i64 conversions, but JavaScript ToInt32 wraps modulo 2^32.
+    let wrapped = n.trunc().rem_euclid((1_u64 << 32) as f64);
+    wrapped as u32 as i32
 }
 
 /// ECMAScript ToUint32: convert f64 to u32 with modular (wrapping) semantics.

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-bit-ops-large-numbers.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-bit-ops-large-numbers.expect.md
@@ -1,0 +1,67 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function foo() {
+  return (
+    <Stringify
+      value={[
+        (2 ** 64) | 0,
+        -(2 ** 64) | 0,
+        1e21 | 0,
+        -1e21 | 0,
+        1e21 & -1,
+        1e21 ^ 0,
+        1e21 >>> 0,
+        (2 ** 64) >> 4,
+        1e21 << 1,
+      ]}
+    />
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function foo() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = (
+      <Stringify
+        value={[
+          0, 0, -559939584, 559939584, -559939584, -559939584, 3735027712, 0,
+          -1119879168,
+        ]}
+      />
+    );
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"value":[0,0,-559939584,559939584,-559939584,-559939584,3735027712,0,-1119879168]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-bit-ops-large-numbers.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-bit-ops-large-numbers.js
@@ -1,0 +1,25 @@
+import {Stringify} from 'shared-runtime';
+
+function foo() {
+  return (
+    <Stringify
+      value={[
+        (2 ** 64) | 0,
+        -(2 ** 64) | 0,
+        1e21 | 0,
+        -1e21 | 0,
+        1e21 & -1,
+        1e21 ^ 0,
+        1e21 >>> 0,
+        (2 ** 64) >> 4,
+        1e21 << 1,
+      ]}
+    />
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};


### PR DESCRIPTION
Before things like 1e21 | 0 would return -1 instead of -559939584 like js expects. This should make this match in all cases.