### PR TITLE
[compiler] Avoid quadratic Array.shift() in three worklist traversals

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts
@@ -463,8 +463,9 @@ export function compileProgram(
   // outputMode takes precedence if specified
   const outputMode: CompilerOutputMode =
     pass.opts.outputMode ?? (pass.opts.noEmit ? 'lint' : 'client');
-  while (queue.length !== 0) {
-    const current = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const current = queue[queueIndex++];
     const compiled = processFn(
       current.fn,
       current.fnType,

--- a/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/HIR/HIRBuilder.ts
@@ -651,8 +651,9 @@ function _shrink(func: HIR): void {
 
   const queue = [func.entry];
   const reachable = new Set<BlockId>();
-  while (queue.length !== 0) {
-    const blockId = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const blockId = queue[queueIndex++];
     if (reachable.has(blockId)) {
       continue;
     }

--- a/compiler/packages/babel-plugin-react-compiler/src/Inference/ControlDominators.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Inference/ControlDominators.ts
@@ -95,8 +95,9 @@ function postDominatorsOf(
   const result = new Set<BlockId>();
   const visited = new Set<BlockId>();
   const queue = [targetId];
-  while (queue.length) {
-    const currentId = queue.shift()!;
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const currentId = queue[queueIndex++];
     if (visited.has(currentId)) {
       continue;
     }


### PR DESCRIPTION
## Summary

Fixes #37414.

Three BFS/worklist traversals in the React Compiler dequeue with `Array.prototype.shift()`:

- `compileProgram`'s worklist of functions to compile (`Entrypoint/Program.ts`)
- HIR reachability shrinking, `_shrink` (`HIR/HIRBuilder.ts`)
- control-flow post-dominator computation, `postDominatorsOf` (`Inference/ControlDominators.ts`)

`Array.prototype.shift()` is O(n) because it re-indexes every remaining element, so looping `shift()` until the queue is empty makes each of these traversals O(n²) instead of O(n) on large inputs.

All three queues are append-only worklists (items are only ever pushed, and visited/seen-set checks prevent re-processing), so the front element never needs to be physically removed. This PR replaces each `shift()`-based loop with an index cursor (`let queueIndex = 0; while (queueIndex < queue.length) { const item = queue[queueIndex++]; ... }`) that advances over the same backing array. Traversal order (FIFO) and dequeue/visit behavior are unchanged — only the O(n) removal cost per dequeue is eliminated.

## How did you test this change?

- `yarn workspace babel-plugin-react-compiler lint` — passes
- `tsc --noEmit` for `babel-plugin-react-compiler` — passes
- `yarn workspace babel-plugin-react-compiler test` (fixture/snapshot suite) — passes, no fixture output changes (traversal order is identical since these are FIFO append-only worklists)