### PR TITLE
[Flight] Apply the traversal guard to fulfillReference

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -1838,6 +1838,8 @@ function fulfillReference(
       if (
         typeof value === 'object' &&
         value !== null &&
+        (getPrototypeOf(value) === ObjectPrototype ||
+          getPrototypeOf(value) === ArrayPrototype) &&
         hasOwnProperty.call(value, name)
       ) {
         value = value[name];


### PR DESCRIPTION
## Summary

#37144 ported the ReplyServer traversal guards to `FlightClient` and covered `getOutlinedModel`. `fulfillReference` performs the same `$id:a:b` path walk on the deferred path and was left checking only `hasOwnProperty`.

Across the two files, three of the four walkers restrict the walk to `Object.prototype` and `Array.prototype`:

| file | function | prototype guard |
|---|---|---|
| `ReactFlightReplyServer.js` | `getOutlinedModel` | yes |
| `ReactFlightReplyServer.js` | `fulfillReference` | yes |
| `ReactFlightClient.js` | `getOutlinedModel` | yes, added in #37144 |
| `ReactFlightClient.js` | `fulfillReference` | **no** |

This PR adds the same two lines to the fourth.

## Which walker runs is decided by stream ordering

`fulfillReference` is the deferred twin of `getOutlinedModel` — it runs when the referenced chunk was blocked rather than already resolved. That is selected by the order rows arrive in:

```
1:{"a":{"b":"hit"}}      // target first  -> resolves immediately -> getOutlinedModel
0:{"v":"$1:a:b"}

0:{"v":"$1:a:b"}         // reference first -> chunk is blocked   -> fulfillReference
1:{"a":{"b":"hit"}}
```

Both return `{"v":"hit"}` on 19.3.0, so reaching the unguarded walker takes nothing but reordering two rows.

## No bypass is known

I could not find a value that reaches the deferred walk whose prototype is neither `Object` nor `Array` **and** which carries the needed own property. `$Q` Map (`size` is a prototype accessor), `$D` Date and typed arrays all fail at `hasOwnProperty`, which both walkers share. The missing prototype check is shadowed rather than reachable today.

That is a property of the current tag alphabet rather than of the walk, and the alphabet grows — `$T` already yields a Proxy when a caller supplies a temporary reference set, and #36818 proposes null-prototype objects. Making the four walkers agree keeps this true by construction instead of by accident.

## How it was found

A static check that groups same-named functions across files and reports one that performs a guard its comparable sibling does not. It flagged `loadServerReference`, `getOutlinedModel`, `parseModelString` and `fulfill` in these two files; reading them produced the table above.
