### PR TITLE
fix(compiler): preserve extra arguments and call context in gating wrappers

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts
@@ -77,17 +77,23 @@ function insertAdditionalFunctionDeclaration(
 
   /**
    * Step 2: insert new function declaration
+   *
+   * The wrapper's formal parameters exist only to preserve `Function.length`
+   * parity with the original source. The actual dispatch to the optimized
+   * or unoptimized implementation is done via `Function.prototype.apply`
+   * with the wrapper's own `arguments` object and `this` value, so that
+   * extra arguments (beyond the declared params), `arguments.length`, and
+   * the call's `this` context are all forwarded faithfully. Using the
+   * synthetic params directly (as an ordinary call) would silently drop
+   * any arguments beyond what's declared and would lose `this`.
    */
   const newParams: Array<t.Identifier | t.RestElement> = [];
-  const genNewArgs: Array<() => t.Identifier | t.SpreadElement> = [];
   for (let i = 0; i < originalFnParams.length; i++) {
     const argName = `arg${i}`;
     if (originalFnParams[i].type === 'RestElement') {
       newParams.push(t.restElement(t.identifier(argName)));
-      genNewArgs.push(() => t.spreadElement(t.identifier(argName)));
     } else {
       newParams.push(t.identifier(argName));
-      genNewArgs.push(() => t.identifier(argName));
     }
   }
   // insertAfter called in reverse order of how nodes should appear in program
@@ -100,14 +106,14 @@ function insertAdditionalFunctionDeclaration(
           gatingCondition,
           t.returnStatement(
             t.callExpression(
-              compiled.id,
-              genNewArgs.map(fn => fn()),
+              t.memberExpression(compiled.id, t.identifier('apply')),
+              [t.thisExpression(), t.identifier('arguments')],
             ),
           ),
           t.returnStatement(
             t.callExpression(
-              unoptimizedFnName,
-              genNewArgs.map(fn => fn()),
+              t.memberExpression(unoptimizedFnName, t.identifier('apply')),
+              [t.thisExpression(), t.identifier('arguments')],
             ),
           ),
         ),

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/component-syntax-ref-gating.flow.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/component-syntax-ref-gating.flow.expect.md
@@ -46,8 +46,9 @@ function Foo_withRef_unoptimized(
   return <Stringify ref={ref} />;
 }
 function Foo_withRef(arg0, arg1) {
-  if (isForgetEnabled_Fixtures_result) return Foo_withRef_optimized(arg0, arg1);
-  else return Foo_withRef_unoptimized(arg0, arg1);
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_withRef_optimized.apply(this, arguments);
+  else return Foo_withRef_unoptimized.apply(this, arguments);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-extra-arguments.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-extra-arguments.expect.md
@@ -1,0 +1,52 @@
+
+## Input
+
+```javascript
+// @gating
+import {memo} from 'react';
+
+export default memo(Foo);
+function Foo(a) {
+  'use memo';
+  return `${arguments.length}:${a}:${arguments[1]}:${arguments[2]}`;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('Foo'),
+  params: ['first', 'second', 2],
+};
+
+```
+
+## Code
+
+```javascript
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag"; // @gating
+import { memo } from "react";
+
+export default memo(Foo);
+const isForgetEnabled_Fixtures_result = isForgetEnabled_Fixtures();
+function Foo_optimized(a) {
+  "use memo";
+
+  return `${arguments.length}:${a}:${arguments[1]}:${arguments[2]}`;
+}
+function Foo_unoptimized(a) {
+  "use memo";
+  return `${arguments.length}:${a}:${arguments[1]}:${arguments[2]}`;
+}
+function Foo(arg0) {
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_optimized.apply(this, arguments);
+  else return Foo_unoptimized.apply(this, arguments);
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval("Foo"),
+  params: ["first", "second", 2],
+};
+
+```
+      
+### Eval output
+(kind: ok) "3:first:second:2"

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-extra-arguments.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-extra-arguments.js
@@ -1,0 +1,13 @@
+// @gating
+import {memo} from 'react';
+
+export default memo(Foo);
+function Foo(a) {
+  'use memo';
+  return `${arguments.length}:${a}:${arguments[1]}:${arguments[2]}`;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: eval('Foo'),
+  params: ['first', 'second', 2],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-ref.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl-ref.expect.md
@@ -45,8 +45,9 @@ function Foo_withRef_unoptimized(props, ref) {
   return <Stringify ref={ref} {...props} />;
 }
 function Foo_withRef(arg0, arg1) {
-  if (isForgetEnabled_Fixtures_result) return Foo_withRef_optimized(arg0, arg1);
-  else return Foo_withRef_unoptimized(arg0, arg1);
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_withRef_optimized.apply(this, arguments);
+  else return Foo_withRef_unoptimized.apply(this, arguments);
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/gating/gating-use-before-decl.expect.md
@@ -49,8 +49,9 @@ function Foo_unoptimized({ prop1, prop2 }) {
   return <Stringify prop1={prop1} prop2={prop2} />;
 }
 function Foo(arg0) {
-  if (isForgetEnabled_Fixtures_result) return Foo_optimized(arg0);
-  else return Foo_unoptimized(arg0);
+  if (isForgetEnabled_Fixtures_result)
+    return Foo_optimized.apply(this, arguments);
+  else return Foo_unoptimized.apply(this, arguments);
 }
 
 export const FIXTURE_ENTRYPOINT = {


### PR DESCRIPTION
## Summary

Fixes #37439.

When a function declaration is referenced before its own declaration site (e.g. `export default memo(Foo); function Foo() {...}`) and compiler gating is enabled, the compiler generates a synthetic top-level wrapper function that picks between the optimized and unoptimized implementations at runtime based on a gating condition:

```js
function Foo(arg0) {
  if (isForgetEnabled_result) return Foo_optimized(arg0);
  else return Foo_unoptimized(arg0);
}
```

This wrapper only forwards its own synthetic named parameters (`arg0`, `arg1`, ...) to the selected implementation via an ordinary call. As a result:
- Any arguments beyond the declared parameter count are silently dropped.
- `arguments.length` observed inside the selected implementation no longer matches what the caller actually passed.
- The caller's `this` context is lost (an ordinary function call has `this === undefined` in strict mode).

None of this happens for the uncompiled/ungated version of the same code, so gating changes runtime behavior in a way that's invisible to the type system and easy to miss.

## Fix

`insertAdditionalFunctionDeclaration` in `compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Gating.ts` now dispatches to the selected implementation using `Function.prototype.apply` with the wrapper's own `arguments` object and `this` value:

```js
function Foo(arg0) {
  if (isForgetEnabled_result) return Foo_optimized.apply(this, arguments);
  else return Foo_unoptimized.apply(this, arguments);
}
```

The synthetic parameters are still declared on the wrapper (so `Function.length` still matches the original source), but the actual call now forwards the complete, real `arguments`/`this` instead of just the named synthetic params. This makes the gated wrapper's calling semantics parity with the uncompiled function.

## Test plan

Added `gating/gating-use-before-decl-extra-arguments.{js,expect.md}`: a fixture that gates a function declared with a single formal parameter but which reads `arguments.length`/`arguments[1]`/`arguments[2]` at runtime, and is invoked with 3 arguments. The eval output confirms parity (`"3:first:second:2"`) with the extra arguments preserved.

Also updated the existing gating fixture snapshots (`gating-use-before-decl`, `gating-use-before-decl-ref`, `component-syntax-ref-gating.flow`) to reflect the new `.apply(this, arguments)` codegen.

- `yarn workspace babel-plugin-react-compiler lint` — clean
- `yarn snap:ci` (in `compiler/packages/babel-plugin-react-compiler`) — 1815 tests, 1815 passed, 0 failed