### PR TITLE
[Reconciler] Fix act() infinite Suspense retry loop with 3+ siblings

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -777,6 +777,70 @@ function runActTests(render, unmount, rerender) {
           expect(document.querySelector('[data-test-id=spinner]')).toBeNull();
           expect(container.textContent).toBe('was suspended');
         });
+
+        // @gate __DEV__
+        // Regression test for https://github.com/facebook/react/issues/37556
+        it('does not infinite-loop when re-rendering 3+ suspended sibling Suspense boundaries', async () => {
+          const count = 3;
+          const entries = Array.from({length: count}, () => {
+            let resolve;
+            const state = {status: 'pending', value: ''};
+            const promise = new Promise(r => {
+              resolve = r;
+            }).then(v => {
+              state.status = 'fulfilled';
+              state.value = v;
+            });
+            return {state, promise, resolve};
+          });
+
+          let attempts = 0;
+          function Tile({index}) {
+            attempts++;
+            // Cap so a hang fails the test instead of wedging the worker.
+            if (attempts > 1000) {
+              throw new Error(
+                'Infinite Suspense retry loop under act(): tile render attempts exceeded 1000',
+              );
+            }
+            const entry = entries[index];
+            if (entry.state.status === 'pending') {
+              throw entry.promise;
+            }
+            return <span>{`content ${entry.state.value}`}</span>;
+          }
+
+          function Parent() {
+            const [, bump] = React.useState(0);
+            React.useEffect(() => {
+              bump(1);
+            }, []);
+            return (
+              <>
+                {entries.map((_, index) => (
+                  <React.Suspense key={index} fallback={<span>loading</span>}>
+                    <Tile index={index} />
+                  </React.Suspense>
+                ))}
+              </>
+            );
+          }
+
+          const root = ReactDOMClient.createRoot(container);
+          await act(() => {
+            root.render(<Parent />);
+          });
+
+          expect(attempts).toBeLessThan(1000);
+          expect(container.textContent).toBe('loading'.repeat(count));
+
+          await act(async () => {
+            entries.forEach(entry => entry.resolve('done'));
+            await Promise.resolve();
+          });
+
+          expect(container.textContent).toBe('content done'.repeat(count));
+        });
       }
     });
   });

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -171,6 +171,7 @@ import {
   getWorkInProgressTransitions,
   shouldRemainOnPreviousScreen,
   markSpawnedRetryLane,
+  requestImmediateSuspenseRetryLane,
 } from './ReactFiberWorkLoop';
 import {
   OffscreenLane,
@@ -178,7 +179,6 @@ import {
   NoLanes,
   includesSomeLane,
   mergeLanes,
-  claimNextRetryLane,
   includesOnlySuspenseyCommitEligibleLanes,
 } from './ReactFiberLane';
 import {resetChildFibers} from './ReactChildFiber';
@@ -661,7 +661,7 @@ function scheduleRetryEffect(
       // I also suspect that we need some further consolidation of offscreen
       // and retry lanes.
       workInProgress.tag !== OffscreenComponent
-        ? claimNextRetryLane()
+        ? requestImmediateSuspenseRetryLane()
         : OffscreenLane;
     workInProgress.lanes = mergeLanes(workInProgress.lanes, retryLane);
 

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -900,11 +900,6 @@ export function markRootFinished(
   suspendedRetryLanes: Lanes,
 ) {
   const previouslyPendingLanes = root.pendingLanes;
-  const previouslySuspendedRetryLanes =
-    root.suspendedLanes & remainingLanes & RetryLanes;
-  const previouslyPingedRetryLanes =
-    root.pingedLanes & remainingLanes & RetryLanes;
-  const previouslyWarmRetryLanes = root.warmLanes & remainingLanes & RetryLanes;
   const noLongerPendingLanes = previouslyPendingLanes & ~remainingLanes;
 
   root.pendingLanes = remainingLanes;
@@ -913,16 +908,6 @@ export function markRootFinished(
   root.suspendedLanes = NoLanes;
   root.pingedLanes = NoLanes;
   root.warmLanes = NoLanes;
-
-  // Exception: sibling Suspense "prewarm" retries are queued as multiple
-  // suspended retry lanes. Clearing those remaining retries here would make
-  // the next pass look like a fresh update (skip siblings → spawn more
-  // retries → infinite loop under act()). Only preserve Retry lane
-  // bookkeeping; other lanes still reset so selective hydration can retry.
-  // (facebook/react#37556)
-  root.suspendedLanes |= previouslySuspendedRetryLanes;
-  root.pingedLanes |= previouslyPingedRetryLanes;
-  root.warmLanes |= previouslyWarmRetryLanes;
 
   if (enableDefaultTransitionIndicator) {
     root.indicatorLanes &= remainingLanes;

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -900,14 +900,22 @@ export function markRootFinished(
   suspendedRetryLanes: Lanes,
 ) {
   const previouslyPendingLanes = root.pendingLanes;
+  const previouslySuspendedLanes = root.suspendedLanes;
+  const previouslyPingedLanes = root.pingedLanes;
+  const previouslyWarmLanes = root.warmLanes;
   const noLongerPendingLanes = previouslyPendingLanes & ~remainingLanes;
 
   root.pendingLanes = remainingLanes;
 
-  // Let's try everything again
-  root.suspendedLanes = NoLanes;
-  root.pingedLanes = NoLanes;
-  root.warmLanes = NoLanes;
+  // Drop lane bookkeeping for work we just finished, but keep it for lanes that
+  // are still pending. Sibling Suspense "prewarm" retries are spawned as
+  // multiple suspended retry lanes; if we cleared suspended/warm for those
+  // remaining lanes here, the next pass would treat them as fresh updates,
+  // skip siblings again, spawn more retries, and loop forever under act()'s
+  // synchronous flush (regression: facebook/react#37556).
+  root.suspendedLanes = previouslySuspendedLanes & remainingLanes;
+  root.pingedLanes = previouslyPingedLanes & remainingLanes;
+  root.warmLanes = previouslyWarmLanes & remainingLanes;
 
   if (enableDefaultTransitionIndicator) {
     root.indicatorLanes &= remainingLanes;

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -900,22 +900,29 @@ export function markRootFinished(
   suspendedRetryLanes: Lanes,
 ) {
   const previouslyPendingLanes = root.pendingLanes;
-  const previouslySuspendedLanes = root.suspendedLanes;
-  const previouslyPingedLanes = root.pingedLanes;
-  const previouslyWarmLanes = root.warmLanes;
+  const previouslySuspendedRetryLanes =
+    root.suspendedLanes & remainingLanes & RetryLanes;
+  const previouslyPingedRetryLanes =
+    root.pingedLanes & remainingLanes & RetryLanes;
+  const previouslyWarmRetryLanes = root.warmLanes & remainingLanes & RetryLanes;
   const noLongerPendingLanes = previouslyPendingLanes & ~remainingLanes;
 
   root.pendingLanes = remainingLanes;
 
-  // Drop lane bookkeeping for work we just finished, but keep it for lanes that
-  // are still pending. Sibling Suspense "prewarm" retries are spawned as
-  // multiple suspended retry lanes; if we cleared suspended/warm for those
-  // remaining lanes here, the next pass would treat them as fresh updates,
-  // skip siblings again, spawn more retries, and loop forever under act()'s
-  // synchronous flush (regression: facebook/react#37556).
-  root.suspendedLanes = previouslySuspendedLanes & remainingLanes;
-  root.pingedLanes = previouslyPingedLanes & remainingLanes;
-  root.warmLanes = previouslyWarmLanes & remainingLanes;
+  // Let's try everything again
+  root.suspendedLanes = NoLanes;
+  root.pingedLanes = NoLanes;
+  root.warmLanes = NoLanes;
+
+  // Exception: sibling Suspense "prewarm" retries are queued as multiple
+  // suspended retry lanes. Clearing those remaining retries here would make
+  // the next pass look like a fresh update (skip siblings → spawn more
+  // retries → infinite loop under act()). Only preserve Retry lane
+  // bookkeeping; other lanes still reset so selective hydration can retry.
+  // (facebook/react#37556)
+  root.suspendedLanes |= previouslySuspendedRetryLanes;
+  root.pingedLanes |= previouslyPingedRetryLanes;
+  root.warmLanes |= previouslyWarmRetryLanes;
 
   if (enableDefaultTransitionIndicator) {
     root.indicatorLanes &= remainingLanes;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -498,6 +498,11 @@ let workInProgressRootRenderPhaseUpdatedLanes: Lanes = NoLanes;
 let workInProgressRootPingedLanes: Lanes = NoLanes;
 // If this render scheduled deferred work, this is the lane of the deferred task.
 let workInProgressDeferredLane: Lane = NoLane;
+// Shared retry lane for all ScheduleRetry effects in the current render.
+// Sibling Suspense prewarm must batch onto one lane; claiming per-boundary
+// leaves remaining retries looking like fresh updates after markRootFinished
+// and loops under act() (facebook/react#37556).
+let workInProgressRetryLane: Lane = NoLane;
 // Represents the retry lanes that were spawned by this render and have not
 // been pinged since, implying that they are still suspended.
 let workInProgressSuspendedRetryLanes: Lanes = NoLanes;
@@ -2267,6 +2272,7 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   workInProgressRootRenderPhaseUpdatedLanes = NoLanes;
   workInProgressRootPingedLanes = NoLanes;
   workInProgressDeferredLane = NoLane;
+  workInProgressRetryLane = NoLane;
   workInProgressSuspendedRetryLanes = NoLanes;
   workInProgressRootConcurrentErrors = null;
   workInProgressRootRecoverableErrors = null;
@@ -3337,6 +3343,15 @@ function throwAndUnwindWorkLoop(
     // this particular path is how that would be implemented.
     completeUnitOfWork(unitOfWork);
   }
+}
+
+export function requestImmediateSuspenseRetryLane(): Lane {
+  // Used by ScheduleRetry during sibling-skipping prewarm. Multiple boundaries
+  // in one render share a single retry lane (same idea as requestDeferredLane).
+  if (workInProgressRetryLane === NoLane) {
+    workInProgressRetryLane = claimNextRetryLane();
+  }
+  return workInProgressRetryLane;
 }
 
 export function markSpawnedRetryLane(lane: Lane): void {


### PR DESCRIPTION
## Summary

Fixes #37556.

Under `act()`, re-rendering **three or more** sibling `<Suspense>` boundaries that throw stable pending thenables could hang forever: each boundary claimed its own retry lane via `ScheduleRetry`, and when the first finished `markRootFinished` cleared suspended bookkeeping on the remaining retries. Those lanes then looked like fresh updates, skipped siblings again, spawned more retries, and looped under `act()`'s synchronous flush.

**Approach:** batch all immediate `ScheduleRetry` effects in a single render onto one shared retry lane (`requestImmediateSuspenseRetryLane`), same idea as `requestDeferredLane`. Promise-resolution retries still use `claimNextRetryLane`. `markRootFinished` keeps its original full reset (needed for selective hydration and prerender↔normal mode switches).

## How did you test this change?

- Regression in `ReactTestUtilsAct-test.js` (3 suspended siblings + parent bump under `act`)
- `yarn test ReactSiblingPrerendering-test ReactTestUtilsAct-test ReactDOMServerSelectiveHydrationActivity-test`
- `yarn test ReactSuspenseWithNoopRenderer-test ReactSuspense-test ReactDOMFizzServer-test`
- Same key suites with `-r=stable`