### PR TITLE
[compiler] Fix DisjointSet.union mutating its input array

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/DisjointSet.ts
@@ -18,7 +18,7 @@ export default class DisjointSet<T> {
    * set.
    */
   union(items: Array<T>): void {
-    const first = items.shift();
+    const first = items[0];
     CompilerError.invariant(first != null, {
       reason: 'Expected set to be non-empty',
       loc: GeneratedSource,
@@ -34,7 +34,8 @@ export default class DisjointSet<T> {
       this.#entries.set(first, first);
     }
     // update remaining items (which may already be part of other sets)
-    for (const item of items) {
+    for (let i = 1; i < items.length; i++) {
+      const item = items[i];
       let itemParent = this.#entries.get(item);
       if (itemParent == null) {
         // new item, no existing set to update

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/DisjointSet-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/DisjointSet-test.ts
@@ -104,6 +104,20 @@ describe('DisjointSet', () => {
     `);
   });
 
+  // Regression test for issue #37417
+  it('.union - does not mutate the input array', () => {
+    const identifiers = new DisjointSet<TestIdentifier>();
+    const [x, y, z] = makeIdentifiers('x', 'y', 'z');
+    const items = [x, y, z];
+
+    identifiers.union(items);
+
+    expect(items).toEqual([x, y, z]);
+    expect(identifiers.find(x)).toBe(x);
+    expect(identifiers.find(y)).toBe(x);
+    expect(identifiers.find(z)).toBe(x);
+  });
+
   // Regression test for issue #933
   it("`forEach` doesn't infinite loop when there are cycles", () => {
     const identifiers = new DisjointSet<TestIdentifier>();


### PR DESCRIPTION
## Summary

Fixes #37417.

`DisjointSet.union(items)` called `items.shift()` to read the representative element. This unexpectedly mutated the caller-owned array (removing its first item) and incurred an unnecessary O(n) shift of the remaining elements before the actual union traversal even began.

## Fix

Read `items[0]` directly instead of calling `shift()`, and iterate over the remaining elements by index starting at `1`. This preserves the original linear traversal behavior of `union()` without mutating the caller's input array.

## Test plan

Added a unit test to `DisjointSet-test.ts` that asserts the input array passed to `union()` is unchanged afterwards, and that the resulting groups are still correctly computed.

- `yarn jest DisjointSet` — all 6 tests pass (including the new one)
- `yarn lint` on `babel-plugin-react-compiler` — passes