### PR TITLE
[DevTools] Build react-devtools-cdt-mcp on npm publish

### DIFF
--- a/packages/react-devtools-cdt-mcp/package.json
+++ b/packages/react-devtools-cdt-mcp/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=production rollup -c rollup.config.cjs",
-    "prepublish": "yarn run build",
+    "prepublishOnly": "yarn run build",
     "start": "cross-env NODE_ENV=development rollup -c rollup.config.cjs --watch",
     "test:e2e": "node e2e/run.js",
     "test:e2e:ci": "cross-env E2E_CI=true node e2e/run.js"


### PR DESCRIPTION
## Summary
- Rename `prepublish` to `prepublishOnly` so `npm publish` actually builds `dist/`.
- npm 11 no longer runs `prepublish` on publish, which is why the dry-run tarball only contained `package.json` and `README.md`.

References:
- https://docs.npmjs.com/cli/v8/using-npm/scripts
- https://github.com/react/react/actions/runs/34289346119/job/102272162731

## Test plan
- [ ] Re-run the publish workflow with `dry: true` and confirm the tarball includes `dist/index.js` and `dist/register.js`.