### PR TITLE
fix(compiler): anchor eslint suppression rule-name matching to avoid prefix/regex false positives

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Suppression.ts
@@ -13,7 +13,7 @@ import {
   CompilerSuggestionOperation,
   ErrorCategory,
 } from '../CompilerError';
-import {assertExhaustive} from '../Utils/utils';
+import {assertExhaustive, escapeStringRegexp} from '../Utils/utils';
 import {GeneratedSource} from '../HIR';
 
 /**
@@ -90,7 +90,18 @@ export function findProgramSuppressions(
   let disablePattern: RegExp | null = null;
   let enablePattern: RegExp | null = null;
   if (ruleNames != null && ruleNames.length !== 0) {
-    const rulePattern = `(${ruleNames.join('|')})`;
+    /*
+     * Escape regex special characters in each configured rule name and anchor
+     * the match to a rule-list separator (comma or whitespace) or the end of
+     * the comment, so that a configured rule like `react-hooks/rules-of-hooks`
+     * does not also match a longer rule sharing the same prefix (e.g.
+     * `react-hooks/rules-of-hooks-extra`), and punctuation such as `.` is
+     * matched literally rather than as a regex wildcard.
+     */
+    const escapedRuleNames = ruleNames.map(ruleName =>
+      escapeStringRegexp(ruleName),
+    );
+    const rulePattern = `(?:${escapedRuleNames.join('|')})(?=[,\\s]|$)`;
     disableNextLinePattern = new RegExp(
       `eslint-disable-next-line ${rulePattern}`,
     );

--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/utils.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/utils.ts
@@ -30,6 +30,14 @@ export function assertExhaustive(_: never, errorMsg: string): never {
   throw new Error(errorMsg);
 }
 
+/*
+ * Escapes special regular expression characters in @param str so that it can
+ * be safely embedded in a RegExp and matched literally.
+ */
+export function escapeStringRegexp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Modifies @param array in place, retaining only the items where the predicate returns true.
 export function retainWhere<T>(
   array: Array<T>,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Suppression-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Suppression-test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as t from '@babel/types';
+import {findProgramSuppressions} from '../Entrypoint/Suppression';
+import {escapeStringRegexp} from '../Utils/utils';
+
+function makeLineComment(value: string): t.Comment {
+  return {
+    type: 'CommentLine',
+    value,
+    start: 0,
+    end: value.length,
+    loc: null,
+  } as unknown as t.Comment;
+}
+
+describe('findProgramSuppressions', () => {
+  it('does not treat a longer rule sharing a prefix as a suppression', () => {
+    // Regression test for https://github.com/facebook/react/issues/37413
+    const comment = makeLineComment(
+      ' eslint-disable-next-line react-hooks/rules-of-hooks-extra',
+    );
+    const suppressions = findProgramSuppressions(
+      [comment],
+      ['react-hooks/rules-of-hooks'],
+      false,
+    );
+    expect(suppressions).toEqual([]);
+  });
+
+  it('still matches the exact configured rule name', () => {
+    const comment = makeLineComment(
+      ' eslint-disable-next-line react-hooks/rules-of-hooks',
+    );
+    const suppressions = findProgramSuppressions(
+      [comment],
+      ['react-hooks/rules-of-hooks'],
+      false,
+    );
+    expect(suppressions.length).toBe(1);
+  });
+
+  it('matches the exact configured rule name when followed by another rule', () => {
+    const comment = makeLineComment(
+      ' eslint-disable-next-line react-hooks/rules-of-hooks, other-rule',
+    );
+    const suppressions = findProgramSuppressions(
+      [comment],
+      ['react-hooks/rules-of-hooks'],
+      false,
+    );
+    expect(suppressions.length).toBe(1);
+  });
+
+  it('does not treat "." in the configured rule name as a regex wildcard', () => {
+    // Regression test for https://github.com/facebook/react/issues/37413
+    const comment = makeLineComment(
+      ' eslint-disable-next-line my-plugin/reactXrule',
+    );
+    const suppressions = findProgramSuppressions(
+      [comment],
+      ['my-plugin/react.rule'],
+      false,
+    );
+    expect(suppressions).toEqual([]);
+  });
+
+  it('matches when the configured rule name contains a literal "."', () => {
+    const comment = makeLineComment(
+      ' eslint-disable-next-line my-plugin/react.rule',
+    );
+    const suppressions = findProgramSuppressions(
+      [comment],
+      ['my-plugin/react.rule'],
+      false,
+    );
+    expect(suppressions.length).toBe(1);
+  });
+});
+
+describe('escapeStringRegexp', () => {
+  it('escapes regex special characters so they are matched literally', () => {
+    expect(escapeStringRegexp('my-plugin/react.rule')).toBe(
+      'my-plugin/react\\.rule',
+    );
+    expect(new RegExp(escapeStringRegexp('a.b')).test('axb')).toBe(false);
+    expect(new RegExp(escapeStringRegexp('a.b')).test('a.b')).toBe(true);
+  });
+});

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bailout-on-suppression-of-custom-rule.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bailout-on-suppression-of-custom-rule.expect.md
@@ -2,7 +2,7 @@
 ## Input
 
 ```javascript
-// @eslintSuppressionRules:["my-app","react-rule"] @validateExhaustiveMemoizationDependencies:false
+// @eslintSuppressionRules:["my-app/react-rule"] @validateExhaustiveMemoizationDependencies:false
 
 /* eslint-disable my-app/react-rule */
 function lowercasecomponent() {
@@ -26,7 +26,7 @@ Error: React Compiler has skipped optimizing this component because one or more 
 React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable my-app/react-rule`.
 
 error.bailout-on-suppression-of-custom-rule.ts:3:0
-  1 | // @eslintSuppressionRules:["my-app","react-rule"] @validateExhaustiveMemoizationDependencies:false
+  1 | // @eslintSuppressionRules:["my-app/react-rule"] @validateExhaustiveMemoizationDependencies:false
   2 |
 > 3 | /* eslint-disable my-app/react-rule */
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Found React rule suppression

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bailout-on-suppression-of-custom-rule.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.bailout-on-suppression-of-custom-rule.js
@@ -1,4 +1,4 @@
-// @eslintSuppressionRules:["my-app","react-rule"] @validateExhaustiveMemoizationDependencies:false
+// @eslintSuppressionRules:["my-app/react-rule"] @validateExhaustiveMemoizationDependencies:false
 
 /* eslint-disable my-app/react-rule */
 function lowercasecomponent() {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-does-not-match-rule-prefix.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-does-not-match-rule-prefix.expect.md
@@ -1,0 +1,55 @@
+
+## Input
+
+```javascript
+// @eslintSuppressionRules:["react-hooks/rules-of-hooks"]
+
+// The configured suppression rule is `react-hooks/rules-of-hooks`. A comment
+// that disables a *different* rule which merely shares this as a prefix
+// (`react-hooks/rules-of-hooks-extra`) must not be treated as a suppression
+// of the configured rule.
+function Component(props) {
+  'use forget';
+  // eslint-disable-next-line react-hooks/rules-of-hooks-extra
+  return <div>{props.text}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{text: 'Hello'}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @eslintSuppressionRules:["react-hooks/rules-of-hooks"]
+
+// The configured suppression rule is `react-hooks/rules-of-hooks`. A comment
+// that disables a *different* rule which merely shares this as a prefix
+// (`react-hooks/rules-of-hooks-extra`) must not be treated as a suppression
+// of the configured rule.
+function Component(props) {
+  "use forget";
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== props.text) {
+    t0 = <div>{props.text}</div>;
+    $[0] = props.text;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ text: "Hello" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>Hello</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-does-not-match-rule-prefix.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-does-not-match-rule-prefix.js
@@ -1,0 +1,16 @@
+// @eslintSuppressionRules:["react-hooks/rules-of-hooks"]
+
+// The configured suppression rule is `react-hooks/rules-of-hooks`. A comment
+// that disables a *different* rule which merely shares this as a prefix
+// (`react-hooks/rules-of-hooks-extra`) must not be treated as a suppression
+// of the configured rule.
+function Component(props) {
+  'use forget';
+  // eslint-disable-next-line react-hooks/rules-of-hooks-extra
+  return <div>{props.text}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{text: 'Hello'}],
+};

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-dot-is-not-a-wildcard.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-dot-is-not-a-wildcard.expect.md
@@ -1,0 +1,55 @@
+
+## Input
+
+```javascript
+// @eslintSuppressionRules:["my-plugin/react.rule"]
+
+// The configured suppression rule name contains a literal `.`. It should be
+// matched literally rather than treated as a regex wildcard, so a comment
+// disabling `my-plugin/reactXrule` must not be treated as a suppression of
+// the configured `my-plugin/react.rule`.
+function Component(props) {
+  'use forget';
+  // eslint-disable-next-line my-plugin/reactXrule
+  return <div>{props.text}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{text: 'Hello'}],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @eslintSuppressionRules:["my-plugin/react.rule"]
+
+// The configured suppression rule name contains a literal `.`. It should be
+// matched literally rather than treated as a regex wildcard, so a comment
+// disabling `my-plugin/reactXrule` must not be treated as a suppression of
+// the configured `my-plugin/react.rule`.
+function Component(props) {
+  "use forget";
+  const $ = _c(2);
+  let t0;
+  if ($[0] !== props.text) {
+    t0 = <div>{props.text}</div>;
+    $[0] = props.text;
+    $[1] = t0;
+  } else {
+    t0 = $[1];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ text: "Hello" }],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>Hello</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-dot-is-not-a-wildcard.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/eslint-suppression-dot-is-not-a-wildcard.js
@@ -1,0 +1,16 @@
+// @eslintSuppressionRules:["my-plugin/react.rule"]
+
+// The configured suppression rule name contains a literal `.`. It should be
+// matched literally rather than treated as a regex wildcard, so a comment
+// disabling `my-plugin/reactXrule` must not be treated as a suppression of
+// the configured `my-plugin/react.rule`.
+function Component(props) {
+  'use forget';
+  // eslint-disable-next-line my-plugin/reactXrule
+  return <div>{props.text}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{text: 'Hello'}],
+};


### PR DESCRIPTION
## Summary

Fixes #37413.

Configured ESLint rule names passed via `eslintSuppressionRules` (and the
built-in default rule list) were interpolated directly into a `RegExp`
without escaping or a trailing boundary. This meant:

- A configured rule could match a *longer* rule sharing the same prefix,
  e.g. `react-hooks/rules-of-hooks` also matched
  `react-hooks/rules-of-hooks-extra`.
- Punctuation in a rule name, such as `.`, was treated as a regex wildcard,
  e.g. a configured `my-plugin/react.rule` also matched
  `my-plugin/reactXrule`.

## Fix

In `Suppression.ts`'s `findProgramSuppressions`, each configured rule name
is now escaped via a small new `escapeStringRegexp` helper (added to
`Utils/utils.ts`) before being interpolated into the generated `RegExp`.
The match is also anchored with a lookahead requiring a rule-list separator
(comma or whitespace) or end of the comment immediately after the rule
name, so a configured rule can no longer match as a prefix of a longer,
unrelated rule name.

I also found and fixed a fixture (`error.bailout-on-suppression-of-custom-rule`)
whose `@eslintSuppressionRules` pragma relied on the old unanchored
substring matching — it split a single scoped rule name
(`my-app/react-rule`) into two separate array entries (`["my-app",
"react-rule"]`), which only "worked" because of the bug being fixed here.
Updated it to use the actual full rule name as a single array entry, which
still triggers the intended suppression-detection bailout.

## Test plan

- Added `Suppression-test.ts` with unit tests for `findProgramSuppressions`
  and `escapeStringRegexp` covering:
  - the rule-prefix false positive from the issue
  - the `.`-as-wildcard false positive from the issue
  - that exact rule name matches (including when followed by another rule
    in the disable list) still work correctly
- Added two new compiler fixtures (`eslint-suppression-does-not-match-rule-prefix`,
  `eslint-suppression-dot-is-not-a-wildcard`) demonstrating that compilation
  no longer bails out for these false-positive cases.
- Ran the full fixture suite (`yarn workspace snap run snap`): 1816/1816
  passing.
- Ran `yarn jest` for `babel-plugin-react-compiler`: 16/16 suites, 49/49
  tests passing.
- Ran `yarn eslint src` for `babel-plugin-react-compiler`: no errors.