### PR TITLE
[DevTools] Normalize BigInt values in facade inspection results

### DIFF
--- a/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
@@ -210,6 +210,7 @@ function normalizeValue(val: mixed, seen?: Set<mixed>, depth?: number): mixed {
   if (typeof val === 'function')
     return val.name ? '[fn ' + val.name + ']' : '[fn]';
   if (typeof val === 'symbol') return '[symbol]';
+  if (typeof val === 'bigint') return val.toString() + 'n';
   if (typeof val === 'object' && val !== null) {
     if ((val as any).$$typeof != null) return '[React element]';
     const currentDepth = depth || 0;

--- a/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
+++ b/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
@@ -51,6 +51,28 @@ describe('react-devtools-facade', () => {
     container = null;
   });
 
+  it.each(['0', '9007199254740993', '-9007199254740993'])(
+    'serializes BigInt props and hook values without losing precision (%s)',
+    value => {
+      function Sample({data}) {
+        React.useState(data);
+        return null;
+      }
+      const data = {id: BigInt(value), nested: [BigInt(value)]};
+      act(() =>
+        ReactDOMClient.createRoot(container).render(<Sample data={data} />),
+      );
+      const tools = createTools(facade);
+      const node = tools.getComponentTree().find(n => n.name === 'Sample');
+      const result = tools.getComponentByUid(node.uid, true);
+      expect(() => JSON.stringify(result)).not.toThrow();
+      const expected = {id: value + 'n', nested: [value + 'n']};
+      expect(result.props.data).toEqual(expected);
+      expect(result.hooks[0].value).toEqual(expected);
+      expect(data.id).toBe(BigInt(value));
+    },
+  );
+
   it('installs __REACT_DEVTOOLS_GLOBAL_HOOK__ on globalThis', () => {
     expect(globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBe(facade.hook);
   });


### PR DESCRIPTION
## Summary

Component inspection through the DevTools facade returns raw BigInt values in props and hooks. JSON serialization of the advertised serialization-safe result then throws, preventing that result from reaching an inspection/MCP consumer.

Fixes #37602

## Root cause

normalizeValue handles undefined, functions, symbols and objects but falls through for bigint. Both normalizeProps and normalizeHooks use this helper; CDT MCP forwards the result.

## Changes

Represent BigInt as its exact decimal string followed by n, consistent with the existing descriptive-string normalization style. Add zero, large positive and large negative cases across nested props, arrays and hook values, verifying input values are not mutated.

## Before / after

Before: normalizeValue returns the BigInt unchanged; JSON.stringify throws for both nested props and hook values.

After: The normalized result should be serializable while preserving the integer value and its BigInt type distinction.

## How did you test this change?

Before: all 3 new tests fail through the official DevTools build test entry with TypeError: Do not know how to serialize a BigInt. After: DevToolsFacade and DevToolsCdtMcp pass 133/133 tests against locally built experimental NODE_DEV React packages. Prettier, ESLint and Flow pass.

```sh
yarn test --build --project devtools DevToolsFacade DevToolsCdtMcp --runInBand --no-watchman
yarn flow dom-node-webpack
```

Validation ran on Windows. Dependencies were installed with frozen yarn.lock using the available Node 24.19.0 runtime; targeted test runs used the repository Jest CLI. Flow was invoked via node node_modules/flow-bin/cli.js status with the generated renderer configuration (the equivalent Windows CLI path). ESLint and Prettier were run directly on changed files. The entire repository test/build matrix was not run.

## Compatibility and risks

Only bigint normalization changes. Strings avoid Number precision loss. Other normalized types and the inspected application values remain unchanged. This targets the experimental DevTools facade/CDT MCP integration.

## Related work

Searched all Issue/PR states for facade serialization, normalizeValue, MCP BigInt and DevTools BigInt. #17207/#17931 concern the older DevTools hydration/copy-to-clipboard path, which already handles bigint separately; they do not fix the newer facade normalizer. No equivalent facade/MCP fix was found.
