### PR TITLE
[compiler] Fix Stack overflow in Stack.find/contains/each/print on deeply nested scopes

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Utils/Stack.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Utils/Stack.ts
@@ -60,18 +60,44 @@ class Node<T> implements StackInterface<T> {
   }
 
   find(fn: (value: T) => boolean): boolean {
-    return fn(this.#value) ? true : this.#next.find(fn);
+    /*
+     * Walk the linked list iteratively instead of recursing per-node so that
+     * deeply nested stacks (e.g. tens of thousands of entries) don't
+     * overflow the JS call stack.
+     */
+    if (fn(this.#value)) {
+      return true;
+    }
+    let node: Stack<T> = this.#next;
+    while (node instanceof Node) {
+      if (fn(node.#value)) {
+        return true;
+      }
+      node = node.#next;
+    }
+    return false;
   }
 
   contains(value: T): boolean {
-    return (
-      value === this.#value ||
-      (this.#next !== null && this.#next.contains(value))
-    );
+    if (value === this.#value) {
+      return true;
+    }
+    let node: Stack<T> = this.#next;
+    while (node instanceof Node) {
+      if (value === node.#value) {
+        return true;
+      }
+      node = node.#next;
+    }
+    return false;
   }
   each(fn: (value: T) => void): void {
     fn(this.#value);
-    this.#next.each(fn);
+    let node: Stack<T> = this.#next;
+    while (node instanceof Node) {
+      fn(node.#value);
+      node = node.#next;
+    }
   }
 
   get value(): T {
@@ -79,7 +105,13 @@ class Node<T> implements StackInterface<T> {
   }
 
   print(fn: (node: T) => string): string {
-    return fn(this.#value) + this.#next.print(fn);
+    let result = fn(this.#value);
+    let node: Stack<T> = this.#next;
+    while (node instanceof Node) {
+      result += fn(node.#value);
+      node = node.#next;
+    }
+    return result;
   }
 }
 

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/Stack-test.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/Stack-test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as Stack from '../Utils/Stack';
+
+describe('Stack', () => {
+  it('.find/.contains/.each/.print work for a small stack', () => {
+    let stack = Stack.create(0);
+    for (let i = 1; i < 5; i++) {
+      stack = stack.push(i);
+    }
+
+    expect(stack.find(value => value === 0)).toBe(true);
+    expect(stack.find(value => value === -1)).toBe(false);
+    expect(stack.contains(3)).toBe(true);
+    expect(stack.contains(100)).toBe(false);
+
+    const visited: Array<number> = [];
+    stack.each(value => visited.push(value));
+    // top-to-bottom order: most recently pushed value first
+    expect(visited).toEqual([4, 3, 2, 1, 0]);
+
+    expect(stack.print(value => `${value}`)).toBe('43210');
+  });
+
+  /**
+   * Regression test for a Stack overflow bug: `find`, `contains`, `each`,
+   * and `print` used to recurse one call-stack frame per linked-list node,
+   * which overflowed the JS call stack for deeply nested compiler inputs.
+   * These traversals should be O(1) in call-stack depth regardless of how
+   * many entries are on the Stack.
+   */
+  it('.find/.contains/.each/.print do not overflow the call stack for a very deep stack', () => {
+    const DEPTH = 50_000;
+    let stack = Stack.create(0);
+    for (let i = 1; i < DEPTH; i++) {
+      stack = stack.push(i);
+    }
+
+    // The bottom-most (first pushed) value is the value with the deepest
+    // recursion depth in the old recursive implementation.
+    expect(() => stack.find(value => value === 0)).not.toThrow();
+    expect(stack.find(value => value === 0)).toBe(true);
+    expect(stack.find(value => value === -1)).toBe(false);
+
+    expect(() => stack.contains(0)).not.toThrow();
+    expect(stack.contains(0)).toBe(true);
+    expect(stack.contains(-1)).toBe(false);
+
+    let count = 0;
+    expect(() => stack.each(() => count++)).not.toThrow();
+    expect(count).toBe(DEPTH);
+
+    let printed: string = '';
+    expect(() => {
+      printed = stack.print(value => `${value},`);
+    }).not.toThrow();
+    expect(printed.split(',').filter(Boolean).length).toBe(DEPTH);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #37445

The compiler's immutable `Stack` data structure (`compiler/packages/babel-plugin-react-compiler/src/Utils/Stack.ts`) implemented `find`, `contains`, `each`, and `print` by recursing one JS call-stack frame per linked-list node. For compiler inputs with a large number of active/nested scopes (tens of thousands of stack entries), these traversals could exceed the JS call-stack depth and throw:

```
RangeError: Maximum call stack size exceeded
```

## Fix

Converted `find`, `contains`, `each`, and `print` on the `Node` class from per-node recursion to iterative `while` loops that walk the linked list. Traversal order (top-to-bottom / most-recently-pushed-first) is preserved exactly; only the call-stack depth changes — it is now O(1) instead of O(n) in the number of stack entries.

To satisfy the `@typescript-eslint/no-this-alias` lint rule (no aliasing `this` to a local variable), each method first processes `this`'s own value, then iterates over `this.#next` onward using a local `node` variable — so `this` itself is never aliased.

`Empty#find/contains/each/print` were already O(1) (terminal case) and are unchanged.

## Test plan

Added `src/__tests__/Stack-test.ts` with:
- Basic correctness checks for `find`/`contains`/`each`/`print` on a small stack, verifying traversal order.
- A regression test that pushes 50,000 entries onto the `Stack` and calls `find`, `contains`, `each`, and `print`, asserting none of them throw and that results are correct — this reproduces the reported overflow on the old recursive implementation and passes with the iterative fix.

Ran:
- `yarn workspace babel-plugin-react-compiler lint` — passes.
- `yarn jest` in `compiler/packages/babel-plugin-react-compiler` — full suite passes (15 suites / 43 tests / 40 snapshots).