### PR TITLE
[DevTools] Fix repository URL for react-devtools-cdt-mcp/package.json

### DIFF
--- a/packages/react-devtools-cdt-mcp/package.json
+++ b/packages/react-devtools-cdt-mcp/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
+    "url": "https://github.com/react/react.git",
     "directory": "packages/react-devtools-cdt-mcp"
   },
   "files": [


### PR DESCRIPTION
Required for trusted publishing, same as https://github.com/react/react/pull/36752