### PR TITLE
[compiler] Fix silent bailout on destructured parameter defaults under Babel 8

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/BuildHIR.ts
@@ -4220,7 +4220,17 @@ function lowerAssignment(
             continue;
           }
           const element = property.get('value');
-          if (!element.isLVal()) {
+          /*
+           * Babel 7 classifies `AssignmentPattern` (ie a destructured default
+           * such as `{a = 1}`) as part of the `LVal` alias group, so
+           * `element.isLVal()` returns true for it. Babel 8 narrowed the
+           * `LVal` alias group and no longer includes `AssignmentPattern`,
+           * even though it remains a valid assignment target that
+           * `lowerAssignment` explicitly handles below. Check for it
+           * separately so this destructuring case continues to compile
+           * under both Babel 7 and Babel 8.
+           */
+          if (!element.isLVal() && !element.isAssignmentPattern()) {
             builder.recordError(
               new CompilerErrorDetail({
                 reason: `(BuildHIR::lowerAssignment) Expected object property value to be an LVal, got: ${element.type}`,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-object-param-default-jsx.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-object-param-default-jsx.expect.md
@@ -1,0 +1,45 @@
+
+## Input
+
+```javascript
+function Component({a = 1}) {
+  return <div>{a}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+  isComponent: true,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+  const $ = _c(2);
+  const { a: t1 } = t0;
+  const a = t1 === undefined ? 1 : t1;
+  let t2;
+  if ($[0] !== a) {
+    t2 = <div>{a}</div>;
+    $[0] = a;
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+  isComponent: true,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>1</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-object-param-default-jsx.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/destructuring-object-param-default-jsx.js
@@ -1,0 +1,9 @@
+function Component({a = 1}) {
+  return <div>{a}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+  isComponent: true,
+};


### PR DESCRIPTION
## Summary

Fixes #37406.

Under `@babel/core@8`, React Compiler silently declined to compile any component using a **destructured parameter default**, e.g. `function C({ a = 1 })`. The identical input compiles fine under `@babel/core@7`.

## Root cause

`BuildHIR::lowerAssignment` guards `ObjectPattern` property values with `element.isLVal()` before lowering them:

```ts
const element = property.get('value');
if (!element.isLVal()) {
  builder.recordError(/* ... Todo bailout ... */);
  continue;
}
```

Under Babel 7, `AssignmentPattern` (the AST node produced for a destructured default like `{a = 1}`) is a member of Babel's `LVal` alias group, so `element.isLVal()` returns `true` for it. **Babel 8 narrowed the `LVal` alias group and no longer includes `AssignmentPattern`** — even though it remains a perfectly valid destructuring target, and `lowerAssignment` already has an explicit `case 'AssignmentPattern'` a few lines below that correctly lowers it (evaluating the default when the value is `undefined`).

Notably, `ArrayPattern` elements (e.g. `[a = 1]`) go through the exact same `lowerAssignment` code path but have **no equivalent `isLVal()` guard**, so array destructuring defaults were never affected by this — only the `ObjectPattern` branch has the extra (now overly strict under Babel 8) check.

Because the bailout's category is `"Todo"`, it's recorded via `builder.recordError` and swallowed at the default `panicThreshold`: the build succeeds with no warning printed, and the affected component is simply left uncompiled (or, depending on surrounding code, lowering continues with the destructured binding silently dropped, occasionally surfacing a secondary internal error further down the pipeline instead).

## Fix

Also accept `AssignmentPattern` as a valid object-pattern property value, matching how `ArrayPattern` items are already handled:

```ts
if (!element.isLVal() && !element.isAssignmentPattern()) {
  // ... Todo bailout ...
}
```

## Verification

- Added fixture `destructuring-object-param-default-jsx.js` (destructured default + JSX, mirroring the issue's repro) and confirmed the expected memoized output.
- Manually reproduced the issue's exact `repro.mjs` script against `@babel/core@8.0.1`:
  - **Before fix:** compilation fails/bails for `function C({ a = 1 }) { return <div>{a}</div>; }`.
  - **After fix:** `compiled: true`, with correct memo-cache emission (verified output matches what `@babel/core@7` already produces).
- `yarn workspace babel-plugin-react-compiler lint` passes.
- Ran the full compiler fixture suite (`node packages/snap/dist/main.js test --sync`, 1815 fixtures) before and after the change: identical set of 16 pre-existing failures (all unrelated to this change, e.g. `fbt`/`debugger`/`using`-declaration fixtures failing due to unrelated environment/version drift), no new failures, and the new/existing destructuring fixtures pass.

## Test plan

- [x] `yarn workspace babel-plugin-react-compiler lint`
- [x] Full fixture suite (`snap`) — no regressions
- [x] Manual repro against `@babel/core@8.0.1` confirming the fix