### PR TITLE
[DOM] Snapshot Fragment event listener options at registration

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3037,6 +3037,14 @@ FragmentInstance.prototype.addEventListener = function (
   let signal: null | AbortSignal = null;
   let cleanup: null | (() => void) = null;
   if (optionsOrUseCapture != null && typeof optionsOrUseCapture !== 'boolean') {
+    // Keep the registration's options stable if the caller later reuses or
+    // mutates the options object, including for children inserted later.
+    optionsOrUseCapture = {
+      capture: optionsOrUseCapture.capture,
+      passive: optionsOrUseCapture.passive,
+      once: optionsOrUseCapture.once,
+      signal: optionsOrUseCapture.signal,
+    };
     signal = optionsOrUseCapture.signal || null;
     if (signal !== null && signal.aborted) {
       return;

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -64,6 +64,76 @@ describe('FragmentRefs', () => {
     document.body.removeChild(container);
   });
 
+  it('keeps the original capture option when the options object changes', async () => {
+    const ref = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+    await act(() =>
+      root.render(
+        <Fragment ref={ref}>
+          <button />
+        </Fragment>,
+      ),
+    );
+    const listener = jest.fn();
+    const options = {capture: false};
+    ref.current.addEventListener('click', listener, options);
+    options.capture = true;
+    ref.current.removeEventListener('click', listener, false);
+    await act(() =>
+      root.render(
+        <Fragment ref={ref}>
+          <button />
+          <button />
+        </Fragment>,
+      ),
+    );
+    container.firstChild.click();
+    container.lastChild.click();
+    expect(listener).toHaveBeenCalledTimes(0);
+  });
+
+  it('keeps once listeners scoped to the Fragment after options change', async () => {
+    const ref = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+    await act(() =>
+      root.render(
+        <Fragment ref={ref}>
+          <button />
+          <button />
+        </Fragment>,
+      ),
+    );
+    const listener = jest.fn();
+    const options = {capture: false, once: true};
+    ref.current.addEventListener('click', listener, options);
+    options.capture = true;
+    container.firstChild.click();
+    container.lastChild.click();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts listeners using their original capture option', async () => {
+    const ref = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+    await act(() =>
+      root.render(
+        <Fragment ref={ref}>
+          <button />
+        </Fragment>,
+      ),
+    );
+    const controller = new AbortController();
+    const listener = jest.fn();
+    const options = {capture: false, signal: controller.signal};
+    ref.current.addEventListener('click', listener, options);
+    options.capture = true;
+    controller.abort();
+    container.firstChild.click();
+    ref.current.addEventListener('click', listener);
+    container.firstChild.click();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   it('attaches a ref to Fragment', async () => {
     const fragmentRef = React.createRef();
     const root = ReactDOMClient.createRoot(container);


### PR DESCRIPTION
## Summary

Fragment refs keep the caller-owned listener options object and read it again later. Changing that object after registration can leave an event listener active after removeEventListener, once delivery or signal abort.

Fixes #37598

## Root cause

StoredEventListener.optionsOrUseCapture aliases the caller object. indexOfEventListener and cleanup derive capture from the mutated object, although existing native listeners were attached using the original capture value.

## Changes

Copy the supported option fields at registration time. Retain the snapshot for matching, once/abort cleanup and later children. Add regression tests for explicit removal, once and AbortSignal cleanup after capture mutation.

## Before / after

Before: The listener remains active. A once listener may also fire again on another child, and abort cleanup can remove the registration record while leaving the original native listener attached.

After: Registration should keep the capture/options values read at addEventListener time, as the native API does. Removing the original non-capture listener should stop its callbacks.

## How did you test this change?

Before: removal/later-child and once regressions each produce 2 calls instead of 0 and 1 respectively. After: both development and production Fragment suites pass 101/101 tests, including the new abort regression. ESLint, Prettier and Flow (dom-node-webpack configuration, which includes DOM bindings) pass.

```sh
yarn test ReactDOMFragmentRefs --runInBand --no-watchman
yarn test ReactDOMFragmentRefs --prod --runInBand --no-watchman
yarn flow dom-node-webpack
```

Validation ran on Windows. Dependencies were installed with frozen yarn.lock using the available Node 24.19.0 runtime; targeted test runs used the repository Jest CLI. Flow was invoked via node node_modules/flow-bin/cli.js status with the generated renderer configuration (the equivalent Windows CLI path). ESLint and Prettier were run directly on changed files. The entire repository test/build matrix was not run.

## Compatibility and risks

Boolean and omitted options retain their existing behavior. Snapshotting reads the supported dictionary fields once and preserves optional passive defaults. No public API is added.

## Related work

Searched all Issue/PR states for Fragment capture/options/mutated/snapshot and examined recent Fragment commits. #36047 and #37251 normalize equivalent option forms; #37457 handles aborted registration cleanup. They do not snapshot caller-owned options, and the new regressions fail on main after those fixes. No equivalent issue or PR was found.
