### PR TITLE
[compiler] Don't mutate the input array in DisjointSet.union

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
@@ -18,7 +18,7 @@ export default class DisjointSet<T> {
    * set.
    */
   union(items: Array<T>): void {
-    const first = items.shift();
+    const first = items[0];
     CompilerError.invariant(first != null, {
       reason: 'Expected set to be non-empty',
       loc: GeneratedSource,
@@ -34,7 +34,8 @@ export default class DisjointSet<T> {
       this.#entries.set(first, first);
     }
     // update remaining items (which may already be part of other sets)
-    for (const item of items) {
+    for (let i = 1; i < items.length; i++) {
+      const item = items[i];
       let itemParent = this.#entries.get(item);
       if (itemParent == null) {
         // new item, no existing set to update

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/DisjointSet-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/DisjointSet-test.ts
@@ -104,6 +104,22 @@ describe('DisjointSet', () => {
     `);
   });
 
+  // Regression test for issue #37417
+  it('.union - does not mutate the input array', () => {
+    const identifiers = new DisjointSet<TestIdentifier>();
+    const [x, y, z] = makeIdentifiers('x', 'y', 'z');
+
+    const items = [x, y, z];
+    identifiers.union(items);
+
+    // the caller's array is left intact
+    expect(items).toEqual([x, y, z]);
+    // and the union itself is still recorded
+    expect(identifiers.find(x)).toBe(x);
+    expect(identifiers.find(y)).toBe(x);
+    expect(identifiers.find(z)).toBe(x);
+  });
+
   // Regression test for issue #933
   it("`forEach` doesn't infinite loop when there are cycles", () => {
     const identifiers = new DisjointSet<TestIdentifier>();


### PR DESCRIPTION
## Summary

`DisjointSet.union(items)` read its representative with `items.shift()`. That
unexpectedly removed the caller's first element and paid an O(n) move before
the actual union traversal. Union now reads `items[0]` and iterates the rest
by index, leaving the caller's array untouched.

I checked every `union()` call site in the compiler (`MergeOverlappingReactiveScopesHIR`,
`AlignMethodCallScopes`, `AlignObjectMethodScopes`, `InferReactiveScopeVariables`):
they all pass fresh array literals or locally-built arrays, so none of them
relied on the mutation.

Fixes #37417

## Test evidence

- Added a regression test (`.union - does not mutate the input array`) to
  `src/__tests__/DisjointSet-test.ts` asserting the input array is intact after
  `union()` and that the union itself is still recorded.
- Ran the full `DisjointSet-test.ts` suite (jest + ts-jest): **6/6 tests pass**,
  including all pre-existing tests.
- Verified the new test **fails on the pre-fix code** (input array comes back
  as `[y, z]` instead of `[x, y, z]`) and passes with the fix.
- Also verified with a standalone reproduction of the old vs. new `union`
  logic: old code mutated the caller's array, new code does not, and union
  semantics are unchanged.
- Prettier check passes on both changed files.
