### PR TITLE
fix(compiler): preserve -0/0 distinction through phi constant propagation and codegen

### DIFF
--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
@@ -195,8 +195,10 @@ function evaluatePhi(phi: Phi, constants: Constants): Constant | null {
           loc: GeneratedSource,
         });
 
-        // different constant values, can't constant propogate
-        // (using Object.is to correctly distinguish -0 from 0, and NaN from itself)
+        /*
+         * different constant values, can't constant propogate
+         * (using Object.is to correctly distinguish -0 from 0, and NaN from itself)
+         */
         if (!Object.is(operandValue.value, value.value)) {
           return null;
         }

--- a/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/Optimization/ConstantPropagation.ts
@@ -196,7 +196,8 @@ function evaluatePhi(phi: Phi, constants: Constants): Constant | null {
         });
 
         // different constant values, can't constant propogate
-        if (operandValue.value !== value.value) {
+        // (using Object.is to correctly distinguish -0 from 0, and NaN from itself)
+        if (!Object.is(operandValue.value, value.value)) {
           return null;
         }
         break;

--- a/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
+++ b/compiler/packages/babel-plugin-react-compiler/src/ReactiveScopes/CodegenReactiveFunction.ts
@@ -2370,11 +2370,15 @@ function codegenValue(
   value: boolean | number | string | null | undefined,
 ): t.Expression {
   if (typeof value === 'number') {
-    if (value < 0) {
+    if (value < 0 || Object.is(value, -0)) {
       /**
        * Babel's code generator produces invalid JS for negative numbers when
        * run with { compact: true }.
        * See repro https://codesandbox.io/p/devbox/5d47fr
+       *
+       * Note this also covers `-0`, which fails the `value < 0` check but
+       * must still be emitted as a unary negation of `0` in order to
+       * preserve the distinction between `0` and `-0` (Object.is semantics).
        */
       return t.unaryExpression('-', t.numericLiteral(-value), false);
     } else {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-unary-number.expect.md
@@ -44,7 +44,7 @@ function foo() {
       <Stringify
         value={[
           -2,
-          0,
+          -0,
           true,
           -Infinity,
           -NaN,

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/negative-zero-phi-constant-propagation.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/negative-zero-phi-constant-propagation.expect.md
@@ -1,0 +1,75 @@
+
+## Input
+
+```javascript
+function Component({sign}) {
+  let x;
+  if (sign) {
+    x = 0;
+  } else {
+    x = -0;
+  }
+  // `1 / x` reveals the sign of zero: `Infinity` for `0`, `-Infinity` for
+  // `-0`. This lets us assert (via the eval fixture harness comparing the
+  // compiled and uncompiled output) that Object.is(x, -0) parity is
+  // preserved through the compiler's constant propagation and codegen.
+  return <div>{`1/x=${1 / x}`}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{sign: true}],
+  sequentialRenders: [
+    {sign: true},
+    {sign: false},
+    {sign: false},
+    {sign: true},
+  ],
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+  const $ = _c(2);
+  const { sign } = t0;
+  let x;
+  if (sign) {
+    x = 0;
+  } else {
+    x = -0;
+  }
+
+  const t1 = `1/x=${1 / x}`;
+  let t2;
+  if ($[0] !== t1) {
+    t2 = <div>{t1}</div>;
+    $[0] = t1;
+    $[1] = t2;
+  } else {
+    t2 = $[1];
+  }
+  return t2;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ sign: true }],
+  sequentialRenders: [
+    { sign: true },
+    { sign: false },
+    { sign: false },
+    { sign: true },
+  ],
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>1/x=Infinity</div>
+<div>1/x=-Infinity</div>
+<div>1/x=-Infinity</div>
+<div>1/x=Infinity</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/negative-zero-phi-constant-propagation.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/negative-zero-phi-constant-propagation.js
@@ -1,0 +1,24 @@
+function Component({sign}) {
+  let x;
+  if (sign) {
+    x = 0;
+  } else {
+    x = -0;
+  }
+  // `1 / x` reveals the sign of zero: `Infinity` for `0`, `-Infinity` for
+  // `-0`. This lets us assert (via the eval fixture harness comparing the
+  // compiled and uncompiled output) that Object.is(x, -0) parity is
+  // preserved through the compiler's constant propagation and codegen.
+  return <div>{`1/x=${1 / x}`}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{sign: true}],
+  sequentialRenders: [
+    {sign: true},
+    {sign: false},
+    {sign: false},
+    {sign: true},
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes #37447. Two paths in the React Compiler collapsed JavaScript's observable distinction between `0` and `-0`:

1. **Constant propagation (`Optimization/ConstantPropagation.ts`)**: `evaluatePhi` compared phi operand constant values with `!==`. Since `0 !== -0` evaluates to `false` in JS, a phi merging `0` on one branch and `-0` on another was incorrectly folded into a single "constant" value, silently discarding whichever branch didn't "win", regardless of which branch actually executed at runtime.
2. **Codegen (`ReactiveScopes/CodegenReactiveFunction.ts`)**: `codegenValue` only emitted a unary negation (`-0`) when `value < 0`. Since `-0 < 0` is `false`, a literal `-0` was re-emitted as plain `0`, losing its sign.

## Fix

- Use `Object.is()` instead of `!==` when comparing phi constant candidates in `evaluatePhi`, so operands with different sign but "equal" primitive values (i.e. `0`/`-0`) are correctly treated as non-constant (and thus preserved as a genuine runtime phi instead of being folded to one arbitrary branch's value).
- Emit a unary negation in codegen when `Object.is(value, -0)` is true, in addition to the existing `value < 0` check, so `-0` literals round-trip correctly.

## Tests

- Added `negative-zero-phi-constant-propagation.js`/`.expect.md`: a component whose phi alternates between `0` and `-0` across renders. `1 / x` is used to observe the sign of zero (`Infinity` vs `-Infinity`), and the fixture harness compares compiled vs. uncompiled eval output, verifying `Object.is` parity is preserved pre/post compile.
- Updated the pre-existing `constant-propagation-unary-number` snapshot: it already contained a `-0` literal that was silently being emitted as `0` in codegen prior to this fix — that regression is now fixed and visible in the updated snapshot (`-2, -0, true, ...` instead of `-2, 0, true, ...`).
- Ran the full `babel-plugin-react-compiler` snap test suite (1817 fixtures) — all pass with only the one expected snapshot update above.
- `yarn workspace babel-plugin-react-compiler lint` passes.

## Test plan

```
cd compiler/packages/babel-plugin-react-compiler
yarn build
yarn workspace snap run snap
yarn lint
```