### PR TITLE
[flags] Cleanup enableFragmentRefs feature flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -64,7 +64,6 @@ describe('FragmentRefs', () => {
     document.body.removeChild(container);
   });
 
-  // @gate enableFragmentRefs
   it('attaches a ref to Fragment', async () => {
     const fragmentRef = React.createRef();
     const root = ReactDOMClient.createRoot(container);
@@ -85,7 +84,6 @@ describe('FragmentRefs', () => {
     expect(fragmentRef.current).not.toBe(null);
   });
 
-  // @gate enableFragmentRefs
   it('accepts a ref callback', async () => {
     let fragmentRef;
     const root = ReactDOMClient.createRoot(container);
@@ -101,7 +99,6 @@ describe('FragmentRefs', () => {
     expect(fragmentRef._fragmentFiber).toBeTruthy();
   });
 
-  // @gate enableFragmentRefs
   it('is available in effects', async () => {
     function Test() {
       const fragmentRef = React.useRef(null);
@@ -122,7 +119,7 @@ describe('FragmentRefs', () => {
     await act(() => root.render(<Test />));
   });
 
-  // @gate enableFragmentRefs && enableFragmentRefsInstanceHandles
+  // @gate enableFragmentRefsInstanceHandles
   it('attaches fragment handles to nodes', async () => {
     const fragmentParentRef = React.createRef();
     const fragmentRef = React.createRef();
@@ -161,7 +158,6 @@ describe('FragmentRefs', () => {
     expect(childD.reactFragments.has(fragmentParentRef.current)).toBe(true);
   });
 
-  // @gate enableFragmentRefs
   it('runs the ref cleanup when an inline ref callback changes identity', async () => {
     const fragmentInstances = [];
     let rerender;
@@ -220,7 +216,6 @@ describe('FragmentRefs', () => {
     expect(fragmentInstances[0]).toBe(fragmentInstances[1]);
   });
 
-  // @gate enableFragmentRefs
   it('runs the ref cleanup when the ref is removed from a mounted Fragment', async () => {
     function Test({withRef}) {
       return (
@@ -255,7 +250,6 @@ describe('FragmentRefs', () => {
     assertLog([]);
   });
 
-  // @gate enableFragmentRefs
   it('detaches and reattaches Fragment refs when StrictMode double invokes', async () => {
     // This one collects its own log rather than using Scheduler.log, because
     // setIsStrictModeForDevtools disables yield values for the duration of the
@@ -309,7 +303,6 @@ describe('FragmentRefs', () => {
 
   describe('focus methods', () => {
     describe('focus()', () => {
-      // @gate enableFragmentRefs
       it('focuses the first focusable child', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -342,7 +335,6 @@ describe('FragmentRefs', () => {
         document.activeElement.blur();
       });
 
-      // @gate enableFragmentRefs
       it('focuses deeply nested focusable children, depth first', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -368,7 +360,6 @@ describe('FragmentRefs', () => {
         expect(document.activeElement.id).toEqual('grandchild-a');
       });
 
-      // @gate enableFragmentRefs
       it('preserves document order when adding and removing children', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -412,7 +403,6 @@ describe('FragmentRefs', () => {
         document.activeElement.blur();
       });
 
-      // @gate enableFragmentRefs
       it('keeps focus on the first focusable child if already focused', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -447,7 +437,6 @@ describe('FragmentRefs', () => {
         document.activeElement.blur();
       });
 
-      // @gate enableFragmentRefs
       it('keeps focus on a nested child if already focused', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -481,7 +470,6 @@ describe('FragmentRefs', () => {
         document.activeElement.blur();
       });
 
-      // @gate enableFragmentRefs
       it('focuses the first focusable child in a fieldset', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -510,7 +498,6 @@ describe('FragmentRefs', () => {
     });
 
     describe('focusLast()', () => {
-      // @gate enableFragmentRefs
       it('focuses the last focusable child', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -548,7 +535,6 @@ describe('FragmentRefs', () => {
         document.activeElement.blur();
       });
 
-      // @gate enableFragmentRefs
       it('focuses deeply nested focusable children, depth first', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -578,7 +564,6 @@ describe('FragmentRefs', () => {
     });
 
     describe('blur()', () => {
-      // @gate enableFragmentRefs
       it('removes focus from an element inside of the Fragment', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -608,7 +593,6 @@ describe('FragmentRefs', () => {
         expect(document.activeElement).toEqual(document.body);
       });
 
-      // @gate enableFragmentRefs
       it('removes focus from a nested element inside of the Fragment', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -638,7 +622,6 @@ describe('FragmentRefs', () => {
         expect(document.activeElement).toEqual(document.body);
       });
 
-      // @gate enableFragmentRefs
       it('removes focus from a portaled element inside of the Fragment', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -673,7 +656,6 @@ describe('FragmentRefs', () => {
         expect(document.activeElement).toEqual(document.body);
       });
 
-      // @gate enableFragmentRefs
       it('does not remove focus from elements outside of the Fragment', async () => {
         const fragmentRefA = React.createRef();
         const fragmentRefB = React.createRef();
@@ -713,7 +695,6 @@ describe('FragmentRefs', () => {
 
   describe('events', () => {
     describe('add/remove event listeners', () => {
-      // @gate enableFragmentRefs
       it('adds and removes event listeners from children', async () => {
         const parentRef = React.createRef();
         const fragmentRef = React.createRef();
@@ -795,7 +776,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['B']);
       });
 
-      // @gate enableFragmentRefs
       it('regression: does not detach a registered listener when removing an unregistered one', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -836,7 +816,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('matches listeners by their normalized capture flag', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -877,7 +856,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('adds and removes event listeners from children with multiple fragments', async () => {
         const fragmentRef = React.createRef();
         const nestedFragmentRef = React.createRef();
@@ -956,7 +934,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['nestedFragmentRef2']);
       });
 
-      // @gate enableFragmentRefs
       it('adds an event listener to a newly added child', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -1004,7 +981,6 @@ describe('FragmentRefs', () => {
         expect(hasClicked).toBe(true);
       });
 
-      // @gate enableFragmentRefs
       it('fires a once listener only once across existing children', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -1043,7 +1019,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('does not re-arm a once listener when a new child is inserted', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -1098,7 +1073,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('should remove the listener when the signal is aborted before registration', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -1131,7 +1105,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['registered']);
       });
 
-      // @gate enableFragmentRefs
       it('should remove the listener when the signal is aborted after registration', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -1169,7 +1142,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['registered']);
       });
 
-      // @gate enableFragmentRefs
       it('should NOT remove the new subscription when the signal for the old subscription is aborted', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -1214,7 +1186,7 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['registered']);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsTextNodes
+      // @gate enableFragmentRefsTextNodes
       it('adds an event listener to a newly added text child', async () => {
         const fragmentRef = React.createRef();
         const parentRef = React.createRef();
@@ -1257,7 +1229,7 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['fragment']);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsTextNodes
+      // @gate enableFragmentRefsTextNodes
       it('removes event listeners from a deleted text child', async () => {
         const fragmentRef = React.createRef();
         const parentRef = React.createRef();
@@ -1311,7 +1283,6 @@ describe('FragmentRefs', () => {
         document.body.removeChild(detachedHost);
       });
 
-      // @gate enableFragmentRefs
       it('applies event listeners to host children nested within non-host children', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -1346,7 +1317,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['Host A', 'Host B']);
       });
 
-      // @gate enableFragmentRefs
       it('allows adding and cleaning up listeners in effects', async () => {
         const root = ReactDOMClient.createRoot(container);
 
@@ -1394,7 +1364,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['child-a']);
       });
 
-      // @gate enableFragmentRefs
       it('does not apply removed event listeners to new children', async () => {
         const root = ReactDOMClient.createRoot(container);
         const fragmentRef = React.createRef(null);
@@ -1424,7 +1393,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('removes a capture listener registered with boolean when removed with options object', async () => {
         const fragmentRef = React.createRef(null);
         function Test() {
@@ -1461,7 +1429,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('removes a capture listener registered with options object when removed with boolean', async () => {
         const fragmentRef = React.createRef(null);
         function Test() {
@@ -1498,7 +1465,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual([]);
       });
 
-      // @gate enableFragmentRefs
       it('applies event listeners to portaled children', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -1534,7 +1500,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['child-b']);
       });
 
-      // @gate enableFragmentRefs
       it('applies event listeners to children portaled in after registration', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -1585,7 +1550,6 @@ describe('FragmentRefs', () => {
       });
 
       describe('with activity', () => {
-        // @gate enableFragmentRefs
         it('does not apply event listeners to hidden trees', async () => {
           const parentRef = React.createRef();
           const fragmentRef = React.createRef();
@@ -1621,7 +1585,6 @@ describe('FragmentRefs', () => {
           expect(logs).toEqual(['Child 1', 'Child 3']);
         });
 
-        // @gate enableFragmentRefs
         it('applies event listeners to visible trees', async () => {
           const parentRef = React.createRef();
           const fragmentRef = React.createRef();
@@ -1657,7 +1620,6 @@ describe('FragmentRefs', () => {
           expect(logs).toEqual(['Child 1', 'Child 2', 'Child 3']);
         });
 
-        // @gate enableFragmentRefs
         it('handles Activity modes switching', async () => {
           const fragmentRef = React.createRef();
           const fragmentRef2 = React.createRef();
@@ -1710,7 +1672,7 @@ describe('FragmentRefs', () => {
           expect(logs).toEqual(['clicked 2', 'clicked 1']);
         });
 
-        // @gate enableFragmentRefs && enableFragmentRefsTextNodes
+        // @gate enableFragmentRefsTextNodes
         it('does not dispatch fragment events from text children while hidden', async () => {
           const parentRef = React.createRef();
           const fragmentRef = React.createRef();
@@ -1773,7 +1735,6 @@ describe('FragmentRefs', () => {
     });
 
     describe('dispatchEvent()', () => {
-      // @gate enableFragmentRefs
       it('fires events on the host parent if bubbles=true', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -1831,7 +1792,6 @@ describe('FragmentRefs', () => {
         expect(isCancelable).toBe(false);
       });
 
-      // @gate enableFragmentRefs
       it('fires events on self, and only self if bubbles=false', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(container);
@@ -1910,7 +1870,6 @@ describe('FragmentRefs', () => {
       document.body.appendChild(container);
     });
 
-    // @gate enableFragmentRefs
     it('attaches intersection observers to children', async () => {
       let logs = [];
       const observer = new IntersectionObserver(entries => {
@@ -1971,7 +1930,6 @@ describe('FragmentRefs', () => {
       expect(logs).toEqual([]);
     });
 
-    // @gate enableFragmentRefs
     it('keeps a removed child observed until after the intersection exit, then unobserves it', async () => {
       const logs = [];
       const observer = new IntersectionObserver(entries => {
@@ -2018,7 +1976,6 @@ describe('FragmentRefs', () => {
       expect(observedIds()).toEqual(['childA']);
     });
 
-    // @gate enableFragmentRefs
     it('unobserveUsing() releases deleted children that were waiting for an exit record', async () => {
       const observer = new IntersectionObserver(() => {});
       const fragmentRef = React.createRef();
@@ -2044,7 +2001,6 @@ describe('FragmentRefs', () => {
       expect(observedIds()).toEqual([]);
     });
 
-    // @gate enableFragmentRefs
     it('unobserves ResizeObserver targets as soon as a child is deleted', async () => {
       const observedTargets = [];
       const resizeObserver = {
@@ -2082,7 +2038,6 @@ describe('FragmentRefs', () => {
       expect(observedTargets.map(node => node.id)).toEqual(['childA']);
     });
 
-    // @gate enableFragmentRefs
     it('unobserves a replaced child after post-paint and keeps the new child observed', async () => {
       const observer = new IntersectionObserver(() => {});
       const fragmentRef = React.createRef();
@@ -2119,7 +2074,6 @@ describe('FragmentRefs', () => {
       expect(intersectionObserverMock.observedTargets[0]).toBe(secondChild);
     });
 
-    // @gate enableFragmentRefs
     it('keeps a child observed if Activity shows it again before the delayed unobserve', async () => {
       const observer = new IntersectionObserver(() => {});
       const fragmentRef = React.createRef();
@@ -2155,7 +2109,6 @@ describe('FragmentRefs', () => {
       expect(observedIds()).toEqual(['child']);
     });
 
-    // @gate enableFragmentRefs
     it('warns when unobserveUsing() is called with an observer that was not observed', async () => {
       const fragmentRef = React.createRef();
       const observer = new IntersectionObserver(() => {});
@@ -2187,7 +2140,7 @@ describe('FragmentRefs', () => {
       ]);
     });
 
-    // @gate enableFragmentRefs && enableFragmentRefsInstanceHandles
+    // @gate enableFragmentRefsInstanceHandles
     it('attaches handles to observed elements to allow caching of observers', async () => {
       const targetToCallbackMap = new WeakMap();
       let cachedObserver = null;
@@ -2309,7 +2262,6 @@ describe('FragmentRefs', () => {
   });
 
   describe('getClientRects', () => {
-    // @gate enableFragmentRefs
     it('returns the bounding client rects of all children', async () => {
       const fragmentRef = React.createRef();
       const childARef = React.createRef();
@@ -2350,7 +2302,6 @@ describe('FragmentRefs', () => {
   });
 
   describe('getRootNode', () => {
-    // @gate enableFragmentRefs
     it('returns the root node of the parent', async () => {
       const fragmentRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
@@ -2373,7 +2324,6 @@ describe('FragmentRefs', () => {
     // fragment + parent are unmounted. Currently we have a pass during unmount that
     // recursively cleans up return pointers of the whole tree. We can change this
     // with a future refactor. See: https://github.com/facebook/react/pull/32682#discussion_r2008313082
-    // @gate enableFragmentRefs
     it('returns the topmost disconnected element if the fragment and parent are unmounted', async () => {
       const containerRef = React.createRef();
       const parentRef = React.createRef();
@@ -2405,7 +2355,6 @@ describe('FragmentRefs', () => {
       expect(fragmentHandle.getRootNode()).toBe(fragmentHandle);
     });
 
-    // @gate enableFragmentRefs
     it('returns self when only the fragment was unmounted', async () => {
       const fragmentRef = React.createRef();
       const parentRef = React.createRef();
@@ -2444,7 +2393,6 @@ describe('FragmentRefs', () => {
       };
       expect(positionResult).toEqual(spec);
     }
-    // @gate enableFragmentRefs
     it('returns the relationship between the fragment instance and a given node', async () => {
       const fragmentRef = React.createRef();
       const beforeRef = React.createRef();
@@ -2576,7 +2524,6 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs
     it('handles fragment instances with one child', async () => {
       const fragmentRef = React.createRef();
       const beforeRef = React.createRef();
@@ -2658,7 +2605,6 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs
     it('handles empty fragment instances', async () => {
       const fragmentRef = React.createRef();
       const beforeParentRef = React.createRef();
@@ -2752,7 +2698,6 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs
     it('handles empty fragments nested inside non-host wrappers', async () => {
       const fragmentRef = React.createRef();
       const beforeRef = React.createRef();
@@ -2797,7 +2742,6 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs
     it('handles nested children', async () => {
       const fragmentRef = React.createRef();
       const nestedFragmentRef = React.createRef();
@@ -2868,7 +2812,6 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs
     it('returns disconnected for comparison with an unmounted fragment instance', async () => {
       const fragmentRef = React.createRef();
       const containerRef = React.createRef();
@@ -2919,7 +2862,6 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs
     it('compares a root-level Fragment', async () => {
       const fragmentRef = React.createRef();
       const emptyFragmentRef = React.createRef();
@@ -3030,7 +2972,6 @@ describe('FragmentRefs', () => {
     });
 
     describe('with portals', () => {
-      // @gate enableFragmentRefs
       it('handles portaled elements', async () => {
         const fragmentRef = React.createRef();
         const portaledSiblingRef = React.createRef();
@@ -3080,7 +3021,6 @@ describe('FragmentRefs', () => {
         );
       });
 
-      // @gate enableFragmentRefs
       it('handles multiple portals to the same element', async () => {
         const root = ReactDOMClient.createRoot(container);
         const fragmentRef = React.createRef();
@@ -3197,7 +3137,6 @@ describe('FragmentRefs', () => {
         );
       });
 
-      // @gate enableFragmentRefs
       it('handles empty fragments', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -3251,7 +3190,6 @@ describe('FragmentRefs', () => {
         );
       });
 
-      // @gate enableFragmentRefs
       it('positions empty portaled fragments against the portal container', async () => {
         const fragmentRef = React.createRef();
         const reactParentRef = React.createRef();
@@ -3301,7 +3239,7 @@ describe('FragmentRefs', () => {
     function expectLast(arr, test) {
       expect(arr[arr.length - 1]).toBe(test);
     }
-    // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+    // @gate enableFragmentRefsScrollIntoView
     it('does not yet support options', async () => {
       const fragmentRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
@@ -3318,7 +3256,7 @@ describe('FragmentRefs', () => {
     });
 
     describe('with children', () => {
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('settles scroll on the first child by default, or if alignToTop=true', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -3354,7 +3292,7 @@ describe('FragmentRefs', () => {
         expectLast(logs, 'childA');
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('calls scrollIntoView on the last child if alignToTop is false', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -3381,7 +3319,7 @@ describe('FragmentRefs', () => {
         expectLast(logs, 'childB');
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('handles portaled elements -- same scroll container', async () => {
         const fragmentRef = React.createRef();
         const childARef = React.createRef();
@@ -3422,7 +3360,7 @@ describe('FragmentRefs', () => {
         expectLast(logs, 'childA');
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('handles portaled elements -- different scroll container', async () => {
         const fragmentRef = React.createRef();
         const headerChildRef = React.createRef();
@@ -3523,7 +3461,7 @@ describe('FragmentRefs', () => {
     });
 
     describe('without children', () => {
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('calls scrollIntoView on the next sibling by default, or if alignToTop=true', async () => {
         const fragmentRef = React.createRef();
         const siblingARef = React.createRef();
@@ -3557,7 +3495,7 @@ describe('FragmentRefs', () => {
         expect(siblingBRef.current.scrollIntoView).toHaveBeenCalledTimes(1);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('finds host siblings when the empty fragment is nested in a non-host wrapper', async () => {
         const fragmentRef = React.createRef();
         const beforeRef = React.createRef();
@@ -3591,7 +3529,7 @@ describe('FragmentRefs', () => {
         expect(afterRef.current.scrollIntoView).toHaveBeenCalledTimes(0);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('calls scrollIntoView on the prev sibling if alignToTop is false', async () => {
         const fragmentRef = React.createRef();
         const siblingARef = React.createRef();
@@ -3628,7 +3566,7 @@ describe('FragmentRefs', () => {
         expect(siblingBRef.current.scrollIntoView).toHaveBeenCalledTimes(0);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('calls scrollIntoView on the parent if there are no siblings', async () => {
         const fragmentRef = React.createRef();
         const parentRef = React.createRef();
@@ -3648,7 +3586,7 @@ describe('FragmentRefs', () => {
         expect(parentRef.current.scrollIntoView).toHaveBeenCalledTimes(1);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('scrolls the host element when the fallback target is a ShadowRoot container', async () => {
         const fragmentRef = React.createRef();
         const host = document.createElement('div');
@@ -3666,7 +3604,7 @@ describe('FragmentRefs', () => {
         expect(host.scrollIntoView).toHaveBeenCalledTimes(1);
       });
 
-      // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+      // @gate enableFragmentRefsScrollIntoView
       it('warns without scrolling when the fallback target is a detached DocumentFragment container', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(
@@ -3690,7 +3628,7 @@ describe('FragmentRefs', () => {
   });
 
   describe('with text nodes', () => {
-    // @gate enableFragmentRefs && enableFragmentRefsTextNodes
+    // @gate enableFragmentRefsTextNodes
     it('getClientRects includes text node bounds', async () => {
       const restoreRange = mockRangeClientRects([
         {x: 0, y: 0, width: 80, height: 16},
@@ -3712,7 +3650,7 @@ describe('FragmentRefs', () => {
       restoreRange();
     });
 
-    // @gate enableFragmentRefs && enableFragmentRefsTextNodes
+    // @gate enableFragmentRefsTextNodes
     it('getClientRects includes both text and element bounds', async () => {
       const restoreRange = mockRangeClientRects([
         {x: 0, y: 0, width: 60, height: 16},
@@ -3742,7 +3680,6 @@ describe('FragmentRefs', () => {
       restoreRange();
     });
 
-    // @gate enableFragmentRefs
     it('compareDocumentPosition works with text children', async () => {
       const fragmentRef = React.createRef();
       const beforeRef = React.createRef();
@@ -3763,7 +3700,6 @@ describe('FragmentRefs', () => {
       expect(position & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
     });
 
-    // @gate enableFragmentRefs
     it('focus is a no-op on text-only fragment', async () => {
       const fragmentRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
@@ -3781,7 +3717,6 @@ describe('FragmentRefs', () => {
       // Test passes if no error is thrown
     });
 
-    // @gate enableFragmentRefs
     it('focusLast is a no-op on text-only fragment', async () => {
       const fragmentRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
@@ -3798,7 +3733,7 @@ describe('FragmentRefs', () => {
       fragmentRef.current.focusLast();
     });
 
-    // @gate enableFragmentRefs && enableFragmentRefsTextNodes
+    // @gate enableFragmentRefsTextNodes
     it('warns when observeUsing is called on text-only fragment', async () => {
       mockIntersectionObserver();
       const fragmentRef = React.createRef();
@@ -3823,7 +3758,7 @@ describe('FragmentRefs', () => {
       );
     });
 
-    // @gate enableFragmentRefs && enableFragmentRefsScrollIntoView
+    // @gate enableFragmentRefsScrollIntoView
     it('scrollIntoView works on text-only fragment using Range API', async () => {
       const restoreRange = mockRangeClientRects([
         {x: 100, y: 200, width: 80, height: 16},
@@ -3853,7 +3788,7 @@ describe('FragmentRefs', () => {
       restoreRange();
     });
 
-    // @gate enableFragmentRefs && enableFragmentRefsTextNodes && enableFragmentRefsScrollIntoView
+    // @gate enableFragmentRefsTextNodes && enableFragmentRefsScrollIntoView
     it('scrollIntoView scrolls to text siblings of an empty fragment using the Range API', async () => {
       const restoreRange = mockRangeClientRects([
         {x: 100, y: 200, width: 80, height: 16},
@@ -3895,7 +3830,6 @@ describe('FragmentRefs', () => {
       restoreRange();
     });
 
-    // @gate enableFragmentRefs
     it('treats passive:true and passive:false as same listener per DOM spec', async () => {
       const fragmentRef = React.createRef();
       const root = ReactDOMClient.createRoot(container);
@@ -3934,7 +3868,6 @@ describe('FragmentRefs', () => {
       document.querySelector('#child').click();
       expect(logs).toEqual([]);
     });
-    // @gate enableFragmentRefs
     it('removes a listener registered with passive:false when removed with passive:true', async () => {
       const fragmentRef = React.createRef(null);
       function Test() {

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -3733,7 +3733,7 @@ describe('FragmentRefs', () => {
       fragmentRef.current.focusLast();
     });
 
-    // @gate enableFragmentRefsTextNodes
+    // @gate enableFragmentRefsTextNodes || !__DEV__
     it('warns when observeUsing is called on text-only fragment', async () => {
       mockIntersectionObserver();
       const fragmentRef = React.createRef();

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefsDocument-test.js
@@ -40,7 +40,6 @@ describe('FragmentRefs', () => {
 
   describe('focus methods', () => {
     describe('blur()', () => {
-      // @gate enableFragmentRefs
       it('throws when the nearest host parent is a Document container', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(document);
@@ -76,7 +75,6 @@ describe('FragmentRefs', () => {
 
   describe('events', () => {
     describe('dispatchEvent()', () => {
-      // @gate enableFragmentRefs
       it('fires events when the fragment is a child of a HostSingleton in a document root', async () => {
         const fragmentRef = React.createRef();
         const bodyRef = React.createRef();
@@ -105,7 +103,6 @@ describe('FragmentRefs', () => {
         expect(bodyListener).toHaveBeenCalledTimes(1);
       });
 
-      // @gate enableFragmentRefs
       it('dispatches to its own listeners when the container is a Document', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(document);
@@ -139,7 +136,6 @@ describe('FragmentRefs', () => {
         expect(isCancelable).toBe(false);
       });
 
-      // @gate enableFragmentRefs
       it('does not propagate through its own children when wrapping documentElement', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(document);
@@ -174,7 +170,6 @@ describe('FragmentRefs', () => {
         expect(logs).toEqual(['fragment', 'document']);
       });
 
-      // @gate enableFragmentRefs
       it('dispatches non-bubbling events when the container is a Document', async () => {
         const fragmentRef = React.createRef();
         const root = ReactDOMClient.createRoot(document);
@@ -207,7 +202,6 @@ describe('FragmentRefs', () => {
     });
 
     describe('addEventListener()', () => {
-      // @gate enableFragmentRefs
       it('attaches listeners to the host children inside singletons', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -237,7 +231,6 @@ describe('FragmentRefs', () => {
         expect(currentTargets).toEqual([document.documentElement]);
       });
 
-      // @gate enableFragmentRefs
       it('attaches listeners to a singleton mounted into the fragment, but not to its content', async () => {
         const fragmentRef = React.createRef();
         const childRef = React.createRef();
@@ -278,7 +271,6 @@ describe('FragmentRefs', () => {
         expect(currentTargets).toEqual([document.documentElement]);
       });
 
-      // @gate enableFragmentRefs
       it('attributes new children inside a singleton to fragments below it, not above it', async () => {
         const outerFragmentRef = React.createRef();
         const innerFragmentRef = React.createRef();
@@ -330,7 +322,6 @@ describe('FragmentRefs', () => {
   });
 
   describe('getClientRects()', () => {
-    // @gate enableFragmentRefs
     it('measures the host children inside singletons', async () => {
       const fragmentRef = React.createRef();
       const childRef = React.createRef();
@@ -371,7 +362,6 @@ describe('FragmentRefs', () => {
       expect(positionResult).toEqual(spec);
     }
 
-    // @gate enableFragmentRefs
     it('treats documentElement as containing the fragment', async () => {
       const fragmentRef = React.createRef();
       const container = document.createElement('div');

--- a/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricFragmentRefs-test.internal.js
@@ -39,7 +39,6 @@ describe('Fabric FragmentRefs', () => {
     }));
   });
 
-  // @gate enableFragmentRefs
   it('attaches a ref to Fragment', async () => {
     const fragmentRef = React.createRef();
 
@@ -61,7 +60,6 @@ describe('Fabric FragmentRefs', () => {
     expect(fragmentRef.current).not.toBe(null);
   });
 
-  // @gate enableFragmentRefs
   it('accepts a ref callback', async () => {
     let fragmentRef;
 
@@ -82,7 +80,6 @@ describe('Fabric FragmentRefs', () => {
   });
 
   describe('observers', () => {
-    // @gate enableFragmentRefs
     it('observes children, newly added children', async () => {
       let logs = [];
       const observer = {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -52,7 +52,6 @@ import isArray from 'shared/isArray';
 import {
   enableAsyncIterableChildren,
   disableLegacyMode,
-  enableFragmentRefs,
   enableOptimisticKey,
 } from 'shared/ReactFeatureFlags';
 
@@ -240,14 +239,10 @@ function validateFragmentProps(
     const keys = Object.keys(element.props);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      if (
-        key !== 'children' &&
-        key !== 'key' &&
-        (enableFragmentRefs ? key !== 'ref' : true)
-      ) {
+      if (key !== 'children' && key !== 'key' && key !== 'ref') {
         if (fiber === null) {
-          // For unkeyed root fragments without refs (enableFragmentRefs),
-          // there's no Fiber. We create a fake one just for error stack handling.
+          // For unkeyed root fragments without refs, there's no Fiber.
+          // We create a fake one just for error stack handling.
           fiber = createFiberFromElement(element, returnFiber.mode, 0);
           if (__DEV__) {
             fiber._debugInfo = currentDebugInfo;
@@ -257,19 +252,11 @@ function validateFragmentProps(
         runWithFiberInDEV(
           fiber,
           erroredKey => {
-            if (enableFragmentRefs) {
-              console.error(
-                'Invalid prop `%s` supplied to `React.Fragment`. ' +
-                  'React.Fragment can only have `key`, `ref`, and `children` props.',
-                erroredKey,
-              );
-            } else {
-              console.error(
-                'Invalid prop `%s` supplied to `React.Fragment`. ' +
-                  'React.Fragment can only have `key` and `children` props.',
-                erroredKey,
-              );
-            }
+            console.error(
+              'Invalid prop `%s` supplied to `React.Fragment`. ' +
+                'React.Fragment can only have `key`, `ref`, and `children` props.',
+              erroredKey,
+            );
           },
           key,
         );
@@ -592,9 +579,7 @@ function createChildReconciler(
         lanes,
         element.key,
       );
-      if (enableFragmentRefs) {
-        coerceRef(updated, element);
-      }
+      coerceRef(updated, element);
       validateFragmentProps(element, updated, returnFiber);
       return updated;
     }
@@ -1724,9 +1709,7 @@ function createChildReconciler(
               // If the old key was optimistic we need to now save the real one.
               existing.key = key;
             }
-            if (enableFragmentRefs) {
-              coerceRef(existing, element);
-            }
+            coerceRef(existing, element);
             existing.return = returnFiber;
             if (__DEV__) {
               existing._debugOwner = element._owner;
@@ -1782,9 +1765,7 @@ function createChildReconciler(
         lanes,
         element.key,
       );
-      if (enableFragmentRefs) {
-        coerceRef(created, element);
-      }
+      coerceRef(created, element);
       created.return = returnFiber;
       if (__DEV__) {
         // We treat the parent as the owner for stack purposes.
@@ -1864,7 +1845,7 @@ function createChildReconciler(
     // not as a fragment. Nested arrays on the other hand will be treated as
     // fragment nodes. Recursion happens at the normal flow.
 
-    // Handle top level unkeyed fragments without refs (enableFragmentRefs)
+    // Handle top level unkeyed fragments without refs
     // as if they were arrays. This leads to an ambiguity between <>{[...]}</> and <>...</>.
     // We treat the ambiguous cases above the same.
     // We don't use recursion here because a fragment inside a fragment
@@ -1874,7 +1855,7 @@ function createChildReconciler(
       newChild !== null &&
       newChild.type === REACT_FRAGMENT_TYPE &&
       newChild.key === null &&
-      (enableFragmentRefs ? newChild.props.ref === undefined : true);
+      newChild.props.ref === undefined;
 
     if (isUnkeyedUnrefedTopLevelFragment) {
       validateFragmentProps(newChild, null, returnFiber);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -119,7 +119,6 @@ import {
   enableCPUSuspense,
   disableLegacyMode,
   enableViewTransition,
-  enableFragmentRefs,
 } from 'shared/ReactFeatureFlags';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
@@ -1366,9 +1365,7 @@ function updateFragment(
   renderLanes: Lanes,
 ) {
   const nextChildren = workInProgress.pendingProps;
-  if (enableFragmentRefs) {
-    markRef(current, workInProgress);
-  }
+  markRef(current, workInProgress);
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   return workInProgress.child;
 }

--- a/packages/react-reconciler/src/ReactFiberCommitEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitEffects.js
@@ -27,7 +27,6 @@ import {
   enableProfilerNestedUpdatePhase,
   enableSchedulingProfiler,
   enableViewTransition,
-  enableFragmentRefs,
 } from 'shared/ReactFeatureFlags';
 import {
   ClassComponent,
@@ -778,16 +777,14 @@ function commitAttachRef(finishedWork: Fiber) {
         instanceToUse = finishedWork.stateNode;
         break;
       }
-      case Fragment:
-        if (enableFragmentRefs) {
-          const instance: null | FragmentInstanceType = finishedWork.stateNode;
-          if (instance === null) {
-            finishedWork.stateNode = createFragmentInstance(finishedWork);
-          }
-          instanceToUse = finishedWork.stateNode;
-          break;
+      case Fragment: {
+        const instance: null | FragmentInstanceType = finishedWork.stateNode;
+        if (instance === null) {
+          finishedWork.stateNode = createFragmentInstance(finishedWork);
         }
-      // Fallthrough
+        instanceToUse = finishedWork.stateNode;
+        break;
+      }
       default:
         instanceToUse = finishedWork.stateNode;
     }

--- a/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
+++ b/packages/react-reconciler/src/ReactFiberCommitHostEffects.js
@@ -61,7 +61,6 @@ import {captureCommitPhaseError} from './ReactFiberWorkLoop';
 import {trackHostMutation} from './ReactFiberMutationTracking';
 
 import {runWithFiberInDEV} from './ReactCurrentFiber';
-import {enableFragmentRefs} from 'shared/ReactFeatureFlags';
 import {
   commitNewChildToFragmentInstances,
   getParentFragmentInstances,
@@ -342,9 +341,7 @@ function insertOrAppendPlacementNodeIntoContainer(
     } else {
       appendChildToContainer(parent, stateNode);
     }
-    if (enableFragmentRefs) {
-      commitNewChildToFragmentInstances(node, parentFragmentInstances);
-    }
+    commitNewChildToFragmentInstances(node, parentFragmentInstances);
     trackHostMutation();
     return;
   } else if (tag === HostPortal) {
@@ -356,12 +353,10 @@ function insertOrAppendPlacementNodeIntoContainer(
 
   // $FlowFixMe[constant-condition]
   if (supportsSingletons ? tag === HostSingleton : false) {
-    if (enableFragmentRefs) {
-      // The singleton is the fragment child. Its own children are not
-      // attributed to the fragment instances above it.
-      commitNewChildToFragmentInstances(node, parentFragmentInstances);
-      parentFragmentInstances = null;
-    }
+    // The singleton is the fragment child. Its own children are not
+    // attributed to the fragment instances above it.
+    commitNewChildToFragmentInstances(node, parentFragmentInstances);
+    parentFragmentInstances = null;
     if (isSingletonScope(node.type)) {
       // This singleton is the parent of deeper nodes and needs to become
       // the parent for child insertions and appends
@@ -406,9 +401,7 @@ function insertOrAppendPlacementNode(
     } else {
       appendChild(parent, stateNode);
     }
-    if (enableFragmentRefs) {
-      commitNewChildToFragmentInstances(node, parentFragmentInstances);
-    }
+    commitNewChildToFragmentInstances(node, parentFragmentInstances);
     trackHostMutation();
     return;
   } else if (tag === HostPortal) {
@@ -420,12 +413,10 @@ function insertOrAppendPlacementNode(
 
   // $FlowFixMe[constant-condition]
   if (supportsSingletons ? tag === HostSingleton : false) {
-    if (enableFragmentRefs) {
-      // The singleton is the fragment child. Its own children are not
-      // attributed to the fragment instances above it.
-      commitNewChildToFragmentInstances(node, parentFragmentInstances);
-      parentFragmentInstances = null;
-    }
+    // The singleton is the fragment child. Its own children are not
+    // attributed to the fragment instances above it.
+    commitNewChildToFragmentInstances(node, parentFragmentInstances);
+    parentFragmentInstances = null;
     if (isSingletonScope(node.type)) {
       // This singleton is the parent of deeper nodes and needs to become
       // the parent for child insertions and appends
@@ -462,18 +453,14 @@ function commitPlacement(finishedWork: Fiber): void {
   }
   // Fragment ancestry is collected separately so portals remain placement
   // parents while fragment bookkeeping still walks past them to ancestors.
-  const parentFragmentInstances = enableFragmentRefs
-    ? getParentFragmentInstances(finishedWork)
-    : null;
+  const parentFragmentInstances = getParentFragmentInstances(finishedWork);
 
   // $FlowFixMe[constant-condition]
   if (!supportsMutation) {
-    if (enableFragmentRefs) {
-      commitImmutablePlacementNodeToFragmentInstances(
-        finishedWork,
-        parentFragmentInstances,
-      );
-    }
+    commitImmutablePlacementNodeToFragmentInstances(
+      finishedWork,
+      parentFragmentInstances,
+    );
     return;
   }
 
@@ -546,9 +533,6 @@ function commitImmutablePlacementNodeToFragmentInstances(
   finishedWork: Fiber,
   parentFragmentInstances: null | Array<FragmentInstanceType>,
 ): void {
-  if (!enableFragmentRefs) {
-    return;
-  }
   const isHost =
     finishedWork.tag === HostComponent ||
     // $FlowFixMe[constant-condition]

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -58,7 +58,6 @@ import {
   disableLegacyMode,
   enableComponentPerformanceTrack,
   enableViewTransition,
-  enableFragmentRefs,
   enableDefaultTransitionIndicator,
   enableFragmentRefsTextNodes,
 } from 'shared/ReactFeatureFlags';
@@ -873,10 +872,8 @@ function commitLayoutEffectOnFiber(
       break;
     }
     case Fragment:
-      if (enableFragmentRefs) {
-        if (flags & Ref) {
-          safelyAttachRef(finishedWork, finishedWork.return);
-        }
+      if (flags & Ref) {
+        safelyAttachRef(finishedWork, finishedWork.return);
       }
     // Fallthrough
     default: {
@@ -1536,9 +1533,7 @@ function commitDeletionEffectsOnFiber(
         if (!offscreenSubtreeWasHidden) {
           safelyDetachRef(deletedFiber, nearestMountedAncestor);
         }
-        if (enableFragmentRefs) {
-          commitFragmentInstanceDeletionEffects(deletedFiber);
-        }
+        commitFragmentInstanceDeletionEffects(deletedFiber);
 
         const prevHostParent = hostParent;
         const prevHostParentIsContainer = hostParentIsContainer;
@@ -1570,14 +1565,11 @@ function commitDeletionEffectsOnFiber(
       if (!offscreenSubtreeWasHidden) {
         safelyDetachRef(deletedFiber, nearestMountedAncestor);
       }
-      if (enableFragmentRefs) {
-        commitFragmentInstanceDeletionEffects(deletedFiber);
-      }
+      commitFragmentInstanceDeletionEffects(deletedFiber);
       // Intentional fallthrough to next branch
     }
     case HostText: {
       if (
-        enableFragmentRefs &&
         enableFragmentRefsTextNodes &&
         // HostComponent falls through into this case.
         deletedFiber.tag === HostText
@@ -1807,18 +1799,15 @@ function commitDeletionEffectsOnFiber(
       // Fallthrough
     }
     case Fragment: {
-      if (enableFragmentRefs) {
-        if (!offscreenSubtreeWasHidden) {
-          safelyDetachRef(deletedFiber, nearestMountedAncestor);
-        }
-        recursivelyTraverseDeletionEffects(
-          finishedRoot,
-          nearestMountedAncestor,
-          deletedFiber,
-        );
-        break;
+      if (!offscreenSubtreeWasHidden) {
+        safelyDetachRef(deletedFiber, nearestMountedAncestor);
       }
-      // Fallthrough
+      recursivelyTraverseDeletionEffects(
+        finishedRoot,
+        nearestMountedAncestor,
+        deletedFiber,
+      );
+      break;
     }
     default: {
       recursivelyTraverseDeletionEffects(
@@ -2779,15 +2768,13 @@ function commitMutationEffectsOnFiber(
       break;
     }
     case Fragment:
-      if (enableFragmentRefs) {
-        if (flags & Ref) {
-          if (!offscreenSubtreeWasHidden && current !== null) {
-            safelyDetachRef(current, current.return);
-          }
+      if (flags & Ref) {
+        if (!offscreenSubtreeWasHidden && current !== null) {
+          safelyDetachRef(current, current.return);
         }
-        if (current && current.stateNode !== null) {
-          updateFragmentInstanceFiber(finishedWork, current.stateNode);
-        }
+      }
+      if (current && current.stateNode !== null) {
+        updateFragmentInstanceFiber(finishedWork, current.stateNode);
       }
     // Fallthrough
     default: {
@@ -3160,11 +3147,10 @@ function disappearLayoutEffects(
       safelyDetachRef(finishedWork, finishedWork.return);
 
       if (
-        enableFragmentRefs &&
         // HostHoistable shares this case via fallthrough but must not be
         // attributed to fragment instances. HostText has its own case below.
-        (finishedWork.tag === HostComponent ||
-          finishedWork.tag === HostSingleton)
+        finishedWork.tag === HostComponent ||
+        finishedWork.tag === HostSingleton
       ) {
         commitFragmentInstanceDeletionEffects(finishedWork);
       }
@@ -3176,7 +3162,7 @@ function disappearLayoutEffects(
       break;
     }
     case HostText: {
-      if (enableFragmentRefs && enableFragmentRefsTextNodes) {
+      if (enableFragmentRefsTextNodes) {
         commitFragmentInstanceDeletionEffects(finishedWork);
       }
       break;
@@ -3236,9 +3222,7 @@ function disappearLayoutEffects(
       break;
     }
     case Fragment: {
-      if (enableFragmentRefs) {
-        safelyDetachRef(finishedWork, finishedWork.return);
-      }
+      safelyDetachRef(finishedWork, finishedWork.return);
       // Fallthrough
     }
     default: {
@@ -3380,9 +3364,8 @@ function reappearLayoutEffects(
     }
     case HostComponent: {
       if (
-        enableFragmentRefs &&
-        (finishedWork.tag === HostComponent ||
-          finishedWork.tag === HostSingleton)
+        finishedWork.tag === HostComponent ||
+        finishedWork.tag === HostSingleton
       ) {
         commitFragmentInstanceInsertionEffects(finishedWork);
       }
@@ -3405,7 +3388,7 @@ function reappearLayoutEffects(
       break;
     }
     case HostText: {
-      if (enableFragmentRefs && enableFragmentRefsTextNodes) {
+      if (enableFragmentRefsTextNodes) {
         commitFragmentInstanceInsertionEffects(finishedWork);
       }
       break;
@@ -3558,9 +3541,7 @@ function reappearLayoutEffects(
       break;
     }
     case Fragment: {
-      if (enableFragmentRefs) {
-        safelyAttachRef(finishedWork, finishedWork.return);
-      }
+      safelyAttachRef(finishedWork, finishedWork.return);
       // Fallthrough
     }
     default: {

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -427,13 +427,9 @@ describe('ReactElementValidator', () => {
     const root = ReactDOMClient.createRoot(document.createElement('div'));
     await act(() => root.render(React.createElement(Foo)));
     assertConsoleErrorDev([
-      gate('enableFragmentRefs')
-        ? 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
-          'can only have `key`, `ref`, and `children` props.\n' +
-          '    in Foo (at **)'
-        : 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
-          'can only have `key` and `children` props.\n' +
-          '    in Foo (at **)',
+      'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+        'can only have `key`, `ref`, and `children` props.\n' +
+        '    in Foo (at **)',
     ]);
   });
 

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -221,17 +221,13 @@ describe('ReactJSXElementValidator', () => {
       root.render(<Foo />);
     });
     assertConsoleErrorDev([
-      gate('enableFragmentRefs')
-        ? 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
-          'can only have `key`, `ref`, and `children` props.\n' +
-          '    in Foo (at **)'
-        : 'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
-          'can only have `key` and `children` props.\n' +
-          '    in Foo (at **)',
+      'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+        'can only have `key`, `ref`, and `children` props.\n' +
+        '    in Foo (at **)',
     ]);
   });
 
-  it('warns for fragments with refs', async () => {
+  it('does not warn for fragments with refs', async () => {
     class Foo extends React.Component {
       render() {
         return (
@@ -250,15 +246,6 @@ describe('ReactJSXElementValidator', () => {
     await act(() => {
       root.render(<Foo />);
     });
-    assertConsoleErrorDev(
-      gate('enableFragmentRefs')
-        ? []
-        : [
-            'Invalid prop `ref` supplied to `React.Fragment`.' +
-              ' React.Fragment can only have `key` and `children` props.\n' +
-              '    in Foo (at **)',
-          ],
-    );
   });
 
   it('does not warn for fragments of multiple elements without keys', async () => {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -162,7 +162,6 @@ export const enableInfiniteRenderLoopDetectionForceThrow: boolean = false;
 
 export const enableConditionalUseWarning: boolean = true;
 
-export const enableFragmentRefs: boolean = true;
 export const enableFragmentRefsScrollIntoView: boolean = true;
 export const enableFragmentRefsInstanceHandles: boolean = true;
 export const enableFragmentRefsTextNodes: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -20,7 +20,6 @@
 export const alwaysThrottleRetries = __VARIANT__;
 export const enableObjectFiber = __VARIANT__;
 export const passChildrenWhenCloningPersistedNodes = __VARIANT__;
-export const enableFragmentRefs = __VARIANT__;
 export const enableFragmentRefsScrollIntoView = __VARIANT__;
 export const enableFragmentRefsInstanceHandles = __VARIANT__;
 export const enableFragmentRefsTextNodes = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -22,7 +22,6 @@ export const {
   alwaysThrottleRetries,
   enableObjectFiber,
   passChildrenWhenCloningPersistedNodes,
-  enableFragmentRefs,
   enableFragmentRefsScrollIntoView,
   enableFragmentRefsInstanceHandles,
   enableFragmentRefsTextNodes,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -73,7 +73,6 @@ export const enableHydrationChangeEvent: boolean = false;
 export const enableDefaultTransitionIndicator: boolean = false;
 export const ownerStackLimit = 1e4;
 
-export const enableFragmentRefs: boolean = true;
 export const enableFragmentRefsScrollIntoView: boolean = false;
 export const enableFragmentRefsInstanceHandles: boolean = true;
 export const enableFragmentRefsTextNodes: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -74,7 +74,6 @@ export const enableHydrationChangeEvent: boolean = false;
 export const enableDefaultTransitionIndicator: boolean = false;
 export const ownerStackLimit = 1e4;
 
-export const enableFragmentRefs: boolean = true;
 export const enableFragmentRefsScrollIntoView: boolean = true;
 export const enableFragmentRefsInstanceHandles: boolean = true;
 export const enableFragmentRefsTextNodes: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native-fb.js
@@ -67,7 +67,6 @@ export const enableFizzBlockingRender = true;
 export const enableSrcObject = false;
 export const enableHydrationChangeEvent = false;
 export const enableDefaultTransitionIndicator = true;
-export const enableFragmentRefs = false;
 export const enableFragmentRefsScrollIntoView = false;
 export const enableFragmentRefsInstanceHandles = false;
 export const enableFragmentRefsTextNodes = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -79,7 +79,6 @@ export const enableSrcObject: boolean = false;
 export const enableHydrationChangeEvent: boolean = false;
 export const enableDefaultTransitionIndicator: boolean = true;
 
-export const enableFragmentRefs: boolean = true;
 export const enableFragmentRefsScrollIntoView: boolean = true;
 export const enableFragmentRefsInstanceHandles: boolean = true;
 export const enableFragmentRefsTextNodes: boolean = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -35,7 +35,6 @@ export const enableSuspenseyImages: boolean = __VARIANT__;
 export const enableViewTransition: boolean = __VARIANT__;
 export const enableViewTransitionParentEnterExit: boolean = __VARIANT__;
 export const enableScrollEndPolyfill: boolean = __VARIANT__;
-export const enableFragmentRefs: boolean = __VARIANT__;
 export const enableFragmentRefsScrollIntoView: boolean = __VARIANT__;
 export const enableFragmentRefsTextNodes: boolean = __VARIANT__;
 export const enableInternalInstanceMap: boolean = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -31,7 +31,6 @@ export const {
   enableSuspenseyImages,
   enableViewTransition,
   enableScrollEndPolyfill,
-  enableFragmentRefs,
   enableFragmentRefsScrollIntoView,
   enableFragmentRefsTextNodes,
   enableInternalInstanceMap,


### PR DESCRIPTION
## Summary

`enableFragmentRefs` is enabled in every channel, so this inlines the enabled branch and removes the flag from `ReactFeatureFlags` and all of its forks.

Most of the diff is mechanical, but a few spots needed care:

- Several `case Fragment:` blocks in `ReactFiberCommitWork` had a `// Fallthrough` that was only reachable with the flag off. Where a preceding case falls *into* `Fragment` (the `ViewTransitionComponent` cases), I verified the resulting behavior is unchanged for every remaining flag combination.
- `commitAttachRef` in `ReactFiberCommitEffects` becomes a plain `case Fragment: { ... break; }` instead of a conditional fallthrough into `default`.
- The `React.Fragment` invalid-prop warning no longer has two variants; it always mentions `key`, `ref`, and `children`.

The three related flags — `enableFragmentRefsScrollIntoView`, `enableFragmentRefsInstanceHandles`, and `enableFragmentRefsTextNodes` — are *not* on everywhere yet and are left in place.

In tests, `enableFragmentRefs` was stripped from 101 `@gate` pragmas. Combined gates such as `@gate enableFragmentRefs && enableFragmentRefsTextNodes` were reduced rather than removed. One test asserted the absence of a warning under the flag, so it was renamed from `warns for fragments with refs` to `does not warn for fragments with refs`.

## How did you test this change?

`yarn lint`, `yarn prettier-check`, and `yarn flow` for `dom-node`, `dom-browser`, and `fabric` all pass.

Full test suite run across `experimental`, `stable`, `www-modern`, `www-classic`, and `xplat`, with both `--variant` settings, plus `--persistent`. The remaining failures (Fizz / Flight / FrameScheduling / ClassEquivalence) are pre-existing: I diffed the individual failing test names against the base commit and they are identical.