### PR TITLE
[DOM] Skip removed Fragment listeners during dispatchEvent

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3240,27 +3240,37 @@ FragmentInstance.prototype.dispatchEvent = function (
       parentHostInstance.nodeType === DOCUMENT_NODE
         ? (parentHostInstance as any as Document).createComment('')
         : document.createTextNode('');
+    const removeListeners: Array<() => void> = [];
     if (eventListeners) {
       for (let i = 0; i < eventListeners.length; i++) {
-        const {type, attachedListener, optionsOrUseCapture} = eventListeners[i];
-        temp.addEventListener(
-          type,
-          attachedListener,
-          getAttachOptions(optionsOrUseCapture),
-        );
+        const storedListener = eventListeners[i];
+        const {type, attachedListener, optionsOrUseCapture} = storedListener;
+        // Removal walks the Fragment's host children, which do not include
+        // this temporary target. Check the original registration so a listener
+        // removed (or removed and re-added) during dispatch is not called.
+        const dispatchListener = function (
+          this: EventTarget,
+          dispatchedEvent: Event,
+        ) {
+          if (eventListeners.indexOf(storedListener) !== -1) {
+            if (typeof attachedListener === 'function') {
+              attachedListener.call(this, dispatchedEvent);
+            } else {
+              attachedListener.handleEvent(dispatchedEvent);
+            }
+          }
+        };
+        const attachOptions = getAttachOptions(optionsOrUseCapture);
+        temp.addEventListener(type, dispatchListener, attachOptions);
+        removeListeners.push(() => {
+          temp.removeEventListener(type, dispatchListener, attachOptions);
+        });
       }
     }
     parentHostInstance.appendChild(temp);
     const cancelable = temp.dispatchEvent(event);
-    if (eventListeners) {
-      for (let i = 0; i < eventListeners.length; i++) {
-        const {type, attachedListener, optionsOrUseCapture} = eventListeners[i];
-        temp.removeEventListener(
-          type,
-          attachedListener,
-          getAttachOptions(optionsOrUseCapture),
-        );
-      }
+    for (let i = 0; i < removeListeners.length; i++) {
+      removeListeners[i]();
     }
     parentHostInstance.removeChild(temp);
     return cancelable;

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -64,6 +64,64 @@ describe('FragmentRefs', () => {
     document.body.removeChild(container);
   });
 
+  it.each(['remove', 'abort', 'replace'])(
+    'skips listeners removed during dispatchEvent (%s)',
+    async kind => {
+      const ref = React.createRef();
+      const root = ReactDOMClient.createRoot(container);
+      await act(() =>
+        root.render(
+          <Fragment ref={ref}>
+            <button />
+          </Fragment>,
+        ),
+      );
+      const controller = new AbortController();
+      const listener = jest.fn();
+      const first = () => {
+        if (kind === 'abort') {
+          controller.abort();
+        } else {
+          ref.current.removeEventListener('click', listener);
+          if (kind === 'replace') {
+            ref.current.addEventListener('click', listener);
+          }
+        }
+      };
+      ref.current.addEventListener('click', first);
+      ref.current.addEventListener('click', listener, {
+        signal: controller.signal,
+      });
+      ref.current.dispatchEvent(new MouseEvent('click'));
+      expect(listener).toHaveBeenCalledTimes(0);
+      ref.current.removeEventListener('click', first);
+      ref.current.dispatchEvent(new MouseEvent('click'));
+      expect(listener).toHaveBeenCalledTimes(kind === 'replace' ? 1 : 0);
+    },
+  );
+
+  it('dispatches listener objects with the correct receiver', async () => {
+    const ref = React.createRef();
+    const root = ReactDOMClient.createRoot(container);
+    await act(() =>
+      root.render(
+        <Fragment ref={ref}>
+          <button />
+        </Fragment>,
+      ),
+    );
+    let receiver;
+    const listener = {
+      handleEvent: jest.fn(function () {
+        receiver = this;
+      }),
+    };
+    ref.current.addEventListener('click', listener);
+    ref.current.dispatchEvent(new MouseEvent('click'));
+    expect(listener.handleEvent).toHaveBeenCalledTimes(1);
+    expect(receiver).toBe(listener);
+  });
+
   it('attaches a ref to Fragment', async () => {
     const fragmentRef = React.createRef();
     const root = ReactDOMClient.createRoot(container);


### PR DESCRIPTION
## Summary

A Fragment listener removed by an earlier callback still executes during the same FragmentInstance.dispatchEvent call. Aborting its signal has the same effect.

Fixes #37600

## Root cause

dispatchEvent copies attached listeners onto a temporary DOM target. removeEventListener walks only Fragment host children; it does not detach the temporary target listener currently participating in dispatch.

## Changes

Wrap temporary-target callbacks with an original-registration identity check. Capture cleanup callbacks when attaching so cleanup does not depend on the registry after callbacks mutate it. Add remove, abort, remove-and-readd regressions plus listener-object receiver coverage.

## Before / after

Before: The removed callback runs once on the temporary dispatch target even though it was removed from the Fragment registry and host children.

After: A listener removed before its turn should not run, consistent with native event dispatch. Removing and re-adding the same callback should not reactivate the original registration in the current dispatch.

## How did you test this change?

Before: remove and abort regressions each call the later listener once instead of zero. After: development and production Fragment suites both pass 102/102 tests. Prettier, ESLint and Flow pass.

```sh
yarn test ReactDOMFragmentRefs --runInBand --no-watchman
yarn test ReactDOMFragmentRefs --prod --runInBand --no-watchman
yarn flow dom-node
```

Validation ran on Windows. Dependencies were installed with frozen yarn.lock using the available Node 24.19.0 runtime; targeted test runs used the repository Jest CLI. Flow was invoked via node node_modules/flow-bin/cli.js status with the generated renderer configuration (the equivalent Windows CLI path). ESLint and Prettier were run directly on changed files. The entire repository test/build matrix was not run.

## Compatibility and risks

The native target still controls propagation, cancellation and callback ordering. The identity guard distinguishes a re-added registration from the removed one; existing once behavior and listener-object receivers are covered. It adds temporary closures and a registry lookup during Fragment dispatch.

## Related work

Searched all Issue/PR states for Fragment dispatchEvent, removed listeners, abort and dispatch. Inspected #37455 and the full diff of #37456: that PR addresses exceptions or imperative removal of the temporary target after dispatch, not callbacks removed before their turn. This fix is independent, though the cleanup hunk may overlap if #37456 lands first.
