### PR TITLE
[DevTools] Find non-resource hoistable DOM instances in the facade

### DIFF
--- a/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
+++ b/packages/react-devtools-facade/src/DevToolsFacadeTreeTools.js
@@ -407,6 +407,8 @@ export function createTreeTools(
       ) {
         return (resource as any).instance;
       }
+      // Hoistable instances such as title and meta have no resource record.
+      return fiber.stateNode;
     }
 
     return null;

--- a/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
+++ b/packages/react-devtools-facade/src/__tests__/DevToolsFacade-test.js
@@ -51,6 +51,52 @@ describe('react-devtools-facade', () => {
     container = null;
   });
 
+  it('looks up hoistable DOM instances without resource records', () => {
+    const root = ReactDOMClient.createRoot(container);
+    act(() =>
+      root.render(
+        <>
+          <meta name="facade-test" content="value" />
+          <title>Facade test title</title>
+          <link rel="author" href="https://example.com/facade-test" />
+        </>,
+      ),
+    );
+    const tools = createTools(facade);
+    const tree = tools.getComponentTree();
+    ['meta', 'title', 'link'].forEach(tag => {
+      const node = tree.find(n => n.name === tag);
+      const element = document.head.querySelector(tag);
+      expect(element).not.toBe(null);
+      const info = tools.getComponentByHostInstance(element);
+      expect(info).toEqual(tools.getComponentByUid(node.uid));
+      expect(info.type).toBe('host');
+      expect(info.name).toBe(tag);
+    });
+    act(() => root.unmount());
+  });
+
+  it('still looks up resource-backed hoistable DOM instances', () => {
+    const root = ReactDOMClient.createRoot(container);
+    act(() =>
+      root.render(
+        <style href="facade-test-style" precedence="default">
+          {'body {}'}
+        </style>,
+      ),
+    );
+    const tools = createTools(facade);
+    const style = document.head.querySelector(
+      'style[data-href="facade-test-style"]',
+    );
+    expect(style).not.toBe(null);
+    const info = tools.getComponentByHostInstance(style);
+    expect(info.name).toBe('style');
+    expect(info.props.href).toBe('facade-test-style');
+    act(() => root.unmount());
+    style.remove();
+  });
+
   it('installs __REACT_DEVTOOLS_GLOBAL_HOOK__ on globalThis', () => {
     expect(globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__).toBe(facade.hook);
   });


### PR DESCRIPTION
## Summary

getComponentByHostInstance reports that a React-managed metadata element is not managed by React. The same element is present and inspectable by UID in getComponentTree, so DOM-based and UID-based inspection disagree.

Fixes #37604

## Root cause

getHostInstanceForFiber handles HostHoistable only through memoizedState.instance. Non-resource hoistables have null memoizedState and store their DOM instance in stateNode (see the HostHoistable commit path).

## Changes

Fall back to stateNode after checking a hoistable resource record. Add title/meta/link lookup parity tests and retain coverage of resource-backed inline styles.

## Before / after

Before: Lookup fails for title/meta and non-resource link instances. Resource-backed style elements follow a different storage path and can be found.

After: A React-managed hoistable DOM element should resolve to its host component, with the same UID and props returned by component-tree inspection.

## How did you test this change?

Before: the non-resource hoistable regression fails and the resource-backed control passes through the official DevTools build test entry. After: DevToolsFacade and DevToolsCdtMcp pass 132/132 tests. Prettier, ESLint and Flow pass.

```sh
yarn test --build --project devtools DevToolsFacade DevToolsCdtMcp --runInBand --no-watchman
yarn flow dom-node-webpack
```

Validation ran on Windows. Dependencies were installed with frozen yarn.lock using the available Node 24.19.0 runtime; targeted test runs used the repository Jest CLI. Flow was invoked via node node_modules/flow-bin/cli.js status with the generated renderer configuration (the equivalent Windows CLI path). ESLint and Prettier were run directly on changed files. The entire repository test/build matrix was not run.

## Compatibility and risks

The resource-record lookup keeps its existing priority. The fallback matches the reconciler stateNode storage for non-resource hoistables. This changes inspection only, not rendering or resource lifetime.

## Related work

Searched all Issue/PR states for getHostInstanceForFiber, facade meta and hoistable DevTools. #36820 introduced this lookup; #30584/#30590 and #35741 concern the separate full DevTools renderer backend and its node mapping/lifecycle. No equivalent facade fallback was found.
