### PR TITLE
[Flight] Guard performance tracks against negative timestamps

### DIFF
--- a/packages/react-client/src/ReactFlightPerformanceTrack.js
+++ b/packages/react-client/src/ReactFlightPerformanceTrack.js
@@ -149,7 +149,7 @@ export function logComponentAborted(
   childrenEndTime: number,
   rootEnv: string,
 ): void {
-  if (supportsUserTiming) {
+  if (supportsUserTiming && childrenEndTime >= 0) {
     const env = componentInfo.env;
     const name = componentInfo.name;
     const isPrimaryEnv = env === rootEnv;
@@ -206,7 +206,7 @@ export function logComponentErrored(
   rootEnv: string,
   error: mixed,
 ): void {
-  if (supportsUserTiming) {
+  if (supportsUserTiming && childrenEndTime >= 0) {
     const env = componentInfo.env;
     const name = componentInfo.name;
     const isPrimaryEnv = env === rootEnv;

--- a/packages/react-client/src/__tests__/ReactFlightPerformanceTrack-test.js
+++ b/packages/react-client/src/__tests__/ReactFlightPerformanceTrack-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+'use strict';
+
+let logComponentAborted;
+let logComponentErrored;
+
+describe('ReactFlightPerformanceTrack', () => {
+  beforeEach(() => {
+    console.timeStamp = jest.fn();
+    jest.spyOn(performance, 'measure');
+    jest.spyOn(performance, 'clearMeasures');
+
+    jest.resetModules();
+    ({
+      logComponentAborted,
+      logComponentErrored,
+    } = require('../ReactFlightPerformanceTrack'));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const componentInfo = {
+    name: 'Component',
+    env: 'Server',
+  };
+
+  it('does not measure an aborted component before its end time is initialized', () => {
+    logComponentAborted(componentInfo, 0, 0, 0, -Infinity, 'Server');
+
+    expect(performance.measure).not.toHaveBeenCalled();
+    expect(performance.clearMeasures).not.toHaveBeenCalled();
+    expect(console.timeStamp).not.toHaveBeenCalled();
+  });
+
+  it('does not measure an errored component before its end time is initialized', () => {
+    logComponentErrored(
+      componentInfo,
+      0,
+      0,
+      0,
+      -Infinity,
+      'Server',
+      new Error('boom'),
+    );
+
+    expect(performance.measure).not.toHaveBeenCalled();
+    expect(performance.clearMeasures).not.toHaveBeenCalled();
+    expect(console.timeStamp).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Skip aborted and errored Server Component performance entries while their children end time is still negative/uninitialized.
- Match the existing guard in `logComponentRender`, preventing invalid User Timing calls when the `-Infinity` sentinel reaches the Flight client.
- Add focused coverage for both aborted and errored component tracks.

Fixes #37561.

This also addresses the Next.js reproduction tracked in vercel/next.js#86060.

## How did you test this change?

- Confirmed the new development test fails before the source change with `TypeError: -Infinity is not a valid timestamp`.
- `yarn test ReactFlightPerformanceTrack --runInBand`
- `yarn test --prod ReactFlightPerformanceTrack --runInBand`
- `yarn lint packages/react-client/src/ReactFlightPerformanceTrack.js packages/react-client/src/__tests__/ReactFlightPerformanceTrack-test.js`
- `yarn flow dom-node`
- Reproduced the original browser failure through a Next.js Server Component auth redirect and verified the equivalent bundled patch removes the exception across repeated navigations.
