### PR TITLE
[compiler] Treat zero-argument `new Date()` as impure during render

### DIFF
--- a/compiler/crates/react_compiler_hir/src/globals.rs
+++ b/compiler/crates/react_compiler_hir/src/globals.rs
@@ -2188,7 +2188,9 @@ fn build_typed_globals(
     typed_globals.push(("performance".to_string(), perf_global.clone()));
     globals.insert("performance".to_string(), perf_global);
 
-    // Date
+    // Date: constructor is a function so `new Date()` gets a call signature.
+    // Zero-arg construction reads the clock (`impure_if_no_args`); `Date.now`
+    // remains a static method on the same shape.
     let date_now = add_function(
         shapes,
         Vec::new(),
@@ -2203,7 +2205,21 @@ fn build_typed_globals(
         None,
         false,
     );
-    let date_global = add_object(shapes, Some("Date"), vec![("now".to_string(), date_now)]);
+    let date_global = add_function(
+        shapes,
+        vec![("now".to_string(), date_now)],
+        FunctionSignatureBuilder {
+            rest_param: Some(Effect::Read),
+            return_type: Type::Poly,
+            return_value_kind: ValueKind::Mutable,
+            impure: true,
+            impure_if_no_args: true,
+            canonical_name: Some("Date".to_string()),
+            ..Default::default()
+        },
+        Some("Date"),
+        false,
+    );
     typed_globals.push(("Date".to_string(), date_global.clone()));
     globals.insert("Date".to_string(), date_global);
 

--- a/compiler/crates/react_compiler_hir/src/object_shape.rs
+++ b/compiler/crates/react_compiler_hir/src/object_shape.rs
@@ -108,6 +108,10 @@ pub struct FunctionSignature {
     pub no_alias: bool,
     pub mutable_only_if_operands_are_mutable: bool,
     pub impure: bool,
+    /// When true, `impure` only applies if the call/construct has no arguments.
+    /// Ported from TS `impureIfNoArgs`. Used for `Date`: `new Date()` reads the
+    /// clock, `new Date(timestamp)` does not.
+    pub impure_if_no_args: bool,
     pub known_incompatible: Option<String>,
     pub canonical_name: Option<String>,
     /// Aliasing signature in config form. Full parsing into AliasingSignature
@@ -226,6 +230,7 @@ pub fn add_function(
             no_alias: sig.no_alias,
             mutable_only_if_operands_are_mutable: sig.mutable_only_if_operands_are_mutable,
             impure: sig.impure,
+            impure_if_no_args: sig.impure_if_no_args,
             known_incompatible: sig.known_incompatible,
             canonical_name: sig.canonical_name,
             aliasing: sig.aliasing,
@@ -258,6 +263,7 @@ pub fn add_hook(registry: &mut ShapeRegistry, sig: HookSignatureBuilder, id: Opt
             no_alias: sig.no_alias,
             mutable_only_if_operands_are_mutable: false,
             impure: false,
+            impure_if_no_args: false,
             known_incompatible: sig.known_incompatible,
             canonical_name: None,
             aliasing: sig.aliasing,
@@ -315,6 +321,7 @@ pub struct FunctionSignatureBuilder {
     pub no_alias: bool,
     pub mutable_only_if_operands_are_mutable: bool,
     pub impure: bool,
+    pub impure_if_no_args: bool,
     pub known_incompatible: Option<String>,
     pub canonical_name: Option<String>,
     pub aliasing: Option<AliasingSignatureConfig>,
@@ -332,6 +339,7 @@ impl Default for FunctionSignatureBuilder {
             no_alias: false,
             mutable_only_if_operands_are_mutable: false,
             impure: false,
+            impure_if_no_args: false,
             known_incompatible: None,
             canonical_name: None,
             aliasing: None,

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -2248,6 +2248,14 @@ fn compute_signature_for_instruction(
                 signature: sig,
                 loc: *loc,
             });
+            // Zero-arg `new Date()` reads the current clock. Matches TS
+            // InferMutationAliasingEffects: the Date global is an Object type,
+            // so NewExpression has no impure function signature.
+            if env.config.validate_no_impure_functions_in_render
+                && is_zero_argument_date_constructor(env, callee.identifier, args)
+            {
+                effects.push(impure_new_date_effect(callee, *loc));
+            }
         }
         InstructionValue::CallExpression { callee, args, loc } => {
             let sig = get_function_call_signature(env, callee.identifier)
@@ -3620,6 +3628,38 @@ fn is_builtin_collection_type(ty: &Type) -> bool {
     matches!(ty, Type::Object { shape_id: Some(id) }
         if id == BUILT_IN_ARRAY_ID || id == BUILT_IN_SET_ID || id == BUILT_IN_MAP_ID
     )
+}
+
+fn is_zero_argument_date_constructor(
+    env: &Environment,
+    callee_id: IdentifierId,
+    args: &[PlaceOrSpread],
+) -> bool {
+    if !args.is_empty() {
+        return false;
+    }
+    let ty = &env.types[env.identifiers[callee_id.0 as usize].type_.0 as usize];
+    matches!(ty, Type::Object { shape_id: Some(id) } if id == "Date")
+}
+
+fn impure_new_date_effect(place: &Place, loc: Option<SourceLocation>) -> AliasingEffect {
+    let mut diagnostic = CompilerDiagnostic::new(
+        ErrorCategory::Purity,
+        "Cannot call impure function during render",
+        Some(
+            "`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent)"
+                .to_string(),
+        ),
+    );
+    diagnostic.details.push(CompilerDiagnosticDetail::Error {
+        loc,
+        message: Some("Cannot call impure function".to_string()),
+        identifier_name: None,
+    });
+    AliasingEffect::Impure {
+        place: place.clone(),
+        error: diagnostic,
+    }
 }
 
 fn get_function_call_signature(

--- a/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
+++ b/compiler/crates/react_compiler_inference/src/infer_mutation_aliasing_effects.rs
@@ -2248,14 +2248,6 @@ fn compute_signature_for_instruction(
                 signature: sig,
                 loc: *loc,
             });
-            // Zero-arg `new Date()` reads the current clock. Matches TS
-            // InferMutationAliasingEffects: the Date global is an Object type,
-            // so NewExpression has no impure function signature.
-            if env.config.validate_no_impure_functions_in_render
-                && is_zero_argument_date_constructor(env, callee.identifier, args)
-            {
-                effects.push(impure_new_date_effect(callee, *loc));
-            }
         }
         InstructionValue::CallExpression { callee, args, loc } => {
             let sig = get_function_call_signature(env, callee.identifier)
@@ -2759,7 +2751,10 @@ fn compute_effects_for_legacy_signature(
         reason: return_value_reason,
     });
 
-    if signature.impure && env.config.validate_no_impure_functions_in_render {
+    if signature.impure
+        && env.config.validate_no_impure_functions_in_render
+        && (!signature.impure_if_no_args || args.is_empty())
+    {
         let mut diagnostic = CompilerDiagnostic::new(
             ErrorCategory::Purity,
             "Cannot call impure function during render",
@@ -3628,38 +3623,6 @@ fn is_builtin_collection_type(ty: &Type) -> bool {
     matches!(ty, Type::Object { shape_id: Some(id) }
         if id == BUILT_IN_ARRAY_ID || id == BUILT_IN_SET_ID || id == BUILT_IN_MAP_ID
     )
-}
-
-fn is_zero_argument_date_constructor(
-    env: &Environment,
-    callee_id: IdentifierId,
-    args: &[PlaceOrSpread],
-) -> bool {
-    if !args.is_empty() {
-        return false;
-    }
-    let ty = &env.types[env.identifiers[callee_id.0 as usize].type_.0 as usize];
-    matches!(ty, Type::Object { shape_id: Some(id) } if id == "Date")
-}
-
-fn impure_new_date_effect(place: &Place, loc: Option<SourceLocation>) -> AliasingEffect {
-    let mut diagnostic = CompilerDiagnostic::new(
-        ErrorCategory::Purity,
-        "Cannot call impure function during render",
-        Some(
-            "`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent)"
-                .to_string(),
-        ),
-    );
-    diagnostic.details.push(CompilerDiagnosticDetail::Error {
-        loc,
-        message: Some("Cannot call impure function".to_string()),
-        identifier_name: None,
-    });
-    AliasingEffect::Impure {
-        place: place.clone(),
-        error: diagnostic,
-    }
 }
 
 fn get_function_call_signature(

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/Globals.ts
@@ -280,22 +280,40 @@ const TYPED_GLOBALS: Array<[string, BuiltInType]> = [
   ],
   [
     'Date',
-    addObject(DEFAULT_SHAPES, 'Date', [
-      // Static methods (TODO)
+    addFunction(
+      DEFAULT_SHAPES,
       [
-        'now',
-        // Date.now()
-        addFunction(DEFAULT_SHAPES, [], {
-          positionalParams: [],
-          restParam: Effect.Read,
-          returnType: {kind: 'Poly'}, // TODO: could be Primitive, but that would change existing compilation
-          calleeEffect: Effect.Read,
-          returnValueKind: ValueKind.Mutable, // same here
-          impure: true,
-          canonicalName: 'Date.now',
-        }),
+        // Static methods (TODO)
+        [
+          'now',
+          // Date.now()
+          addFunction(DEFAULT_SHAPES, [], {
+            positionalParams: [],
+            restParam: Effect.Read,
+            returnType: {kind: 'Poly'}, // TODO: could be Primitive, but that would change existing compilation
+            calleeEffect: Effect.Read,
+            returnValueKind: ValueKind.Mutable, // same here
+            impure: true,
+            canonicalName: 'Date.now',
+          }),
+        ],
       ],
-    ]),
+      {
+        positionalParams: [],
+        restParam: Effect.Read,
+        returnType: {kind: 'Poly'},
+        calleeEffect: Effect.Read,
+        returnValueKind: ValueKind.Mutable,
+        /*
+         * Zero-arg `new Date()` / `Date()` reads the current clock.
+         * `new Date(timestamp)` is treated as pure via `impureIfNoArgs`.
+         */
+        impure: true,
+        impureIfNoArgs: true,
+        canonicalName: 'Date',
+      },
+      'Date',
+    ),
   ],
   [
     'Math',

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/ObjectShape.ts
@@ -331,6 +331,11 @@ export type FunctionSignature = {
   mutableOnlyIfOperandsAreMutable?: boolean;
 
   impure?: boolean;
+  /**
+   * When true, `impure` only applies if the call/construct has no arguments.
+   * Used for `Date`: `new Date()` reads the clock, `new Date(timestamp)` does not.
+   */
+  impureIfNoArgs?: boolean;
   knownIncompatible?: string | null | undefined;
 
   canonicalName?: string;

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -1839,21 +1839,6 @@ function computeSignatureForInstruction(
         signature,
         loc: value.loc,
       });
-      // Zero-arg `new Date()` reads the current clock. `Date.now()` is already
-      // marked impure via its function signature; the constructor is an Object
-      // type (static `now` lives on the same global) so NewExpression has no
-      // signature. Constructing from an explicit timestamp is treated as pure.
-      if (
-        value.kind === 'NewExpression' &&
-        env.config.validateNoImpureFunctionsInRender &&
-        isZeroArgumentDateConstructor(callee.identifier.type, value.args)
-      ) {
-        effects.push({
-          kind: 'Impure',
-          place: callee,
-          error: createImpureFunctionDiagnostic('new Date', value.loc),
-        });
-      }
       break;
     }
     case 'PropertyDelete':
@@ -2344,7 +2329,11 @@ function computeEffectsForLegacySignature(
     value: signature.returnValueKind,
     reason: returnValueReason,
   });
-  if (signature.impure && state.env.config.validateNoImpureFunctionsInRender) {
+  if (
+    signature.impure &&
+    state.env.config.validateNoImpureFunctionsInRender &&
+    (!signature.impureIfNoArgs || args.length === 0)
+  ) {
     effects.push({
       kind: 'Impure',
       place: receiver,
@@ -2860,32 +2849,6 @@ export function getFunctionCallSignature(
     return null;
   }
   return env.getFunctionSignature(type);
-}
-
-function isZeroArgumentDateConstructor(
-  type: Type,
-  args: Array<Place | SpreadPattern | Hole>,
-): boolean {
-  return (
-    args.length === 0 && type.kind === 'Object' && type.shapeId === 'Date'
-  );
-}
-
-function createImpureFunctionDiagnostic(
-  canonicalName: string,
-  loc: SourceLocation,
-): CompilerDiagnostic {
-  return CompilerDiagnostic.create({
-    category: ErrorCategory.Purity,
-    reason: 'Cannot call impure function during render',
-    description:
-      `\`${canonicalName}\` is an impure function. ` +
-      'Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent)',
-  }).withDetails({
-    kind: 'error',
-    loc,
-    message: 'Cannot call impure function',
-  });
 }
 
 export function isKnownMutableEffect(effect: Effect): boolean {

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts
@@ -1839,6 +1839,21 @@ function computeSignatureForInstruction(
         signature,
         loc: value.loc,
       });
+      // Zero-arg `new Date()` reads the current clock. `Date.now()` is already
+      // marked impure via its function signature; the constructor is an Object
+      // type (static `now` lives on the same global) so NewExpression has no
+      // signature. Constructing from an explicit timestamp is treated as pure.
+      if (
+        value.kind === 'NewExpression' &&
+        env.config.validateNoImpureFunctionsInRender &&
+        isZeroArgumentDateConstructor(callee.identifier.type, value.args)
+      ) {
+        effects.push({
+          kind: 'Impure',
+          place: callee,
+          error: createImpureFunctionDiagnostic('new Date', value.loc),
+        });
+      }
       break;
     }
     case 'PropertyDelete':
@@ -2845,6 +2860,32 @@ export function getFunctionCallSignature(
     return null;
   }
   return env.getFunctionSignature(type);
+}
+
+function isZeroArgumentDateConstructor(
+  type: Type,
+  args: Array<Place | SpreadPattern | Hole>,
+): boolean {
+  return (
+    args.length === 0 && type.kind === 'Object' && type.shapeId === 'Date'
+  );
+}
+
+function createImpureFunctionDiagnostic(
+  canonicalName: string,
+  loc: SourceLocation,
+): CompilerDiagnostic {
+  return CompilerDiagnostic.create({
+    category: ErrorCategory.Purity,
+    reason: 'Cannot call impure function during render',
+    description:
+      `\`${canonicalName}\` is an impure function. ` +
+      'Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent)',
+  }).withDetails({
+    kind: 'error',
+    loc,
+    message: 'Cannot call impure function',
+  });
 }
 
 export function isKnownMutableEffect(effect: Effect): boolean {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-new-date-in-render.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-new-date-in-render.expect.md
@@ -1,0 +1,62 @@
+
+## Input
+
+```javascript
+// @validateNoImpureFunctionsInRender
+
+function Component() {
+  const date = new Date();
+  const time = new Date().getTime();
+  const year = new Date().getFullYear();
+  return <Foo date={date} time={time} year={year} />;
+}
+
+```
+
+
+## Error
+
+```
+Found 3 errors:
+
+Error: Cannot call impure function during render
+
+`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+
+error.invalid-new-date-in-render.ts:4:15
+  2 |
+  3 | function Component() {
+> 4 |   const date = new Date();
+    |                ^^^^^^^^^^ Cannot call impure function
+  5 |   const time = new Date().getTime();
+  6 |   const year = new Date().getFullYear();
+  7 |   return <Foo date={date} time={time} year={year} />;
+
+Error: Cannot call impure function during render
+
+`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+
+error.invalid-new-date-in-render.ts:5:15
+  3 | function Component() {
+  4 |   const date = new Date();
+> 5 |   const time = new Date().getTime();
+    |                ^^^^^^^^^^ Cannot call impure function
+  6 |   const year = new Date().getFullYear();
+  7 |   return <Foo date={date} time={time} year={year} />;
+  8 | }
+
+Error: Cannot call impure function during render
+
+`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+
+error.invalid-new-date-in-render.ts:6:15
+  4 |   const date = new Date();
+  5 |   const time = new Date().getTime();
+> 6 |   const year = new Date().getFullYear();
+    |                ^^^^^^^^^^ Cannot call impure function
+  7 |   return <Foo date={date} time={time} year={year} />;
+  8 | }
+  9 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-new-date-in-render.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-new-date-in-render.expect.md
@@ -21,7 +21,7 @@ Found 3 errors:
 
 Error: Cannot call impure function during render
 
-`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+`Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
 
 error.invalid-new-date-in-render.ts:4:15
   2 |
@@ -34,7 +34,7 @@ error.invalid-new-date-in-render.ts:4:15
 
 Error: Cannot call impure function during render
 
-`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+`Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
 
 error.invalid-new-date-in-render.ts:5:15
   3 | function Component() {
@@ -47,7 +47,7 @@ error.invalid-new-date-in-render.ts:5:15
 
 Error: Cannot call impure function during render
 
-`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+`Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
 
 error.invalid-new-date-in-render.ts:6:15
   4 |   const date = new Date();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-new-date-in-render.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-new-date-in-render.js
@@ -1,0 +1,8 @@
+// @validateNoImpureFunctionsInRender
+
+function Component() {
+  const date = new Date();
+  const time = new Date().getTime();
+  const year = new Date().getFullYear();
+  return <Foo date={date} time={time} year={year} />;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/error.invalid-new-date-in-render.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/error.invalid-new-date-in-render.expect.md
@@ -1,0 +1,62 @@
+
+## Input
+
+```javascript
+// @validateNoImpureFunctionsInRender @enableNewMutationAliasingModel
+
+function Component() {
+  const date = new Date();
+  const time = new Date().getTime();
+  const year = new Date().getFullYear();
+  return <Foo date={date} time={time} year={year} />;
+}
+
+```
+
+
+## Error
+
+```
+Found 3 errors:
+
+Error: Cannot call impure function during render
+
+`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+
+error.invalid-new-date-in-render.ts:4:15
+  2 |
+  3 | function Component() {
+> 4 |   const date = new Date();
+    |                ^^^^^^^^^^ Cannot call impure function
+  5 |   const time = new Date().getTime();
+  6 |   const year = new Date().getFullYear();
+  7 |   return <Foo date={date} time={time} year={year} />;
+
+Error: Cannot call impure function during render
+
+`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+
+error.invalid-new-date-in-render.ts:5:15
+  3 | function Component() {
+  4 |   const date = new Date();
+> 5 |   const time = new Date().getTime();
+    |                ^^^^^^^^^^ Cannot call impure function
+  6 |   const year = new Date().getFullYear();
+  7 |   return <Foo date={date} time={time} year={year} />;
+  8 | }
+
+Error: Cannot call impure function during render
+
+`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+
+error.invalid-new-date-in-render.ts:6:15
+  4 |   const date = new Date();
+  5 |   const time = new Date().getTime();
+> 6 |   const year = new Date().getFullYear();
+    |                ^^^^^^^^^^ Cannot call impure function
+  7 |   return <Foo date={date} time={time} year={year} />;
+  8 | }
+  9 |
+```
+          
+      

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/error.invalid-new-date-in-render.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/error.invalid-new-date-in-render.expect.md
@@ -21,7 +21,7 @@ Found 3 errors:
 
 Error: Cannot call impure function during render
 
-`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+`Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
 
 error.invalid-new-date-in-render.ts:4:15
   2 |
@@ -34,7 +34,7 @@ error.invalid-new-date-in-render.ts:4:15
 
 Error: Cannot call impure function during render
 
-`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+`Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
 
 error.invalid-new-date-in-render.ts:5:15
   3 | function Component() {
@@ -47,7 +47,7 @@ error.invalid-new-date-in-render.ts:5:15
 
 Error: Cannot call impure function during render
 
-`new Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
+`Date` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).
 
 error.invalid-new-date-in-render.ts:6:15
   4 |   const date = new Date();

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/error.invalid-new-date-in-render.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/error.invalid-new-date-in-render.js
@@ -1,0 +1,8 @@
+// @validateNoImpureFunctionsInRender @enableNewMutationAliasingModel
+
+function Component() {
+  const date = new Date();
+  const time = new Date().getTime();
+  const year = new Date().getFullYear();
+  return <Foo date={date} time={time} year={year} />;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/valid-new-date-from-timestamp.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/valid-new-date-from-timestamp.expect.md
@@ -1,0 +1,45 @@
+
+## Input
+
+```javascript
+// @validateNoImpureFunctionsInRender @enableNewMutationAliasingModel
+
+function Component({timestamp}) {
+  const date = new Date(timestamp);
+  return <Foo date={date} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateNoImpureFunctionsInRender @enableNewMutationAliasingModel
+
+function Component(t0) {
+  const $ = _c(4);
+  const { timestamp } = t0;
+  let t1;
+  if ($[0] !== timestamp) {
+    t1 = new Date(timestamp);
+    $[0] = timestamp;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const date = t1;
+  let t2;
+  if ($[2] !== date) {
+    t2 = <Foo date={date} />;
+    $[2] = date;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/valid-new-date-from-timestamp.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/new-mutability/valid-new-date-from-timestamp.js
@@ -1,0 +1,6 @@
+// @validateNoImpureFunctionsInRender @enableNewMutationAliasingModel
+
+function Component({timestamp}) {
+  const date = new Date(timestamp);
+  return <Foo date={date} />;
+}

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-new-date-from-timestamp.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-new-date-from-timestamp.expect.md
@@ -1,0 +1,45 @@
+
+## Input
+
+```javascript
+// @validateNoImpureFunctionsInRender
+
+function Component({timestamp}) {
+  const date = new Date(timestamp);
+  return <Foo date={date} />;
+}
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime"; // @validateNoImpureFunctionsInRender
+
+function Component(t0) {
+  const $ = _c(4);
+  const { timestamp } = t0;
+  let t1;
+  if ($[0] !== timestamp) {
+    t1 = new Date(timestamp);
+    $[0] = timestamp;
+    $[1] = t1;
+  } else {
+    t1 = $[1];
+  }
+  const date = t1;
+  let t2;
+  if ($[2] !== date) {
+    t2 = <Foo date={date} />;
+    $[2] = date;
+    $[3] = t2;
+  } else {
+    t2 = $[3];
+  }
+  return t2;
+}
+
+```
+      
+### Eval output
+(kind: exception) Fixture not implemented

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-new-date-from-timestamp.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/valid-new-date-from-timestamp.js
@@ -1,0 +1,6 @@
+// @validateNoImpureFunctionsInRender
+
+function Component({timestamp}) {
+  const date = new Date(timestamp);
+  return <Foo date={date} />;
+}

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/ImpureFunctionCallsRule-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/ImpureFunctionCallsRule-test.ts
@@ -16,7 +16,17 @@ testRule(
   'no impure function calls rule',
   allRules[getRuleForCategory(ErrorCategory.Purity).name].rule,
   {
-    valid: [],
+    valid: [
+      {
+        name: 'Date constructed from a timestamp is not flagged',
+        code: normalizeIndent`
+      function Component({ timestamp }) {
+        const date = new Date(timestamp);
+        return <Foo date={date} />;
+      }
+    `,
+      },
+    ],
     invalid: [
       {
         name: 'Known impure function calls are caught',
@@ -26,6 +36,22 @@ testRule(
         const now = performance.now();
         const rand = Math.random();
         return <Foo date={date} now={now} rand={rand} />;
+      }
+    `,
+        errors: [
+          makeTestCaseError('Cannot call impure function during render'),
+          makeTestCaseError('Cannot call impure function during render'),
+          makeTestCaseError('Cannot call impure function during render'),
+        ],
+      },
+      {
+        name: 'Zero-argument Date constructor is impure',
+        code: normalizeIndent`
+      function Component() {
+        const date = new Date();
+        const time = new Date().getTime();
+        const year = new Date().getFullYear();
+        return <Foo date={date} time={time} year={year} />;
       }
     `,
         errors: [

--- a/compiler/packages/eslint-plugin-react-compiler/__tests__/RustBackendComparison-test.ts
+++ b/compiler/packages/eslint-plugin-react-compiler/__tests__/RustBackendComparison-test.ts
@@ -354,6 +354,30 @@ const testCases: ComparisonTestCase[] = [
     rule: 'recommended',
     expectedErrorCount: 3,
   },
+  {
+    name: '[ImpureFunctionCalls] Zero-argument Date constructor is impure',
+    code: normalizeIndent`
+      function Component() {
+        const date = new Date();
+        const time = new Date().getTime();
+        const year = new Date().getFullYear();
+        return <Foo date={date} time={time} year={year} />;
+      }
+    `,
+    rule: 'recommended',
+    expectedErrorCount: 3,
+  },
+  {
+    name: '[ImpureFunctionCalls] Date constructed from a timestamp is not flagged',
+    code: normalizeIndent`
+      function Component({ timestamp }) {
+        const date = new Date(timestamp);
+        return <Foo date={date} />;
+      }
+    `,
+    rule: 'recommended',
+    expectedErrorCount: 0,
+  },
 
   // ---- NoCapitalizedCallsRule-test.ts ----
   {


### PR DESCRIPTION
## Summary

`react-hooks/purity` already reports `Date.now()` during render, but not `new Date()` / `new Date().getTime()` / `new Date().getFullYear()`. Those also read the current clock. React's purity docs list `new Date()` next to `Date.now()`.

Zero-argument `new Date()` is now treated as an impure call (same diagnostic as `Date.now()`). Constructing from an explicit timestamp stays allowed: `new Date(timestamp)`.

Fixes #37553

## How did you test this change?

- `yarn snap --pattern "**/*new-date*"` (4 fixtures passed)
- `yarn workspace eslint-plugin-react-compiler test -- ImpureFunctionCallsRule` (4 tests passed)


Made with [Cursor](https://cursor.com)