### PR TITLE
[Flight] Reject pending models when Node readable streams close prematurely

### DIFF
--- a/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-esm/src/client/ReactFlightDOMClientNode.js
@@ -16,6 +16,7 @@ import type {
 } from 'react-client/src/ReactFlightClient';
 
 import type {Readable} from 'stream';
+import {finished} from 'stream';
 
 import {
   createResponse,
@@ -79,11 +80,15 @@ function startReadingFromStream(
     }
   });
 
-  stream.on('error', error => {
-    reportGlobalError(response, error);
+  // A destroyed Readable may emit close without end or error. Track the
+  // readable side only: a duplex debug channel can remain writable after EOF.
+  finished(stream, {readable: true, writable: false}, error => {
+    if (error) {
+      reportGlobalError(response, error);
+    } else {
+      onEnd();
+    }
   });
-
-  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(

--- a/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-parcel/src/client/ReactFlightDOMClientNode.js
@@ -10,6 +10,7 @@
 import type {Thenable, ReactCustomFormAction} from 'shared/ReactTypes.js';
 import type {DebugChannel, Response} from 'react-client/src/ReactFlightClient';
 import type {Readable} from 'stream';
+import {finished} from 'stream';
 
 import {
   createResponse,
@@ -74,11 +75,15 @@ function startReadingFromStream(
     }
   });
 
-  stream.on('error', error => {
-    reportGlobalError(response, error);
+  // A destroyed Readable may emit close without end or error. Track the
+  // readable side only: a duplex debug channel can remain writable after EOF.
+  finished(stream, {readable: true, writable: false}, error => {
+    if (error) {
+      reportGlobalError(response, error);
+    } else {
+      onEnd();
+    }
   });
-
-  stream.on('end', onEnd);
 }
 
 export function createFromNodeStream<T>(

--- a/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-turbopack/src/client/ReactFlightDOMClientNode.js
@@ -28,6 +28,7 @@ type ServerConsumerManifest = {
 };
 
 import type {Readable} from 'stream';
+import {finished} from 'stream';
 
 import {
   createResponse,
@@ -82,11 +83,15 @@ function startReadingFromStream(
     }
   });
 
-  stream.on('error', error => {
-    reportGlobalError(response, error);
+  // A destroyed Readable may emit close without end or error. Track the
+  // readable side only: a duplex debug channel can remain writable after EOF.
+  finished(stream, {readable: true, writable: false}, error => {
+    if (error) {
+      reportGlobalError(response, error);
+    } else {
+      onEnd();
+    }
   });
-
-  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(

--- a/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-unbundled/src/client/ReactFlightDOMClientNode.js
@@ -28,6 +28,7 @@ type ServerConsumerManifest = {
 };
 
 import type {Readable} from 'stream';
+import {finished} from 'stream';
 
 import {
   createResponse,
@@ -82,11 +83,15 @@ function startReadingFromStream(
     }
   });
 
-  stream.on('error', error => {
-    reportGlobalError(response, error);
+  // A destroyed Readable may emit close without end or error. Track the
+  // readable side only: a duplex debug channel can remain writable after EOF.
+  finished(stream, {readable: true, writable: false}, error => {
+    if (error) {
+      reportGlobalError(response, error);
+    } else {
+      onEnd();
+    }
   });
-
-  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNodeStreamLifecycle-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMNodeStreamLifecycle-test.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+'use strict';
+
+const {PassThrough} = require('stream');
+
+describe.each(['webpack', 'turbopack', 'parcel', 'esm', 'unbundled'])(
+  'Flight Node stream lifecycle (%s)',
+  adapter => {
+    let createFromStream;
+
+    beforeEach(() => {
+      jest.resetModules();
+      const {createFromNodeStream} = require(
+        'react-server-dom-' +
+          adapter +
+          (adapter === 'unbundled' ? '/client' : '/client.node'),
+      );
+      createFromStream = (stream, options) => {
+        if (adapter === 'esm') {
+          return createFromNodeStream(
+            stream,
+            'file:///',
+            'http://localhost/',
+            options,
+          );
+        }
+        if (adapter === 'parcel') {
+          return createFromNodeStream(stream, options);
+        }
+        return createFromNodeStream(
+          stream,
+          {
+            moduleMap: {},
+            moduleLoading: null,
+            serverModuleMap: null,
+          },
+          options,
+        );
+      };
+    });
+
+    it('rejects pending models when the readable closes without an error', async () => {
+      const stream = new PassThrough();
+      const result = createFromStream(stream);
+      let rejection;
+      result.then(
+        () => {},
+        error => {
+          rejection = error;
+        },
+      );
+      await new Promise(resolve => {
+        stream.once('close', resolve);
+        stream.destroy();
+      });
+      expect(rejection).toBeDefined();
+      expect(rejection.code).toBe('ERR_STREAM_PREMATURE_CLOSE');
+    });
+
+    it('preserves the original stream error', async () => {
+      const stream = new PassThrough();
+      const error = new Error('read failed');
+      const result = Promise.resolve(createFromStream(stream));
+      stream.destroy(error);
+      await expect(result).rejects.toBe(error);
+    });
+
+    it('resolves a model when a stream ends normally', async () => {
+      const stream = new PassThrough();
+      const result = Promise.resolve(createFromStream(stream));
+      stream.end('0:"hello"\n');
+      await expect(result).resolves.toBe('hello');
+    });
+
+    it('rejects a stream that was already destroyed before reading', async () => {
+      const stream = new PassThrough();
+      await new Promise(resolve => {
+        stream.once('close', resolve);
+        stream.destroy();
+      });
+      await expect(
+        Promise.resolve(createFromStream(stream)),
+      ).rejects.toMatchObject({
+        code: 'ERR_STREAM_PREMATURE_CLOSE',
+      });
+    });
+
+    it('handles premature debug channel closure only in development', async () => {
+      const stream = new PassThrough();
+      const debugChannel = new PassThrough();
+      const result = Promise.resolve(createFromStream(stream, {debugChannel}));
+      debugChannel.destroy();
+      if (__DEV__) {
+        await expect(result).rejects.toMatchObject({
+          code: 'ERR_STREAM_PREMATURE_CLOSE',
+        });
+      } else {
+        stream.end('0:"hello"\n');
+        await expect(result).resolves.toBe('hello');
+      }
+      stream.destroy();
+    });
+
+    it('waits for data after the debug channel ends and closes normally', async () => {
+      const stream = new PassThrough();
+      const debugChannel = new PassThrough();
+      const result = Promise.resolve(createFromStream(stream, {debugChannel}));
+      // Production ignores the debug channel, so consume its readable side.
+      debugChannel.resume();
+      await new Promise(resolve => {
+        debugChannel.once('close', resolve);
+        debugChannel.end();
+      });
+      stream.end('0:"hello"\n');
+      await expect(result).resolves.toBe('hello');
+    });
+  },
+);

--- a/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
+++ b/packages/react-server-dom-webpack/src/client/ReactFlightDOMClientNode.js
@@ -28,6 +28,7 @@ type ServerConsumerManifest = {
 };
 
 import type {Readable} from 'stream';
+import {finished} from 'stream';
 
 import {
   createResponse,
@@ -82,11 +83,15 @@ function startReadingFromStream(
     }
   });
 
-  stream.on('error', error => {
-    reportGlobalError(response, error);
+  // A destroyed Readable may emit close without end or error. Track the
+  // readable side only: a duplex debug channel can remain writable after EOF.
+  finished(stream, {readable: true, writable: false}, error => {
+    if (error) {
+      reportGlobalError(response, error);
+    } else {
+      onEnd();
+    }
   });
-
-  stream.on('end', onEnd);
 }
 
 function createFromNodeStream<T>(


### PR DESCRIPTION
## Summary

createFromNodeStream does not settle a pending model when its Node Readable is destroyed without an error. A consumer awaiting that model can wait indefinitely after the input has already closed.

Fixes #37596

## Root cause

startReadingFromStream subscribes only to data, error and end. Node destroy() can emit close without end or error. The same adapter logic exists in webpack, turbopack, parcel, ESM and the internal unbundled adapter.

## Changes

Use node:stream finished() (imported through the existing stream module convention) to observe readable completion, error and premature close, explicitly ignoring the writable half of duplex streams. Add lifecycle tests for all five adapters, including normal EOF, original errors, already-destroyed inputs and development/production debug-channel behavior.

## Before / after

Before: The input emits close, but the returned model remains pending. The same issue affects an interrupted development debug channel.

After: Reject pending work after premature readable termination, while preserving successful EOF and the original error when one is supplied.

## How did you test this change?

Before: the new premature-close regression fails in all five adapters (5 failures). After: ReactFlightDOMNodeStreamLifecycle passes 30/30 in development; ReactFlightDOMNode passes 57/57 in production. The broader development run passes 54 tests and has 3 existing Windows stack-path assertion failures; an unmodified baseline run reproduces the identical 3 failures (24 passed, 3 failed). No tests were skipped or weakened to hide these failures. ESLint, Prettier and the dom-node-webpack Flow configuration pass.

```sh
yarn test ReactFlightDOMNodeStreamLifecycle --runInBand --no-watchman
yarn test ReactFlightDOMNode --prod --runInBand --no-watchman
yarn test ReactFlightDOMNode --runInBand --no-watchman
yarn flow dom-node-webpack
```

Validation ran on Windows. Dependencies were installed with frozen yarn.lock using the available Node 24.19.0 runtime; targeted test runs used the repository Jest CLI. Flow was invoked via node node_modules/flow-bin/cli.js status with the generated renderer configuration (the equivalent Windows CLI path). ESLint and Prettier were run directly on changed files. The entire repository test/build matrix was not run.

## Compatibility and risks

Normal end and supplied errors retain their behavior. Premature close now rejects with Node ERR_STREAM_PREMATURE_CLOSE. readable:true/writable:false avoids waiting for the writable half of a duplex debug channel. This is a termination/correctness report, not a security finding.

## Related work

Searched all Issue/PR states for createFromNodeStream, destroy, premature stream close and Connection closed. Reviewed the existing debug-channel completion work (#34236, #34304) and current adapter history. #37106 concerns exceptions in the separate server-side decodeReplyFromAsyncIterable path, not Node client readable termination. No equivalent fix was found; Discussions are disabled for this repository.
