### PR TITLE
[DOM] Fix Fragment compareDocumentPosition(document) TypeError

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3716,8 +3716,12 @@ function validateDocumentPositionWithFiberTree(
   }
   if (documentPosition & Node.DOCUMENT_POSITION_CONTAINS) {
     if (otherFiber === null) {
-      // otherFiber could be null if its the document, documentElement, or body
-      const ownerDocument = otherNode.ownerDocument;
+      // otherFiber could be null if its the document, documentElement, or body.
+      // Document.ownerDocument is null, so treat the node itself as the document.
+      const ownerDocument =
+        otherNode.nodeType === DOCUMENT_NODE
+          ? (otherNode: any)
+          : otherNode.ownerDocument;
       return (
         (otherNode as Instance | Document) === ownerDocument ||
         otherNode === ownerDocument.documentElement ||

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3717,11 +3717,10 @@ function validateDocumentPositionWithFiberTree(
   if (documentPosition & Node.DOCUMENT_POSITION_CONTAINS) {
     if (otherFiber === null) {
       // otherFiber could be null if its the document, documentElement, or body.
-      // Document.ownerDocument is null, so treat the node itself as the document.
-      const ownerDocument =
-        otherNode.nodeType === DOCUMENT_NODE
-          ? (otherNode: any)
-          : otherNode.ownerDocument;
+      // Document.ownerDocument is null, so reuse the shared helper.
+      const ownerDocument = getOwnerDocumentFromRootContainer(
+        (otherNode: Element | Document | DocumentFragment),
+      );
       return (
         (otherNode as Instance | Document) === ownerDocument ||
         otherNode === ownerDocument.documentElement ||

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3716,10 +3716,9 @@ function validateDocumentPositionWithFiberTree(
   }
   if (documentPosition & Node.DOCUMENT_POSITION_CONTAINS) {
     if (otherFiber === null) {
-      // otherFiber could be null if its the document, documentElement, or body.
-      // Document.ownerDocument is null, so reuse the shared helper.
+      // otherFiber could be null if its the document, documentElement, or body
       const ownerDocument = getOwnerDocumentFromRootContainer(
-        (otherNode: Element | Document | DocumentFragment),
+        (otherNode: any),
       );
       return (
         (otherNode as Instance | Document) === ownerDocument ||

--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3717,9 +3717,7 @@ function validateDocumentPositionWithFiberTree(
   if (documentPosition & Node.DOCUMENT_POSITION_CONTAINS) {
     if (otherFiber === null) {
       // otherFiber could be null if its the document, documentElement, or body
-      const ownerDocument = getOwnerDocumentFromRootContainer(
-        (otherNode: any),
-      );
+      const ownerDocument = getOwnerDocumentFromRootContainer(otherNode);
       return (
         (otherNode as Instance | Document) === ownerDocument ||
         otherNode === ownerDocument.documentElement ||

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -2433,6 +2433,16 @@ describe('FragmentRefs', () => {
         },
       );
 
+      // document is preceding and contains the fragment (Document.ownerDocument is null)
+      expectPosition(fragmentRef.current.compareDocumentPosition(document), {
+        preceding: true,
+        following: false,
+        contains: true,
+        containedBy: false,
+        disconnected: false,
+        implementationSpecific: false,
+      });
+
       // beforeRef is preceding the fragment
       expectPosition(
         fragmentRef.current.compareDocumentPosition(beforeRef.current),


### PR DESCRIPTION
## Summary

Fixes #37578.

`FragmentInstance.compareDocumentPosition(document)` threw:

```
TypeError: Cannot read properties of null (reading 'documentElement')
```

because `Document.ownerDocument` is `null`, and the `CONTAINS` fiber-validation fallback read `ownerDocument.documentElement` unconditionally. `document.body` / `document.documentElement` already worked.

This treats a `Document` node as its own owner document, matching `Node.compareDocumentPosition(document)`.

## How did you test this change?

- Added a regression assertion in `ReactDOMFragmentRefs-test` for `compareDocumentPosition(document)`
- `yarn test ReactDOMFragmentRefs-test` (dev) — pass
- `yarn test ReactDOMFragmentRefs-test --prod` — pass
- `yarn test ReactDOMFragmentRefsDocument-test` — pass

## CLA

I have read the CLA and can sign it for this contribution if needed.

Made with [Cursor](https://cursor.com)