### PR TITLE
[DOM] Handle non-element portal roots in Fragment document position

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3629,7 +3629,7 @@ FragmentInstance.prototype.compareDocumentPosition = function (
   // our best guess is to use the parent of the child instance, rather than
   // the fiber tree host parent.
   const parentHostInstanceFromDOM = fiberIsPortaledIntoHost(this._fragmentFiber)
-    ? (firstNode.parentElement as ?Instance)
+    ? firstNode.parentNode
     : parentHostInstance;
 
   if (parentHostInstanceFromDOM == null) {

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -64,6 +64,43 @@ describe('FragmentRefs', () => {
     document.body.removeChild(container);
   });
 
+  it.each(['ShadowRoot', 'DocumentFragment', 'Element'])(
+    'compares portaled Fragment children inside a %s',
+    async kind => {
+      const target =
+        kind === 'ShadowRoot'
+          ? container.attachShadow({mode: 'open'})
+          : kind === 'DocumentFragment'
+            ? document.createDocumentFragment()
+            : document.createElement('div');
+      const ref = React.createRef();
+      const root = ReactDOMClient.createRoot(document.createElement('div'));
+      await act(() =>
+        root.render(
+          createPortal(
+            <Fragment ref={ref}>
+              <button>
+                <span />
+              </button>
+              <button />
+            </Fragment>,
+            target,
+          ),
+        ),
+      );
+      expect(ref.current.compareDocumentPosition(target.firstChild)).toBe(
+        Node.DOCUMENT_POSITION_CONTAINED_BY,
+      );
+      expect(ref.current.compareDocumentPosition(target.lastChild)).toBe(
+        Node.DOCUMENT_POSITION_CONTAINED_BY,
+      );
+      expect(
+        ref.current.compareDocumentPosition(target.firstChild.firstChild),
+      ).toBe(Node.DOCUMENT_POSITION_CONTAINED_BY);
+      await act(() => root.unmount());
+    },
+  );
+
   it('attaches a ref to Fragment', async () => {
     const fragmentRef = React.createRef();
     const root = ReactDOMClient.createRoot(container);


### PR DESCRIPTION
## Summary

FragmentInstance.compareDocumentPosition reports DOCUMENT_POSITION_DISCONNECTED for the Fragment own children when the Fragment is portaled into a ShadowRoot or DocumentFragment.

Fixes #37606

## Root cause

The portal path derives its DOM parent from firstNode.parentElement. ShadowRoot and DocumentFragment are valid portal containers but are not Elements, so this is null and the method returns DISCONNECTED before checking actual containment.

## Changes

Use parentNode for the portaled child DOM parent. Add first-child, last-child and nested-descendant comparisons with ShadowRoot, DocumentFragment and Element portal targets.

## Before / after

Before: All such children are reported disconnected even though both the DOM and Fiber trees contain them.

After: Own children and their descendants should be recognized as contained, as they are for an Element portal target.

## How did you test this change?

Before: both ShadowRoot and DocumentFragment cases return 1 instead of 16. After: development and production Fragment suites pass 101/101 tests, with Element portal controls and existing Document/empty-Fragment coverage. Prettier, ESLint and Flow pass.

```sh
yarn test ReactDOMFragmentRefs --runInBand --no-watchman
yarn test ReactDOMFragmentRefs --prod --runInBand --no-watchman
yarn flow dom-node
```

Validation ran on Windows. Dependencies were installed with frozen yarn.lock using the available Node 24.19.0 runtime; targeted test runs used the repository Jest CLI. Flow was invoked via node node_modules/flow-bin/cli.js status with the generated renderer configuration (the equivalent Windows CLI path). ESLint and Prettier were run directly on changed files. The entire repository test/build matrix was not run.

## Compatibility and risks

Element parents still produce the same node. parentNode additionally admits supported non-element portal containers; the existing Fiber validation remains in place.

## Related work

Searched all Issue/PR states for Fragment parentElement, ShadowRoot, DocumentFragment and compareDocumentPosition. Inspected #37142: it fixes Fiber ancestor validation after imperative DOM movement, not the parentElement null short-circuit. #37163/#37579 address Document/empty-portal paths. No equivalent non-element portal-parent fix was found.
