### PR TITLE
[compiler] Probe smallest remaining set first in Set_intersect

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/utils.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/utils.ts
@@ -110,9 +110,18 @@ export function Set_intersect<T>(sets: Array<ReadonlySet<T>>): Set<T> {
   }
   const result: Set<T> = new Set();
   const first = sets[0];
+  /*
+   * Check the remaining sets smallest-first so that non-members short
+   * circuit against the cheapest set to query, instead of always probing
+   * the sets in their supplied order (which may check large sets before
+   * ruling an element out via a much smaller one). This does not change
+   * `result`'s contents or insertion order, which are still driven solely
+   * by iterating `first`.
+   */
+  const rest = sets.slice(1).sort((a, b) => a.size - b.size);
   outer: for (const e of first) {
-    for (let i = 1; i < sets.length; i++) {
-      if (!sets[i].has(e)) {
+    for (const set of rest) {
+      if (!set.has(e)) {
         continue outer;
       }
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/utils-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/utils-test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Set_intersect} from '../Utils/utils';
+
+/**
+ * A `ReadonlySet` that counts calls to `.has()` so tests can assert on how
+ * many membership checks were performed against it.
+ */
+class CountingSet<T> implements ReadonlySet<T> {
+  #inner: Set<T>;
+  hasCallCount: number = 0;
+
+  constructor(values: Iterable<T>) {
+    this.#inner = new Set(values);
+  }
+
+  has(value: T): boolean {
+    this.hasCallCount++;
+    return this.#inner.has(value);
+  }
+
+  get size(): number {
+    return this.#inner.size;
+  }
+
+  forEach(
+    callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void,
+    thisArg?: any,
+  ): void {
+    this.#inner.forEach((value, value2) => callbackfn(value, value2, this), thisArg);
+  }
+
+  entries(): IterableIterator<[T, T]> {
+    return this.#inner.entries();
+  }
+
+  keys(): IterableIterator<T> {
+    return this.#inner.keys();
+  }
+
+  values(): IterableIterator<T> {
+    return this.#inner.values();
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.#inner[Symbol.iterator]();
+  }
+}
+
+describe('Set_intersect', () => {
+  it('returns the intersection of the given sets', () => {
+    const a = new Set([1, 2, 3, 4]);
+    const b = new Set([2, 3, 4, 5]);
+    const c = new Set([3, 4, 5, 6]);
+
+    expect(Set_intersect([a, b, c])).toEqual(new Set([3, 4]));
+  });
+
+  it('returns an empty set when any input is empty', () => {
+    expect(Set_intersect([new Set([1, 2]), new Set()])).toEqual(new Set());
+  });
+
+  it('returns a copy of the input when given a single set', () => {
+    const a = new Set([1, 2, 3]);
+    const result = Set_intersect([a]);
+    expect(result).toEqual(a);
+    expect(result).not.toBe(a);
+  });
+
+  it('preserves the first set iteration order in the result, regardless of remaining set order', () => {
+    const first = new Set(['c', 'a', 'b']);
+    const second = new Set(['a', 'b', 'c']);
+    expect([...Set_intersect([first, second])]).toEqual(['c', 'a', 'b']);
+  });
+
+  it('probes remaining sets smallest-first, minimizing checks against a large predecessor set', () => {
+    const SIZE = 10_000;
+    const range = Array.from({length: SIZE}, (_, i) => i);
+    // A large first set that we iterate over.
+    const first = new Set(range);
+    // A large second set supplied *before* the tiny third set. Under the
+    // naive "supplied order" strategy every element of `first` would be
+    // checked against this large set before ever reaching the tiny set.
+    const large = new CountingSet(range);
+    // A tiny set that excludes almost everything in `first`. If we probe
+    // smallest-first, most elements should short-circuit here without ever
+    // touching `large`.
+    const tiny = new CountingSet([1, 2]);
+
+    const result = Set_intersect([first, large, tiny]);
+
+    expect(result).toEqual(new Set([1, 2]));
+    // Every element of `first` is checked against the smallest set first.
+    expect(tiny.hasCallCount).toBe(first.size);
+    // Only elements that survive the tiny-set check (i.e. members of
+    // `tiny`) should ever be checked against the large set.
+    expect(large.hasCallCount).toBe(2);
+    expect(large.hasCallCount).toBeLessThan(tiny.hasCallCount);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #37437.

`Set_intersect` iterates the first input set and, for each element, checks
membership against the remaining sets **in the order they were supplied**,
regardless of set size. In the compiler's live use (intersecting
predecessor `assumedNonNullObjects` in `CollectHoistablePropertyLoads`),
an early large predecessor set followed by a much smaller one means most
non-member candidates still pay for a membership check against the large
set before the tiny set gets a chance to reject them cheaply.

## Fix

Sort the remaining sets (everything after the first) by size once before
the loop, and probe them smallest-first. Non-members now short-circuit
against the cheapest set to query. This does not change the algorithm's
semantics:

- The result's contents and insertion order are still driven solely by
  iterating the first set — unchanged.
- Only the *order in which the remaining sets are checked* per candidate
  changes, which cannot affect the intersection result since all sets
  must contain the element for it to be included either way.

## Test plan

Added `src/__tests__/utils-test.ts` covering `Set_intersect`, including a
regression test with a large first set, a large second set, and a tiny
third set. The test uses a small `ReadonlySet` wrapper that counts calls
to `.has()` and asserts that far fewer membership checks are performed
against the large set than against the tiny set (previously every element
of the first set that survived would hit the large set first).

- `yarn workspace babel-plugin-react-compiler lint` — passes
- `npx jest --config scripts/jest/main.config.js` — all 32 tests pass