### PR TITLE
[compiler] Fix refs validation false positive: scope ref-taint to exact property path

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoRefAccessInRender.ts
@@ -15,7 +15,9 @@ import {
   GeneratedSource,
   HIRFunction,
   IdentifierId,
+  ObjectPropertyKey,
   Place,
+  PropertyLiteral,
   SourceLocation,
   getHookKindForType,
   isRefValueType,
@@ -74,7 +76,21 @@ type RefAccessType =
 type RefAccessRefType =
   | {kind: 'Ref'; refId: RefId}
   | {kind: 'RefValue'; loc?: SourceLocation; refId?: RefId}
-  | {kind: 'Structure'; value: null | RefAccessRefType; fn: null | RefFnType};
+  | {
+      kind: 'Structure';
+      value: null | RefAccessRefType;
+      fn: null | RefFnType;
+      /*
+       * Tracks the ref-access type of each *statically known* property of
+       * this object, keyed by property name. This lets us answer "is this
+       * specific property a ref" precisely, instead of collapsing every
+       * property of the object into a single `value` (which previously
+       * caused a ref-taint on one property, e.g. from a JSX `ref` attribute,
+       * to incorrectly bleed into unrelated sibling properties).
+       * See https://github.com/facebook/react/issues/37507.
+       */
+      properties: null | Map<string, RefAccessType>;
+    };
 
 type RefFnType = {readRefEffect: boolean; returnType: RefAccessType};
 
@@ -82,6 +98,13 @@ class Env {
   #changed = false;
   #data: Map<IdentifierId, RefAccessType> = new Map();
   #temporaries: Map<IdentifierId, Place> = new Map();
+  /*
+   * Tracks a canonical Place for each (object identifier, property name) pair
+   * so that ref-taint inferred for one property (e.g. via a JSX `ref`
+   * attribute) does not bleed into sibling properties of the same object.
+   * See https://github.com/facebook/react/issues/37507.
+   */
+  #propertyTemporaries: Map<string, Place> = new Map();
 
   lookup(place: Place): Place {
     return this.#temporaries.get(place.identifier.id) ?? place;
@@ -89,6 +112,23 @@ class Env {
 
   define(place: Place, value: Place): void {
     this.#temporaries.set(place.identifier.id, value);
+  }
+
+  lookupProperty(
+    object: Place,
+    property: PropertyLiteral,
+  ): Place | undefined {
+    const objectId = this.lookup(object).identifier.id;
+    return this.#propertyTemporaries.get(`${objectId}.${property}`);
+  }
+
+  defineProperty(
+    object: Place,
+    property: PropertyLiteral,
+    value: Place,
+  ): void {
+    const objectId = this.lookup(object).identifier.id;
+    this.#propertyTemporaries.set(`${objectId}.${property}`, value);
   }
 
   resetChanged(): void {
@@ -156,9 +196,19 @@ function collectTemporariesSidemap(fn: HIRFunction, env: Env): void {
           ) {
             continue;
           }
-          const temp = env.lookup(value.object);
-          if (temp != null) {
-            env.define(lvalue, temp);
+          /*
+           * Alias this property load to the canonical temporary for the same
+           * (object, property) path, rather than to the object as a whole.
+           * Aliasing to the whole object would cause a ref-taint inferred for
+           * one property (e.g. `ctx.foo` passed to a JSX `ref` attribute) to
+           * incorrectly propagate to unrelated sibling properties read from
+           * the same object (e.g. `ctx.files`).
+           */
+          const existing = env.lookupProperty(value.object, value.property);
+          if (existing != null) {
+            env.define(lvalue, existing);
+          } else {
+            env.defineProperty(value.object, value.property, lvalue);
           }
           break;
         }
@@ -211,13 +261,66 @@ function tyEqual(a: RefAccessType, b: RefAccessType): boolean {
           b.fn !== null &&
           a.fn.readRefEffect === b.fn.readRefEffect &&
           tyEqual(a.fn.returnType, b.fn.returnType));
-      return (
-        fnTypesEqual &&
-        (a.value === b.value ||
-          (a.value !== null && b.value !== null && tyEqual(a.value, b.value)))
-      );
+      const valueEqual =
+        a.value === b.value ||
+        (a.value !== null && b.value !== null && tyEqual(a.value, b.value));
+      return fnTypesEqual && valueEqual && propertiesEqual(a.properties, b.properties);
     }
   }
+}
+
+function objectPropertyKeyToString(key: ObjectPropertyKey): string | null {
+  switch (key.kind) {
+    case 'string':
+    case 'identifier':
+      return key.name;
+    case 'number':
+      return String(key.name);
+    case 'computed':
+      return null;
+    default: {
+      return null;
+    }
+  }
+}
+
+function propertiesEqual(
+  a: null | Map<string, RefAccessType>,
+  b: null | Map<string, RefAccessType>,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || b === null) {
+    return a === null && b === null;
+  }
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const [key, aType] of a) {
+    const bType = b.get(key);
+    if (bType === undefined || !tyEqual(aType, bType)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function joinPropertiesMaps(
+  a: null | Map<string, RefAccessType>,
+  b: null | Map<string, RefAccessType>,
+): null | Map<string, RefAccessType> {
+  if (a === null || b === null) {
+    return null;
+  }
+  const result = new Map<string, RefAccessType>();
+  const keys = new Set([...a.keys(), ...b.keys()]);
+  for (const key of keys) {
+    const aType = a.get(key) ?? {kind: 'None'};
+    const bType = b.get(key) ?? {kind: 'None'};
+    result.set(key, joinRefAccessTypes(aType, bType));
+  }
+  return result;
 }
 
 function joinRefAccessTypes(...types: Array<RefAccessType>): RefAccessType {
@@ -263,10 +366,12 @@ function joinRefAccessTypes(...types: Array<RefAccessType>): RefAccessType {
           : b.value === null
             ? a.value
             : joinRefAccessRefTypes(a.value, b.value);
+      const properties = joinPropertiesMaps(a.properties, b.properties);
       return {
         kind: 'Structure',
         fn,
         value,
+        properties,
       };
     }
   }
@@ -369,7 +474,35 @@ function validateNoRefAccessInRenderImpl(
             const objType = env.get(instr.value.object.identifier.id);
             let lookupType: null | RefAccessType = null;
             if (objType?.kind === 'Structure') {
-              lookupType = objType.value;
+              /*
+               * Prefer the exact per-property type when statically known
+               * (e.g. `{ref, other}.other`) rather than falling back to the
+               * merged `value`, which represents "does this object have some
+               * ref-typed property" and would otherwise incorrectly taint
+               * unrelated sibling properties. See
+               * https://github.com/facebook/react/issues/37507.
+               */
+              const propertyType =
+                instr.value.kind === 'PropertyLoad' &&
+                objType.properties != null
+                  ? objType.properties.get(String(instr.value.property))
+                  : undefined;
+              if (propertyType !== undefined) {
+                lookupType = propertyType;
+              } else if (objType.properties == null) {
+                /*
+                 * No precise per-property info is available for this object
+                 * (e.g. it resulted from a whole-object merge such as
+                 * `object.foo = fn`, or from a spread/array). Conservatively
+                 * fall back to the object's merged type, matching this
+                 * validation's pre-existing (coarser) behavior for these
+                 * cases. When the object is known to hold a ref-accessing
+                 * function (`fn`), propagate the whole structure so that
+                 * function is still detected when called through this
+                 * property (e.g. `object.foo()`).
+                 */
+                lookupType = objType.fn != null ? objType : objType.value;
+              }
             } else if (objType?.kind === 'Ref') {
               lookupType = {
                 kind: 'RefValue',
@@ -451,6 +584,7 @@ function validateNoRefAccessInRenderImpl(
                 returnType,
               },
               value: null,
+              properties: null,
             });
             break;
           }
@@ -627,6 +761,38 @@ function validateNoRefAccessInRenderImpl(
               types.push(env.get(operand.identifier.id) ?? {kind: 'None'});
             }
             const value = joinRefAccessTypes(...types);
+            /*
+             * For object literals with statically known keys, also record the
+             * exact ref-access type of each property. This lets later
+             * `PropertyLoad`s of a *specific* property (e.g. `ctx.files`)
+             * answer precisely, instead of relying solely on `value` (the
+             * join of every property, including unrelated ones such as
+             * `ctx.inputRef`). See
+             * https://github.com/facebook/react/issues/37507.
+             */
+            let properties: null | Map<string, RefAccessType> = null;
+            if (instr.value.kind === 'ObjectExpression') {
+              properties = new Map();
+              for (const property of instr.value.properties) {
+                if (property.kind !== 'ObjectProperty') {
+                  /*
+                   * Spread element: we don't statically know which keys it
+                   * contributes, so we can't build a precise properties map.
+                   */
+                  properties = null;
+                  break;
+                }
+                const key = objectPropertyKeyToString(property.key);
+                if (key == null) {
+                  properties = null;
+                  break;
+                }
+                properties.set(
+                  key,
+                  env.get(property.place.identifier.id) ?? {kind: 'None'},
+                );
+              }
+            }
             if (
               value.kind === 'None' ||
               value.kind === 'Guard' ||
@@ -638,6 +804,7 @@ function validateNoRefAccessInRenderImpl(
                 kind: 'Structure',
                 value,
                 fn: null,
+                properties,
               });
             }
             break;

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-does-not-taint-sibling-properties.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-does-not-taint-sibling-properties.expect.md
@@ -1,0 +1,60 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+function Component({ctx}) {
+  return (
+    <div>
+      <input ref={ctx.foo} />
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+function Component(t0) {
+  const $ = _c(7);
+  const { ctx } = t0;
+  let t1;
+  if ($[0] !== ctx.foo) {
+    t1 = <input ref={ctx.foo} />;
+    $[0] = ctx.foo;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  let t2;
+  if ($[2] !== ctx.files.length) {
+    t2 = ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null;
+    $[2] = ctx.files.length;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  let t3;
+  if ($[4] !== t1 || $[5] !== t2) {
+    t3 = (
+      <div>
+        {t1}
+        {t2}
+      </div>
+    );
+    $[4] = t1;
+    $[5] = t2;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  return t3;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-does-not-taint-sibling-properties.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-jsx-ref-attribute-does-not-taint-sibling-properties.js
@@ -1,0 +1,9 @@
+// @validateRefAccessDuringRender
+function Component({ctx}) {
+  return (
+    <div>
+      <input ref={ctx.foo} />
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-in-object-literal-does-not-taint-sibling-properties.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-in-object-literal-does-not-taint-sibling-properties.expect.md
@@ -1,0 +1,82 @@
+
+## Input
+
+```javascript
+// @validateRefAccessDuringRender
+import {useRef, useState} from "react";
+function Component() {
+  const inputRef = useRef(null);
+  const [files] = useState([]);
+  const ctx = { inputRef, files };
+  return (
+    <div>
+      <input ref={ctx.inputRef} />
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateRefAccessDuringRender
+import { useRef, useState } from "react";
+function Component() {
+  const $ = _c(10);
+  const inputRef = useRef(null);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = [];
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  const [files] = useState(t0);
+  let t1;
+  if ($[1] !== files) {
+    t1 = { inputRef, files };
+    $[1] = files;
+    $[2] = t1;
+  } else {
+    t1 = $[2];
+  }
+  const ctx = t1;
+  let t2;
+  if ($[3] !== ctx.inputRef) {
+    t2 = <input ref={ctx.inputRef} />;
+    $[3] = ctx.inputRef;
+    $[4] = t2;
+  } else {
+    t2 = $[4];
+  }
+  let t3;
+  if ($[5] !== ctx.files.length) {
+    t3 = ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null;
+    $[5] = ctx.files.length;
+    $[6] = t3;
+  } else {
+    t3 = $[6];
+  }
+  let t4;
+  if ($[7] !== t2 || $[8] !== t3) {
+    t4 = (
+      <div>
+        {t2}
+        {t3}
+      </div>
+    );
+    $[7] = t2;
+    $[8] = t3;
+    $[9] = t4;
+  } else {
+    t4 = $[9];
+  }
+  return t4;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-in-object-literal-does-not-taint-sibling-properties.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/allow-ref-in-object-literal-does-not-taint-sibling-properties.js
@@ -1,0 +1,13 @@
+// @validateRefAccessDuringRender
+import {useRef, useState} from "react";
+function Component() {
+  const inputRef = useRef(null);
+  const [files] = useState([]);
+  const ctx = { inputRef, files };
+  return (
+    <div>
+      <input ref={ctx.inputRef} />
+      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
+    </div>
+  );
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-use-ref-added-to-dep-without-type-info.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-use-ref-added-to-dep-without-type-info.expect.md
@@ -41,13 +41,14 @@ Error: Cannot access refs during render
 
 React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef).
 
-error.invalid-use-ref-added-to-dep-without-type-info.ts:12:28
-  10 |   const x = {a, val: val.ref.current};
+error.invalid-use-ref-added-to-dep-without-type-info.ts:10:21
+   8 |   // however, this is an instance of accessing a ref during render and is disallowed
+   9 |   // under React's rules, so we reject this input
+> 10 |   const x = {a, val: val.ref.current};
+     |                      ^^^^^^^^^^^^^^^ Cannot access ref value during render
   11 |
-> 12 |   return <VideoList videos={x} />;
-     |                             ^ Cannot access ref value during render
+  12 |   return <VideoList videos={x} />;
   13 | }
-  14 |
 ```
           
       


### PR DESCRIPTION
## Summary

Fixes #37507.

`react-hooks/refs` (the compiler's `validateNoRefAccessInRender` pass) reported a false positive "Cannot access refs during render" on **unrelated sibling properties** of an object, whenever *any* property of that same object was passed to a JSX `ref` attribute:

```tsx
function Component({ctx}: {ctx: any}) {
  return (
    <div>
      <input ref={ctx.foo} />
      {ctx.files.length > 0 ? <p>{ctx.files.length}</p> : null}
    </div>
  );
}
```

`ctx.files` is not a ref and is never treated as one anywhere else — the only reason it was flagged is that a *sibling* property (`ctx.foo`) was passed to a JSX `ref=` attribute. The same false positive occurs for a real `useRef` stored inside a plain object literal (`const ctx = {inputRef, files}`).

## Root cause

1. `TypeInference/InferTypes.ts` infers (via `enableTreatRefLikeIdentifiersAsRefs`, default on) that any expression passed to a JSX `ref` attribute is ref-typed. This unification happens on the specific temporary produced by the `PropertyLoad`, e.g. the load of `ctx.foo`.
2. `Validation/ValidateNoRefAccessInRender.ts`'s `collectTemporariesSidemap` pre-pass aliased the result of **every** non-`.current` `PropertyLoad` to its *base object* identifier (not to the specific property).
3. Because `Env.get`/`Env.set` resolve reads/writes through this alias, when the main validation pass wrote the ref type inferred in step 1 for `ctx.foo`'s load, it landed in **`ctx`'s own slot** instead of a slot scoped to `foo`.
4. Every subsequent `PropertyLoad` of `ctx.*` then read `ctx`'s (now ref-tainted) slot and was reported as a ref access, regardless of which property was actually being read.
5. A related issue existed for object literals: `ObjectExpression` computed a single merged `value` representing "does any property of this object look like a ref", which a `PropertyLoad` of *any* property would read, again conflating sibling properties.

## Fix

- In `collectTemporariesSidemap`, alias a `PropertyLoad`'s result to the canonical temporary for the same **(object, property)** path instead of to the whole object. Property paths are now stable across `LoadLocal`/`StoreLocal` renames, matching the existing alias-following behavior, but no longer bleed across *different* properties of the same object.
- Track a per-property ref-access type map (`properties: Map<string, RefAccessType>`) on `Structure` types produced from object literals (`ObjectExpression`), so a `PropertyLoad` of a specific, statically-known property looks up that property's own type rather than the object-wide merged `value`.
- When no precise per-property info is available (e.g. the object contains a spread, or was mutated via `object.foo = someRefAccessingFn`), the validation conservatively falls back to the previous whole-object behavior, so existing detections (like calling a ref-accessing function that was dynamically assigned to a property) keep working.

## Testing

- Added two new compiler fixtures reproducing the reporter's exact repros, both now compile without errors:
  - `allow-jsx-ref-attribute-does-not-taint-sibling-properties.js`
  - `allow-ref-in-object-literal-does-not-taint-sibling-properties.js`
- Ran the full compiler snapshot suite (`yarn workspace snap run snap test`): **1817/1817 passing**, no regressions.
- One existing fixture's error *location* changed by a few characters, from a location that landed on a `PropertyLoad` of a *different* property. That fixture (`error.invalid-use-ref-added-to-dep-without-type-info`) still reports the same 2 real errors — a case still correctly rejected under React's ref-access-during-render rules — the diff is only in which of the two locations happens to have a specific loc attached; both are legitimate references to the ref access.
- `yarn workspace babel-plugin-react-compiler lint` passes.