### PR TITLE
[RN] Move RN globals to RN private interface module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -459,13 +459,6 @@ module.exports = {
       },
     },
     {
-      files: ['packages/react-native-renderer/**/*.js'],
-      globals: {
-        nativeFabricUIManager: 'readonly',
-        RN$isNativeEventTargetEventDispatchingEnabled: 'readonly',
-      },
-    },
-    {
       files: ['packages/react-server-dom-webpack/**/*.js'],
       globals: {
         __webpack_chunk_load__: 'readonly',

--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -7,11 +7,14 @@
  * @flow
  */
 
+// Modules provided by RN:
+import {fabricUIManager} from 'react-native/react-private-interface';
+
 const ReactFabricGlobalResponderHandler = {
   onChange: function (from: any, to: any, blockNativeResponder: boolean) {
     if (from && from.stateNode) {
       // equivalent to clearJSResponder
-      nativeFabricUIManager.setIsJSResponder(
+      fabricUIManager.setIsJSResponder(
         from.stateNode.node,
         false,
         blockNativeResponder || false,
@@ -20,7 +23,7 @@ const ReactFabricGlobalResponderHandler = {
 
     if (to && to.stateNode) {
       // equivalent to setJSResponder
-      nativeFabricUIManager.setIsJSResponder(
+      fabricUIManager.setIsJSResponder(
         to.stateNode.node,
         true,
         blockNativeResponder || false,

--- a/packages/react-native-renderer/src/ReactFiberConfigFabric.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabric.js
@@ -36,6 +36,7 @@ import {
   createPublicTextInstance,
   createAttributePayload,
   diffAttributePayloads,
+  fabricUIManager,
   type PublicInstance as ReactNativePublicInstance,
   type PublicTextInstance,
   type PublicRootInstance,
@@ -61,7 +62,7 @@ const {
   unstable_IdleEventPriority: FabricIdlePriority,
   unstable_getCurrentEventPriority: fabricGetCurrentEventPriority,
   suspendOnActiveViewTransition: fabricSuspendOnActiveViewTransition,
-} = nativeFabricUIManager;
+} = fabricUIManager;
 
 import {getClosestInstanceFromNode} from './ReactFabricComponentTree';
 import {compareDocumentPositionForEmptyFragment} from 'shared/ReactDOMFragmentRefShared';

--- a/packages/react-native-renderer/src/ReactFiberConfigFabricWithViewTransition.js
+++ b/packages/react-native-renderer/src/ReactFiberConfigFabricWithViewTransition.js
@@ -18,12 +18,15 @@ import type {
 
 import {allocateTag} from './ReactFiberConfigFabric';
 
+// Modules provided by RN:
+import {fabricUIManager} from 'react-native/react-private-interface';
+
 const {
   applyViewTransitionName: fabricApplyViewTransitionName,
   createViewTransitionInstance: fabricCreateViewTransitionInstance,
   startViewTransition: fabricStartViewTransition,
   startViewTransitionReadyFinished: fabricStartViewTransitionReadyFinished,
-} = nativeFabricUIManager;
+} = fabricUIManager;
 
 export type InstanceMeasurement = {
   rect: {x: number, y: number, width: number, height: number},

--- a/packages/react-native-renderer/src/ReactNativeFeatureFlags.js
+++ b/packages/react-native-renderer/src/ReactNativeFeatureFlags.js
@@ -7,17 +7,23 @@
  * @flow
  */
 
-// These globals are set by React Native (e.g. in setUpDOM.js, setUpTimers.js)
-// and provide access to RN's feature flags. We use global functions because we
-// don't have another mechanism to pass feature flags from RN to React in OSS.
+// Modules provided by RN:
+import {ReactNativeFeatureFlags} from 'react-native/react-private-interface';
+
+// These accessors are provided by React Native and give us access to RN's
+// feature flags. Both the object and each accessor on it are treated as
+// optional so that removing a flag on the React Native side doesn't throw here.
 // Values are lazily evaluated and cached on first access.
 
 let _enableNativeEventTargetEventDispatching: boolean | null = null;
 export function enableNativeEventTargetEventDispatching(): boolean {
   if (_enableNativeEventTargetEventDispatching == null) {
+    const isEnabled =
+      ReactNativeFeatureFlags != null
+        ? ReactNativeFeatureFlags.enableNativeEventTargetEventDispatching
+        : null;
     _enableNativeEventTargetEventDispatching =
-      typeof RN$isNativeEventTargetEventDispatchingEnabled === 'function' &&
-      RN$isNativeEventTargetEventDispatchingEnabled();
+      typeof isEnabled === 'function' && isEnabled();
   }
   return _enableNativeEventTargetEventDispatching;
 }

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -16,8 +16,11 @@ import {
 } from 'react-reconciler/src/ReactFiberTreeReflection';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 import {HostComponent} from 'react-reconciler/src/ReactWorkTags';
-// Module provided by RN:
-import {getNodeFromPublicInstance} from 'react-native/react-private-interface';
+// Modules provided by RN:
+import {
+  getNodeFromPublicInstance,
+  fabricUIManager,
+} from 'react-native/react-private-interface';
 import {getNodeFromInternalInstanceHandle} from './ReactNativePublicCompat';
 import {getStackByFiberInDevAndProd} from 'react-reconciler/src/ReactFiberComponentStack';
 
@@ -43,7 +46,7 @@ if (__DEV__) {
               hostFiber.stateNode.node;
 
             if (node) {
-              nativeFabricUIManager.measure(node, callback);
+              fabricUIManager.measure(node, callback);
             }
           },
         };
@@ -142,7 +145,7 @@ function getInspectorDataForViewAtPoint(
     const fabricNode = getNodeFromPublicInstance(inspectedView);
     if (fabricNode) {
       // For Fabric we can look up the instance handle directly and measure it.
-      nativeFabricUIManager.findNodeAtPoint(
+      fabricUIManager.findNodeAtPoint(
         fabricNode,
         locationX,
         locationY,
@@ -169,20 +172,16 @@ function getInspectorDataForViewAtPoint(
           const nativeViewTag =
             internalInstanceHandle.stateNode.canonical.nativeTag;
 
-          nativeFabricUIManager.measure(
-            node,
-            (x, y, width, height, pageX, pageY) => {
-              const inspectorData =
-                getInspectorDataForInstance(closestInstance);
-              callback({
-                ...inspectorData,
-                pointerY: locationY,
-                frame: {left: pageX, top: pageY, width, height},
-                touchedViewTag: nativeViewTag,
-                closestPublicInstance,
-              });
-            },
-          );
+          fabricUIManager.measure(node, (x, y, width, height, pageX, pageY) => {
+            const inspectorData = getInspectorDataForInstance(closestInstance);
+            callback({
+              ...inspectorData,
+              pointerY: locationY,
+              frame: {left: pageX, top: pageY, width, height},
+              touchedViewTag: nativeViewTag,
+              closestPublicInstance,
+            });
+          });
         },
       );
     } else {

--- a/packages/react-native-renderer/src/ReactNativePublicCompat.js
+++ b/packages/react-native-renderer/src/ReactNativePublicCompat.js
@@ -16,6 +16,7 @@ import {
   getNodeFromPublicInstance,
   getNativeTagFromPublicInstance,
   getInternalInstanceHandleFromPublicInstance,
+  fabricUIManager,
 } from 'react-native/react-private-interface';
 
 import {
@@ -148,7 +149,7 @@ export function dispatchCommand(
   const node = getNodeFromPublicInstance(handle);
 
   if (node != null) {
-    nativeFabricUIManager.dispatchCommand(node, command, args);
+    fabricUIManager.dispatchCommand(node, command, args);
   } else {
     if (__DEV__) {
       console.error(
@@ -163,7 +164,7 @@ export function sendAccessibilityEvent(handle: any, eventType: string) {
   const node = getNodeFromPublicInstance(handle);
 
   if (node != null) {
-    nativeFabricUIManager.sendAccessibilityEvent(node, eventType);
+    fabricUIManager.sendAccessibilityEvent(node, eventType);
   } else {
     if (__DEV__) {
       console.error(

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeFeatureFlags.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeFeatureFlags.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+module.exports = {
+  enableNativeEventTargetEventDispatching(): boolean {
+    return false;
+  },
+};

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -8,8 +8,14 @@
  */
 
 module.exports = {
+  get fabricUIManager() {
+    return global.nativeFabricUIManager;
+  },
   get ReactFiberErrorDialog() {
     return require('./ReactFiberErrorDialog');
+  },
+  get ReactNativeFeatureFlags() {
+    return require('./ReactNativeFeatureFlags');
   },
   get ReactNativeViewConfigRegistry() {
     return require('./ReactNativeViewConfigRegistry');

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -13,6 +13,7 @@
 let React;
 let ReactFabric;
 let ReactNativePrivateInterface;
+let fabricUIManager;
 let createReactNativeComponentClass;
 let StrictMode;
 let act;
@@ -36,6 +37,7 @@ describe('ReactFabric', () => {
     StrictMode = React.StrictMode;
     ReactFabric = require('react-native-renderer/fabric');
     ReactNativePrivateInterface = require('react-native/react-private-interface');
+    fabricUIManager = ReactNativePrivateInterface.fabricUIManager;
     createReactNativeComponentClass =
       require('react-native/react-private-interface')
         .ReactNativeViewConfigRegistry.register;
@@ -51,9 +53,9 @@ describe('ReactFabric', () => {
     await act(() => {
       ReactFabric.render(<View foo="test" />, 1, null, true);
     });
-    expect(nativeFabricUIManager.createNode).toHaveBeenCalled();
-    expect(nativeFabricUIManager.appendChild).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalled();
+    expect(fabricUIManager.createNode).toHaveBeenCalled();
+    expect(fabricUIManager.appendChild).not.toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).toHaveBeenCalled();
   });
 
   it('should be able to create and update a native component', async () => {
@@ -64,28 +66,24 @@ describe('ReactFabric', () => {
 
     const firstNode = {};
 
-    nativeFabricUIManager.createNode.mockReturnValue(firstNode);
+    fabricUIManager.createNode.mockReturnValue(firstNode);
 
     await act(() => {
       ReactFabric.render(<View foo="foo" />, 11, null, true);
     });
 
-    expect(nativeFabricUIManager.createNode).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.createNode).toHaveBeenCalledTimes(1);
 
     await act(() => {
       ReactFabric.render(<View foo="bar" />, 11, null, true);
     });
 
-    expect(nativeFabricUIManager.createNode).toHaveBeenCalledTimes(1);
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(nativeFabricUIManager.cloneNodeWithNewProps.mock.calls[0][0]).toBe(
+    expect(fabricUIManager.createNode).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.cloneNodeWithNewProps.mock.calls[0][0]).toBe(
       firstNode,
     );
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewProps.mock.calls[0][1],
-    ).toEqual({
+    expect(fabricUIManager.cloneNodeWithNewProps.mock.calls[0][1]).toEqual({
       foo: 'bar',
     });
   });
@@ -99,71 +97,55 @@ describe('ReactFabric', () => {
     await act(() => {
       ReactFabric.render(<Text foo="a">1</Text>, 11, null, true);
     });
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
 
     // If no properties have changed, we shouldn't call cloneNode.
     await act(() => {
       ReactFabric.render(<Text foo="a">1</Text>, 11, null, true);
     });
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
 
     // Only call cloneNode for the changed property (and not for text).
     await act(() => {
       ReactFabric.render(<Text foo="b">1</Text>, 11, null, true);
     });
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(1);
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
 
     // Only call cloneNode for the changed text (and no other properties).
     await act(() => {
       ReactFabric.render(<Text foo="b">2</Text>, 11, null, true);
     });
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(1);
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).toHaveBeenCalledTimes(1);
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
 
     // Call cloneNode for both changed text and properties.
     await act(() => {
       ReactFabric.render(<Text foo="c">3</Text>, 11, null, true);
     });
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(1);
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).toHaveBeenCalledTimes(1);
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).toHaveBeenCalledTimes(1);
   });
 
@@ -183,13 +165,11 @@ describe('ReactFabric', () => {
         true,
       );
     });
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
 
     jest
@@ -206,12 +186,10 @@ describe('ReactFabric', () => {
         true,
       );
     });
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewProps.mock.calls[0][1],
-    ).toEqual({
+    expect(fabricUIManager.cloneNodeWithNewProps.mock.calls[0][1]).toEqual({
       bar: 'b',
     });
-    expect(nativeFabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
+    expect(fabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
  RCTText {"foo":"a","bar":"b"}
    RCTRawText {"text":"1"}`);
 
@@ -232,13 +210,11 @@ describe('ReactFabric', () => {
       ? 2
       : 1;
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps.mock.calls[0][
-        argIndex
-      ],
+      fabricUIManager.cloneNodeWithNewChildrenAndProps.mock.calls[0][argIndex],
     ).toEqual({
       foo: 'b',
     });
-    expect(nativeFabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
+    expect(fabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
  RCTText {"foo":"b","bar":"b"}
    RCTRawText {"text":"2"}`);
   });
@@ -258,41 +234,36 @@ describe('ReactFabric', () => {
     await act(() =>
       ReactFabric.render(<Component foo={true} />, 11, null, true),
     );
-    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).toHaveBeenCalled();
     jest.clearAllMocks();
 
     await act(() =>
       ReactFabric.render(<Component foo={false} />, 11, null, true),
     );
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledWith(
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.cloneNodeWithNewProps).toHaveBeenCalledWith(
       expect.anything(),
       {foo: false},
     );
 
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
-    ).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.cloneNodeWithNewChildren).toHaveBeenCalledTimes(1);
     if (gate(flags => flags.passChildrenWhenCloningPersistedNodes)) {
-      expect(
-        nativeFabricUIManager.cloneNodeWithNewChildren,
-      ).toHaveBeenCalledWith(expect.anything(), [
-        expect.objectContaining({props: {foo: false}}),
-      ]);
-      expect(nativeFabricUIManager.appendChild).not.toHaveBeenCalled();
+      expect(fabricUIManager.cloneNodeWithNewChildren).toHaveBeenCalledWith(
+        expect.anything(),
+        [expect.objectContaining({props: {foo: false}})],
+      );
+      expect(fabricUIManager.appendChild).not.toHaveBeenCalled();
     } else {
-      expect(
-        nativeFabricUIManager.cloneNodeWithNewChildren,
-      ).toHaveBeenCalledWith(expect.anything());
-      expect(nativeFabricUIManager.appendChild).toHaveBeenCalledTimes(1);
+      expect(fabricUIManager.cloneNodeWithNewChildren).toHaveBeenCalledWith(
+        expect.anything(),
+      );
+      expect(fabricUIManager.appendChild).toHaveBeenCalledTimes(1);
     }
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).toHaveBeenCalled();
   });
 
   it('should not clone nodes when layout effects are used', async () => {
@@ -316,7 +287,7 @@ describe('ReactFabric', () => {
         true,
       ),
     );
-    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).toHaveBeenCalled();
     jest.clearAllMocks();
 
     await act(() =>
@@ -329,15 +300,13 @@ describe('ReactFabric', () => {
         true,
       ),
     );
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.completeRoot).not.toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).not.toHaveBeenCalled();
   });
 
   it('should not clone nodes when insertion effects are used', async () => {
@@ -361,7 +330,7 @@ describe('ReactFabric', () => {
         true,
       ),
     );
-    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).toHaveBeenCalled();
     jest.clearAllMocks();
 
     await act(() =>
@@ -374,15 +343,13 @@ describe('ReactFabric', () => {
         true,
       ),
     );
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.completeRoot).not.toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).not.toHaveBeenCalled();
   });
 
   it('should not clone nodes when useImperativeHandle is used', async () => {
@@ -408,7 +375,7 @@ describe('ReactFabric', () => {
         true,
       ),
     );
-    expect(nativeFabricUIManager.completeRoot).toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).toHaveBeenCalled();
     expect(ref.current.greet()).toBe('hello');
     jest.clearAllMocks();
 
@@ -422,15 +389,13 @@ describe('ReactFabric', () => {
         true,
       ),
     );
-    expect(nativeFabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNode).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewChildren).not.toHaveBeenCalled();
+    expect(fabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
     expect(
-      nativeFabricUIManager.cloneNodeWithNewChildren,
+      fabricUIManager.cloneNodeWithNewChildrenAndProps,
     ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.cloneNodeWithNewProps).not.toHaveBeenCalled();
-    expect(
-      nativeFabricUIManager.cloneNodeWithNewChildrenAndProps,
-    ).not.toHaveBeenCalled();
-    expect(nativeFabricUIManager.completeRoot).not.toHaveBeenCalled();
+    expect(fabricUIManager.completeRoot).not.toHaveBeenCalled();
     expect(ref.current.greet()).toBe('hello');
   });
 
@@ -440,7 +405,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    nativeFabricUIManager.dispatchCommand.mockClear();
+    fabricUIManager.dispatchCommand.mockClear();
 
     let viewRef;
     await act(() => {
@@ -456,10 +421,10 @@ describe('ReactFabric', () => {
       );
     });
 
-    expect(nativeFabricUIManager.dispatchCommand).not.toHaveBeenCalled();
+    expect(fabricUIManager.dispatchCommand).not.toHaveBeenCalled();
     ReactFabric.dispatchCommand(viewRef, 'updateCommand', [10, 20]);
-    expect(nativeFabricUIManager.dispatchCommand).toHaveBeenCalledTimes(1);
-    expect(nativeFabricUIManager.dispatchCommand).toHaveBeenCalledWith(
+    expect(fabricUIManager.dispatchCommand).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.dispatchCommand).toHaveBeenCalledWith(
       expect.any(Object),
       'updateCommand',
       [10, 20],
@@ -473,7 +438,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    nativeFabricUIManager.dispatchCommand.mockReset();
+    fabricUIManager.dispatchCommand.mockReset();
 
     let viewRef;
     await act(() => {
@@ -489,11 +454,11 @@ describe('ReactFabric', () => {
       );
     });
 
-    expect(nativeFabricUIManager.dispatchCommand).not.toHaveBeenCalled();
+    expect(fabricUIManager.dispatchCommand).not.toHaveBeenCalled();
     ReactFabric.dispatchCommand(viewRef, 'updateCommand', [10, 20]);
     assertConsoleErrorDev([DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT]);
 
-    expect(nativeFabricUIManager.dispatchCommand).not.toHaveBeenCalled();
+    expect(fabricUIManager.dispatchCommand).not.toHaveBeenCalled();
   });
 
   it('should call sendAccessibilityEvent for native refs', async () => {
@@ -502,7 +467,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    nativeFabricUIManager.sendAccessibilityEvent.mockClear();
+    fabricUIManager.sendAccessibilityEvent.mockClear();
 
     let viewRef;
     await act(() => {
@@ -518,12 +483,10 @@ describe('ReactFabric', () => {
       );
     });
 
-    expect(nativeFabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
+    expect(fabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
     ReactFabric.sendAccessibilityEvent(viewRef, 'focus');
-    expect(nativeFabricUIManager.sendAccessibilityEvent).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(nativeFabricUIManager.sendAccessibilityEvent).toHaveBeenCalledWith(
+    expect(fabricUIManager.sendAccessibilityEvent).toHaveBeenCalledTimes(1);
+    expect(fabricUIManager.sendAccessibilityEvent).toHaveBeenCalledWith(
       expect.any(Object),
       'focus',
     );
@@ -536,7 +499,7 @@ describe('ReactFabric', () => {
       }
     }
 
-    nativeFabricUIManager.sendAccessibilityEvent.mockReset();
+    fabricUIManager.sendAccessibilityEvent.mockReset();
 
     let viewRef;
     await act(() => {
@@ -552,11 +515,11 @@ describe('ReactFabric', () => {
       );
     });
 
-    expect(nativeFabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
+    expect(fabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
     ReactFabric.sendAccessibilityEvent(viewRef, 'eventTypeName');
     assertConsoleErrorDev([SEND_ACCESSIBILITY_EVENT_REQUIRES_HOST_COMPONENT]);
 
-    expect(nativeFabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
+    expect(fabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
   });
 
   it('calls the callback with the correct instance and returns null', async () => {
@@ -637,7 +600,7 @@ describe('ReactFabric', () => {
     await act(() => {
       ReactFabric.render(<Component chars={before} />, 11, null, true);
     });
-    expect(nativeFabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
+    expect(fabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
  RCTView {}
    RCTView {"title":"a"}
    RCTView {"title":"b"}
@@ -663,7 +626,7 @@ describe('ReactFabric', () => {
     await act(() => {
       ReactFabric.render(<Component chars={after} />, 11, null, true);
     });
-    expect(nativeFabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
+    expect(fabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
  RCTView {}
    RCTView {"title":"m"}
    RCTView {"title":"x"}
@@ -724,7 +687,7 @@ describe('ReactFabric', () => {
         true,
       );
     });
-    expect(nativeFabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(
+    expect(fabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(
       `11
  RCTView {}
    RCTView {}
@@ -757,7 +720,7 @@ describe('ReactFabric', () => {
         chars: after,
       });
     });
-    expect(nativeFabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
+    expect(fabricUIManager.__dumpHierarchyForJestTestsOnly()).toBe(`11
  RCTView {}
    RCTView {}
      RCTView {"title":"m"}
@@ -806,10 +769,10 @@ describe('ReactFabric', () => {
     }));
 
     const snapshots = [];
-    nativeFabricUIManager.completeRoot.mockImplementation(
+    fabricUIManager.completeRoot.mockImplementation(
       function (rootTag, newChildSet) {
         snapshots.push(
-          nativeFabricUIManager.__dumpChildSetForJestTestsOnly(newChildSet),
+          fabricUIManager.__dumpChildSetForJestTestsOnly(newChildSet),
         );
       },
     );
@@ -943,15 +906,11 @@ describe('ReactFabric', () => {
       ReactFabric.render(<View onTouchStart={touchStart} />, 11, null, true);
     });
 
-    expect(nativeFabricUIManager.createNode.mock.calls.length).toBe(1);
-    expect(nativeFabricUIManager.registerEventHandler.mock.calls.length).toBe(
-      1,
-    );
+    expect(fabricUIManager.createNode.mock.calls.length).toBe(1);
+    expect(fabricUIManager.registerEventHandler.mock.calls.length).toBe(1);
 
-    const [, , , , instanceHandle] =
-      nativeFabricUIManager.createNode.mock.calls[0];
-    const [dispatchEvent] =
-      nativeFabricUIManager.registerEventHandler.mock.calls[0];
+    const [, , , , instanceHandle] = fabricUIManager.createNode.mock.calls[0];
+    const [dispatchEvent] = fabricUIManager.registerEventHandler.mock.calls[0];
 
     const touchEvent = {
       touches: [],
@@ -1037,14 +996,11 @@ describe('ReactFabric', () => {
         );
       });
 
-      expect(nativeFabricUIManager.createNode.mock.calls.length).toBe(2);
-      expect(nativeFabricUIManager.registerEventHandler.mock.calls.length).toBe(
-        1,
-      );
-      const [, , , , childInstance] =
-        nativeFabricUIManager.createNode.mock.calls[0];
+      expect(fabricUIManager.createNode.mock.calls.length).toBe(2);
+      expect(fabricUIManager.registerEventHandler.mock.calls.length).toBe(1);
+      const [, , , , childInstance] = fabricUIManager.createNode.mock.calls[0];
       const [dispatchEvent] =
-        nativeFabricUIManager.registerEventHandler.mock.calls[0];
+        fabricUIManager.registerEventHandler.mock.calls[0];
 
       dispatchEvent(childInstance, 'topDefaultBubblingEvent', event);
       expect(targetBubble).toHaveBeenCalledTimes(1);
@@ -1092,7 +1048,7 @@ describe('ReactFabric', () => {
 
     function getViewById(id) {
       const [reactTag, , , , instanceHandle] =
-        nativeFabricUIManager.createNode.mock.calls.find(
+        fabricUIManager.createNode.mock.calls.find(
           args => args[3] && args[3].id === id,
         );
 
@@ -1138,8 +1094,7 @@ describe('ReactFabric', () => {
       );
     });
 
-    const [dispatchEvent] =
-      nativeFabricUIManager.registerEventHandler.mock.calls[0];
+    const [dispatchEvent] = fabricUIManager.registerEventHandler.mock.calls[0];
 
     const preexistingEvent = {};
     global.event = preexistingEvent;
@@ -1194,7 +1149,7 @@ describe('ReactFabric', () => {
 
     function getViewById(id) {
       const [reactTag, , , , instanceHandle] =
-        nativeFabricUIManager.createNode.mock.calls.find(
+        fabricUIManager.createNode.mock.calls.find(
           args => args[3] && args[3].id === id,
         );
 
@@ -1241,8 +1196,7 @@ describe('ReactFabric', () => {
       );
     });
 
-    const [dispatchEvent] =
-      nativeFabricUIManager.registerEventHandler.mock.calls[0];
+    const [dispatchEvent] = fabricUIManager.registerEventHandler.mock.calls[0];
 
     dispatchEvent(getViewById('default').instanceHandle, 'topTouchStart', {
       target: getViewById('default').reactTag,
@@ -1511,7 +1465,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    nativeFabricUIManager.sendAccessibilityEvent.mockReset();
+    fabricUIManager.sendAccessibilityEvent.mockReset();
 
     let viewRef;
     await act(() => {
@@ -1540,7 +1494,7 @@ describe('ReactFabric', () => {
         'native component. Use React.forwardRef to get access to the underlying native component',
     ]);
 
-    expect(nativeFabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
+    expect(fabricUIManager.sendAccessibilityEvent).not.toHaveBeenCalled();
   });
 
   it('getNodeFromInternalInstanceHandle should return the correct shadow node', async () => {
@@ -1553,12 +1507,10 @@ describe('ReactFabric', () => {
       ReactFabric.render(<View foo="test" />, 1, null, true);
     });
 
-    const internalInstanceHandle =
-      nativeFabricUIManager.createNode.mock.calls[0][4];
+    const internalInstanceHandle = fabricUIManager.createNode.mock.calls[0][4];
     expect(internalInstanceHandle).toEqual(expect.any(Object));
 
-    const expectedShadowNode =
-      nativeFabricUIManager.createNode.mock.results[0].value;
+    const expectedShadowNode = fabricUIManager.createNode.mock.results[0].value;
     expect(expectedShadowNode).toEqual(expect.any(Object));
 
     const node = ReactFabric.getNodeFromInternalInstanceHandle(
@@ -1588,8 +1540,7 @@ describe('ReactFabric', () => {
       );
     });
 
-    const internalInstanceHandle =
-      nativeFabricUIManager.createNode.mock.calls[0][4];
+    const internalInstanceHandle = fabricUIManager.createNode.mock.calls[0][4];
     expect(internalInstanceHandle).toEqual(expect.any(Object));
 
     const publicInstance =
@@ -1622,8 +1573,7 @@ describe('ReactFabric', () => {
     });
 
     // Access the internal instance handle used to create the text node.
-    const internalInstanceHandle =
-      nativeFabricUIManager.createNode.mock.calls[0][4];
+    const internalInstanceHandle = fabricUIManager.createNode.mock.calls[0][4];
     expect(internalInstanceHandle).toEqual(expect.any(Object));
 
     // Text public instances should be created lazily.

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -55,6 +55,14 @@ declare opaque type __PublicTextInstance;
 declare opaque type __PublicRootInstance;
 
 declare module 'react-native/react-private-interface' {
+  declare export type FabricUIManager = __FabricUIManager;
+  declare export const fabricUIManager: __FabricUIManager;
+  // Feature flags owned by React Native. Each accessor is optional so that
+  // removing a flag on the React Native side doesn't throw here.
+  declare export interface ReactNativeFeatureFlags {
+    +enableNativeEventTargetEventDispatching?: () => boolean;
+  }
+  declare export const ReactNativeFeatureFlags: ReactNativeFeatureFlags;
   declare export function deepFreezeAndThrowOnMutationInDev<T>(obj: T): T;
   declare export const ReactFiberErrorDialog: {
     showErrorDialog: (error: __CapturedError) => boolean,
@@ -127,15 +135,8 @@ declare module 'react-native' {
   declare export type MeasureOnSuccessCallback = __MeasureOnSuccessCallback;
 }
 
-// eslint-disable-next-line no-unused-vars
-declare const RN$isNativeEventTargetEventDispatchingEnabled:
-  | (() => boolean)
-  | void;
-
-// This is needed for a short term solution.
 // See https://github.com/facebook/react/pull/15490 for more info
-// eslint-disable-next-line no-unused-vars
-declare const nativeFabricUIManager: {
+type __FabricUIManager = {
   createNode: (
     reactTag: number,
     viewName: string,

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -43,10 +43,6 @@ module.exports = {
     __REACT_DEVTOOLS_GLOBAL_HOOK__: 'readonly',
     // FB
     __DEV__: 'readonly',
-    // Fabric. See https://github.com/facebook/react/pull/15490
-    // for more information
-    nativeFabricUIManager: 'readonly',
-    RN$isNativeEventTargetEventDispatchingEnabled: 'readonly',
     // Trusted Types
     trustedTypes: 'readonly',
     // RN supports this


### PR DESCRIPTION
## Summary

ReactNativeFeatureFlags and fabricUIManager were introduced in `react-native/react-private-interface` in https://github.com/react/react-native/pull/57940 and https://github.com/react/react-native/pull/58398:

https://github.com/react/react-native/blob/73a76ddced2088d925809432fd6b0503f239dbfe/packages/react-native/src/react-private-interface.js#L74

https://github.com/react/react-native/blob/73a76ddced2088d925809432fd6b0503f239dbfe/packages/react-native/src/react-private-interface.js#L87

This migrates the use of globals for those bindings to use the exported values instead.

## How did you test this change?

Existing tests and Flow.