### PR TITLE
[DOM] Add support for `onAnimationCancel`

### DIFF
--- a/packages/react-dom-bindings/src/events/DOMEventNames.js
+++ b/packages/react-dom-bindings/src/events/DOMEventNames.js
@@ -13,8 +13,9 @@ export type DOMEventName =
   | 'abort'
   | 'afterblur' // Not a real event. This is used by event experiments.
   // These are vendor-prefixed so you should use the exported constants instead:
+  // 'animationcancel' |
   // 'animationiteration' |
-  // 'animationend |
+  // 'animationend' |
   // 'animationstart' |
   | 'beforeblur' // Not a real event. This is used by event experiments.
   | 'beforeinput'
@@ -115,6 +116,8 @@ export type DOMEventName =
   | 'waiting'
   | 'wheel';
 
+export const ANIMATION_CANCEL: DOMEventName =
+  getVendorPrefixedEventName('animationcancel');
 export const ANIMATION_END: DOMEventName =
   getVendorPrefixedEventName('animationend');
 export const ANIMATION_ITERATION: DOMEventName =

--- a/packages/react-dom-bindings/src/events/DOMEventProperties.js
+++ b/packages/react-dom-bindings/src/events/DOMEventProperties.js
@@ -11,6 +11,7 @@ import type {DOMEventName} from './DOMEventNames';
 
 import {registerTwoPhaseEvent} from './EventRegistry';
 import {
+  ANIMATION_CANCEL,
   ANIMATION_END,
   ANIMATION_ITERATION,
   ANIMATION_START,
@@ -135,6 +136,7 @@ export function registerSimpleEvents() {
     registerSimpleEvent(domEventName, 'on' + capitalizedEvent);
   }
   // Special cases where event names don't match.
+  registerSimpleEvent(ANIMATION_CANCEL, 'onAnimationCancel');
   registerSimpleEvent(ANIMATION_END, 'onAnimationEnd');
   registerSimpleEvent(ANIMATION_ITERATION, 'onAnimationIteration');
   registerSimpleEvent(ANIMATION_START, 'onAnimationStart');

--- a/packages/react-dom-bindings/src/events/TopLevelEventTypes.js
+++ b/packages/react-dom-bindings/src/events/TopLevelEventTypes.js
@@ -10,8 +10,9 @@
 export type TopLevelType =
   | 'abort'
   // Dynamic and vendor-prefixed at the usage site:
+  // 'animationcancel' |
   // 'animationiteration' |
-  // 'animationend |
+  // 'animationend' |
   // 'animationstart' |
   | 'canplay'
   | 'canplaythrough'

--- a/packages/react-dom-bindings/src/events/getVendorPrefixedEventName.js
+++ b/packages/react-dom-bindings/src/events/getVendorPrefixedEventName.js
@@ -28,6 +28,7 @@ function makePrefixMap(styleProp, eventName) {
  * A list of event names to a configurable list of vendor prefixes.
  */
 const vendorPrefixes = {
+  animationcancel: makePrefixMap('Animation', 'AnimationCancel'),
   animationend: makePrefixMap('Animation', 'AnimationEnd'),
   animationiteration: makePrefixMap('Animation', 'AnimationIteration'),
   animationstart: makePrefixMap('Animation', 'AnimationStart'),
@@ -58,6 +59,7 @@ if (canUseDOM) {
   // style object but the events that fire will still be prefixed, so we need
   // to check if the un-prefixed events are usable, and if not remove them from the map.
   if (!('AnimationEvent' in window)) {
+    delete vendorPrefixes.animationcancel.animation;
     delete vendorPrefixes.animationend.animation;
     delete vendorPrefixes.animationiteration.animation;
     delete vendorPrefixes.animationstart.animation;

--- a/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SimpleEventPlugin.js
@@ -32,6 +32,7 @@ import {
 } from '../../events/SyntheticEvent';
 
 import {
+  ANIMATION_CANCEL,
   ANIMATION_END,
   ANIMATION_ITERATION,
   ANIMATION_START,
@@ -133,6 +134,7 @@ function extractEvents(
     case 'touchstart':
       SyntheticEventCtor = SyntheticTouchEvent;
       break;
+    case ANIMATION_CANCEL:
     case ANIMATION_END:
     case ANIMATION_ITERATION:
     case ANIMATION_START:

--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -56,6 +56,23 @@ describe('ReactDOMEventListener', () => {
   }
 
   describe('bubbling events', () => {
+    it('onAnimationCancel', async () => {
+      await testNativeBubblingEvent({
+        type: 'div',
+        reactEvent: 'onAnimationCancel',
+        reactEventType: 'animationcancel',
+        nativeEvent: 'animationcancel',
+        dispatch(node) {
+          node.dispatchEvent(
+            new Event('animationcancel', {
+              bubbles: true,
+              cancelable: false,
+            }),
+          );
+        },
+      });
+    });
+
     it('onAnimationEnd', async () => {
       await testNativeBubblingEvent({
         type: 'div',

--- a/packages/react-dom/src/events/__tests__/SyntheticAnimationEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticAnimationEvent-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOMClient;
+let act;
+
+describe('SyntheticAnimationEvent', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    act = require('internal-test-utils').act;
+
+    // The container has to be attached for events to fire.
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = ReactDOMClient.createRoot(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('should normalize properties from the AnimationEvent interface for onAnimationCancel', async () => {
+    const events = [];
+    const onAnimationCancel = event => {
+      event.persist();
+      events.push(event);
+    };
+    await act(async () => {
+      root.render(<div onAnimationCancel={onAnimationCancel} />);
+    });
+
+    const event = new Event('animationcancel', {bubbles: true});
+    // jsdom doesn't implement AnimationEvent so we add the fields manually.
+    Object.assign(event, {
+      animationName: 'fade',
+      elapsedTime: 0.5,
+      pseudoElement: '::before',
+    });
+    container.firstChild.dispatchEvent(event);
+
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe('animationcancel');
+    expect(events[0].animationName).toBe('fade');
+    expect(events[0].elapsedTime).toBe(0.5);
+    expect(events[0].pseudoElement).toBe('::before');
+  });
+});


### PR DESCRIPTION
## Summary

AI Disclosure: This was assisted using Claude Code, Fable 5.1. This PR description was fully written by me, manually, and the code was reviewed and tested by me manually.

This improves the accuracy of the animation-related event props supported by React.

This adds `onAnimationCancel` alongside the existing `onAnimationStart`, `onAnimationIteration`, and `onAnimationEnd` props.

Adds `onAnimationCancel` to React DOM, completing the animation event family alongside `onAnimationStart`, `onAnimationIteration`, and `onAnimationEnd`. [`animationcancel`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animationcancel_event) is a CSS Animations Level 1 event fired when an animation stops before it has completed.

This changeset is based on the similar changes in #27345 for the transition events.

Note that MDN's browser compat data [currently claims](https://developer.mozilla.org/en-US/docs/Web/API/Element/animationcancel_event) that this is not supported in Chrome or Edge (at least not as `onanimationcancel`), but this change will work in Chrome 83+ due to React passing things through `addEventListener` anyway, and also the MDN docs are [outdated about this](https://github.com/mdn/browser-compat-data/issues/29376), Chrome has started supporting `onanimationcancel` directly [since earlier this year](https://issues.chromium.org/issues/41404325).

Also note that the animation and transition events on DOMEventName can probably be made to no longer do this vendor prefixing dance? I didn't do that in this PR and it should be done separately, but they've not been prefixed in a long time now and the comment rationalizing the current code mentions Android 4.x, which was last released over a decade ago now. So it seems like something that has just never been cleaned up.

## How did you test this change?

- Added tests to match the sibling properties' tests.
- Ran `yarn test`, `yarn lint`, and `yarn prettier` and all passed.