### PR TITLE
[rust-compiler] Fix exponentiation to match js semantics

### DIFF
--- a/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
+++ b/compiler/crates/react_compiler_optimization/src/constant_propagation.rs
@@ -919,7 +919,7 @@ fn evaluate_binary_op(
         },
         BinaryOperator::Exponent => match (lhs, rhs) {
             (PrimitiveValue::Number(l), PrimitiveValue::Number(r)) => Some(PrimitiveValue::Number(
-                FloatValue::new(l.value().powf(r.value())),
+                FloatValue::new(js_exponentiate(l.value(), r.value())),
             )),
             _ => None,
         },
@@ -1106,6 +1106,15 @@ fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
 // =============================================================================
 // JavaScript Number.toString() approximation
 // =============================================================================
+
+/// ECMAScript Number::exponentiate (`**`). `f64::powf` follows IEEE 754, which
+/// returns 1 for `1 ** NaN` and `(±1) ** ±Infinity`; JavaScript returns NaN.
+fn js_exponentiate(base: f64, exponent: f64) -> f64 {
+    if base.abs() == 1.0 && !exponent.is_finite() {
+        return f64::NAN;
+    }
+    base.powf(exponent)
+}
 
 /// ECMAScript ToInt32: convert f64 to i32 with modular (wrapping) semantics.
 fn js_to_int32(n: f64) -> i32 {

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-exponent-non-finite.expect.md
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-exponent-non-finite.expect.md
@@ -1,0 +1,63 @@
+
+## Input
+
+```javascript
+import {Stringify} from 'shared-runtime';
+
+function foo() {
+  return (
+    <Stringify
+      value={[
+        1 ** (0 / 0),
+        1 ** (1 / 0),
+        1 ** (-1 / 0),
+        (-1) ** (1 / 0),
+        (-1) ** (-1 / 0),
+        (-1) ** (0 / 0),
+        (0 / 0) ** 0,
+        2 ** (1 / 0),
+        0.5 ** (1 / 0),
+        2 ** 10,
+      ]}
+    />
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};
+
+```
+
+## Code
+
+```javascript
+import { c as _c } from "react/compiler-runtime";
+import { Stringify } from "shared-runtime";
+
+function foo() {
+  const $ = _c(1);
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = (
+      <Stringify value={[NaN, NaN, NaN, NaN, NaN, NaN, 1, Infinity, 0, 1024]} />
+    );
+    $[0] = t0;
+  } else {
+    t0 = $[0];
+  }
+  return t0;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};
+
+```
+      
+### Eval output
+(kind: ok) <div>{"value":[null,null,null,null,null,null,1,null,0,1024]}</div>

--- a/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-exponent-non-finite.js
+++ b/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/constant-propagation-exponent-non-finite.js
@@ -1,0 +1,26 @@
+import {Stringify} from 'shared-runtime';
+
+function foo() {
+  return (
+    <Stringify
+      value={[
+        1 ** (0 / 0),
+        1 ** (1 / 0),
+        1 ** (-1 / 0),
+        (-1) ** (1 / 0),
+        (-1) ** (-1 / 0),
+        (-1) ** (0 / 0),
+        (0 / 0) ** 0,
+        2 ** (1 / 0),
+        0.5 ** (1 / 0),
+        2 ** 10,
+      ]}
+    />
+  );
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: foo,
+  params: [],
+  isComponent: false,
+};


### PR DESCRIPTION
## Summary

The Rust port's constant propagation folds `**` with `f64::powf`, which follows IEEE 754. IEEE `pow` returns `1` for `pow(1, NaN)` and `pow(±1, ±∞)`, but ECMAScript's [`Number::exponentiate`](https://tc39.es/ecma262/#sec-numeric-types-number-exponentiate) returns `NaN` in those cases. The TS compiler folds with native `lhs ** rhs`, so the two backends disagree, and the Rust-compiled output changes runtime behavior:

```js
const x = 1 ** (1 / 0); // JS: NaN, Rust-compiled: 1
```

This adds `js_exponentiate`, which returns `NaN` when `|base| == 1` and the exponent is not finite, and otherwise defers to `powf`. `**=` lowers to the same `BinaryOperator::Exponent`, so it is covered too.

To check the guard is neither too narrow nor too broad, I compared `f64::powf` against JS `**` over all 225 pairs drawn from {NaN, ±Infinity, ±0, ±1, ±2, ±0.5, ±3, ±1e308}. The only mismatches were `1 ** NaN`, `1 ** ±Infinity` and `(-1) ** ±Infinity`. The condition also matches `(-1) ** NaN`, where `powf` already returns `NaN`.

While in this file I noticed two places where `js_to_number` diverges from `ToNumber`. I left them out to keep this PR focused, and can send a follow-up if that's useful:

- `trimmed.parse::<f64>()` accepts `"inf"`, `"infinity"` and `"INFINITY"`, so `"inf" == 1 / 0` folds to `true` (JS: `false`).
- The `0x`/`0o`/`0b` branches use `u64::from_str_radix`, which fails past 64 bits (`"0xFFFFFFFFFFFFFFFFF" == 295147905179352830000` folds to `false`, JS: `true`) and accepts a sign after the prefix (`"0x+10" == 16` folds to `true`, JS: `false`).

## How did you test this change?

Added `constant-propagation-exponent-non-finite.js` with the five mismatching cases plus five controls: `(-1) ** NaN`, `NaN ** 0`, `2 ** Infinity`, `0.5 ** Infinity` and `2 ** 10`. The snapshot was generated with the TS compiler.

- Before the fix, `yarn snap --rust -p constant-propagation-exponent-non-finite` fails on eval output: expected `[null,null,null,null,null,null,1,null,0,1024]`, got `[1,1,1,1,1,null,1,null,0,1024]`.
- With a narrower guard (`exponent.is_infinite()` instead of `!exponent.is_finite()`) it still fails, only on `1 ** NaN`.
- With the fix, it passes on both backends.

I also ran the steps from `compiler_rust.yml` locally:

- `cargo check`, `cargo build`, `cargo test --workspace` (49 passed)
- `bash scripts/test-babel-ast.sh`
- `bash scripts/test-rust-port.sh`: 1816 passed, 0 failed (1815 on `main`, before the new fixture)
- `yarn snap --rust` and `yarn snap`: 1817 passed, 0 failed
