### PR TITLE
[compiler] Fix unused optional chain referencing a memoized declaration outside its scope

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/PropagateScopeDependenciesHIR.ts
@@ -567,21 +567,20 @@ export class DependencyCollectionContext {
     this.visitDependency(nextDependency);
   }
 
-  visitDependency(maybeDependency: ReactiveScopeDependency): void {
-    /*
-     * Any value used after its originally defining scope has concluded must be added as an
-     * output of its defining scope. Regardless of whether its a const or not,
-     * some later code needs access to the value. If the current
-     * scope we are visiting is the same scope where the value originates, it can't be a dependency
-     * on itself.
-     */
-
+  /*
+   * Any value used after its originally defining scope has concluded must be added as an
+   * output of its defining scope. Regardless of whether its a const or not,
+   * some later code needs access to the value. If the current
+   * scope we are visiting is the same scope where the value originates, it can't be a dependency
+   * on itself.
+   */
+  markPotentialScopeEscape(identifier: Identifier): void {
     /*
      * if originalDeclaration is undefined here, then this is not a local var
      * (all decls e.g. `let x;` should be initialized in BuildHIR)
      */
     const originalDeclaration = this.#declarations.get(
-      maybeDependency.identifier.declarationId,
+      identifier.declarationId,
     );
     if (
       originalDeclaration !== undefined &&
@@ -592,18 +591,20 @@ export class DependencyCollectionContext {
           !this.#isScopeActive(scope) &&
           !Iterable_some(
             scope.declarations.values(),
-            decl =>
-              decl.identifier.declarationId ===
-              maybeDependency.identifier.declarationId,
+            decl => decl.identifier.declarationId === identifier.declarationId,
           )
         ) {
-          scope.declarations.set(maybeDependency.identifier.id, {
-            identifier: maybeDependency.identifier,
+          scope.declarations.set(identifier.id, {
+            identifier,
             scope: originalDeclaration.scope.value!,
           });
         }
       });
     }
+  }
+
+  visitDependency(maybeDependency: ReactiveScopeDependency): void {
+    this.markPotentialScopeEscape(maybeDependency.identifier);
 
     // ref.current access is not a valid dep
     if (
@@ -690,6 +691,10 @@ export function handleInstruction(
   if (
     context.isDeferredDependency({kind: HIRValue.Instruction, value: instr})
   ) {
+    // An unused chain (e.g. `const x = a?.b`) still needs `a` to escape its scope.
+    if (value.kind === 'LoadLocal') {
+      context.markPotentialScopeEscape(value.place.identifier);
+    }
     return;
   }
   if (value.kind === 'PropertyLoad') {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/prune-unused-optional-member-expression-in-memo-block.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/prune-unused-optional-member-expression-in-memo-block.expect.md
@@ -1,0 +1,120 @@
+
+## Input
+
+```javascript
+function useLocation() {
+  return '/x';
+}
+const TABLE = {k1: {slug: 's1', icon: 'I1'}};
+function detect(pathname) {
+  return 'k1';
+}
+function routesFor(slug) {
+  return [slug];
+}
+function nameOf(key) {
+  return 'name';
+}
+
+function Sidebar({navigation}) {
+  const pathname = useLocation();
+  const key = detect(pathname);
+  const active = key ? TABLE[key] : null;
+  const contextNavigation = active ? routesFor(active.slug) : [];
+  const effective = navigation ?? contextNavigation;
+  const title = key ? nameOf(key) : 'home';
+  const Icon = active?.icon;
+  return <aside title={title}>{effective.length}</aside>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Sidebar,
+  params: [{navigation: undefined}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function useLocation() {
+  return "/x";
+}
+
+const TABLE = { k1: { slug: "s1", icon: "I1" } };
+function detect(pathname) {
+  return "k1";
+}
+
+function routesFor(slug) {
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== slug) {
+    t0 = [slug];
+    $[0] = slug;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+function nameOf(key) {
+  return "name";
+}
+
+function Sidebar(t0) {
+  const $ = _c(10);
+  const { navigation } = t0;
+  const pathname = useLocation();
+  let active;
+  let effective;
+  let t1;
+  if ($[0] !== navigation || $[1] !== pathname) {
+    const key = detect(pathname);
+    active = key ? TABLE[key] : null;
+    let t2;
+    if ($[5] !== active) {
+      t2 = active ? routesFor(active.slug) : [];
+      $[5] = active;
+      $[6] = t2;
+    } else {
+      t2 = $[6];
+    }
+    const contextNavigation = t2;
+    effective = navigation ?? contextNavigation;
+    t1 = key ? nameOf(key) : "home";
+    $[0] = navigation;
+    $[1] = pathname;
+    $[2] = active;
+    $[3] = effective;
+    $[4] = t1;
+  } else {
+    active = $[2];
+    effective = $[3];
+    t1 = $[4];
+  }
+  const title = t1;
+  active?.icon;
+  let t2;
+  if ($[7] !== effective.length || $[8] !== title) {
+    t2 = <aside title={title}>{effective.length}</aside>;
+    $[7] = effective.length;
+    $[8] = title;
+    $[9] = t2;
+  } else {
+    t2 = $[9];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Sidebar,
+  params: [{ navigation: undefined }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <aside title="name">1</aside>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/prune-unused-optional-member-expression-in-memo-block.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/prune-unused-optional-member-expression-in-memo-block.js
@@ -1,0 +1,29 @@
+function useLocation() {
+  return '/x';
+}
+const TABLE = {k1: {slug: 's1', icon: 'I1'}};
+function detect(pathname) {
+  return 'k1';
+}
+function routesFor(slug) {
+  return [slug];
+}
+function nameOf(key) {
+  return 'name';
+}
+
+function Sidebar({navigation}) {
+  const pathname = useLocation();
+  const key = detect(pathname);
+  const active = key ? TABLE[key] : null;
+  const contextNavigation = active ? routesFor(active.slug) : [];
+  const effective = navigation ?? contextNavigation;
+  const title = key ? nameOf(key) : 'home';
+  const Icon = active?.icon;
+  return <aside title={title}>{effective.length}</aside>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Sidebar,
+  params: [{navigation: undefined}],
+};


### PR DESCRIPTION
## PR Description
## Summary

Fixes a React Compiler bug where an unused optional-chain expression (e.g. `const Icon = active?.icon` that nothing reads) could survive compilation as a bare statement positioned *after* the memoization block that declares `active` closes — throwing `ReferenceError: active is not defined` at runtime.

## Root Cause

Values that get grouped into one memo block are only hoisted with a `let` declaration (instead of staying fully block-scoped `const`) when the compiler detects they're read from outside that block. For most cases this works correctly. But the individual instructions that make up an optional chain are treated as "deferred" - their dependency on `active` is meant to be recorded once, at the chain's overall site of use. When the chain's result is entirely unused, that site of use never exists, so the deferred read of `active` is never checked, and `active`'s declaration is never widened - even though `DeadCodeElimination` still structurally retains the chain's instructions (a documented, intentional behavior for value blocks), so they still get emitted.

## Changes

- `PropagateScopeDependenciesHIR.ts`: extracted the scope-escape check into a reusable method, and call it for the base identifier of a deferred `LoadLocal` (the root of a property/optional chain) so it still gets checked even when the chain's overall result is unused. Restricted to `LoadLocal` to avoid affecting context variables, which rely on the same deferral mechanism for reassignment/TDZ-sensitive bookkeeping.
- Added a regression fixture reproducing the issue's exact shape.

## Testing

- Full fixture suite: 1815 passed, 0 failed
- Lint: passed
- Typecheck: passed

## Manual Verification

1. Compile the new fixture and confirm `active` is now declared with `let` outside the memo block instead of `const` inside it.
2. Confirm the fixture evaluates without throwing.
3. Re-ran `hoisting-invalid-tdz-let` (a pre-existing fixture exercising the same deferred-dependency path for context variables) to confirm it's unaffected.

## Related Issue

Closes #37540
