### PR TITLE
[DOM] Fix Fragment blur() inside a ShadowRoot

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
+++ b/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js
@@ -3326,11 +3326,16 @@ FragmentInstance.prototype.blur = function (this: FragmentInstanceType): void {
     Instance | Container,
   >(parentHostFiber);
   // Instance is included in the Container type for DOM.
-  const ownerDocument = getOwnerDocumentFromRootContainer(
-    parentInstanceOrContainer,
-  );
-  const activeElement = ownerDocument.activeElement;
-  if (activeElement === null) {
+  // Document.activeElement is retargeted to the shadow host when the container
+  // is inside a shadow tree, and the host is never one of the fragment's
+  // children. Read activeElement from the enclosing DocumentOrShadowRoot.
+  const activeElementRoot = getHoistableRoot(parentInstanceOrContainer);
+  // Flow's ShadowRoot is missing the DocumentOrShadowRoot mixin. activeElement
+  // is also undefined for a detached DocumentFragment container, which is not
+  // a DocumentOrShadowRoot at all.
+  // $FlowFixMe[prop-missing]
+  const activeElement: ?Element = activeElementRoot.activeElement;
+  if (activeElement == null) {
     return;
   }
   traverseFragmentInstancesAndTextInstances(

--- a/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFragmentRefs-test.js
@@ -690,6 +690,92 @@ describe('FragmentRefs', () => {
         });
         expect(document.activeElement.id).toEqual('child-a');
       });
+
+      it('removes focus from an element inside of the Fragment in a ShadowRoot', async () => {
+        const fragmentRef = React.createRef();
+        const host = document.createElement('div');
+        container.appendChild(host);
+        const shadowRoot = host.attachShadow({mode: 'open'});
+        const root = ReactDOMClient.createRoot(shadowRoot);
+
+        function Test() {
+          return (
+            <Fragment ref={fragmentRef}>
+              <input id="shadow-input" />
+            </Fragment>
+          );
+        }
+
+        await act(() => {
+          root.render(<Test />);
+        });
+
+        await act(() => {
+          fragmentRef.current.focus();
+        });
+        // Document.activeElement is retargeted to the host element, so the
+        // ShadowRoot is the only place the focused child is observable.
+        expect(shadowRoot.activeElement.id).toEqual('shadow-input');
+
+        await act(() => {
+          fragmentRef.current.blur();
+        });
+        expect(shadowRoot.activeElement).toBe(null);
+      });
+
+      it('does not remove focus from elements outside of the Fragment in a ShadowRoot', async () => {
+        const fragmentRef = React.createRef();
+        const host = document.createElement('div');
+        container.appendChild(host);
+        const shadowRoot = host.attachShadow({mode: 'open'});
+        const root = ReactDOMClient.createRoot(shadowRoot);
+
+        function Test() {
+          return (
+            <div>
+              <Fragment ref={fragmentRef}>
+                <input id="inside" />
+              </Fragment>
+              <input id="outside" />
+            </div>
+          );
+        }
+
+        await act(() => {
+          root.render(<Test />);
+        });
+
+        await act(() => {
+          shadowRoot.getElementById('outside').focus();
+        });
+        expect(shadowRoot.activeElement.id).toEqual('outside');
+
+        await act(() => {
+          fragmentRef.current.blur();
+        });
+        expect(shadowRoot.activeElement.id).toEqual('outside');
+      });
+
+      it('does not throw when the container is a detached DocumentFragment', async () => {
+        const fragmentRef = React.createRef();
+        const root = ReactDOMClient.createRoot(
+          document.createDocumentFragment(),
+        );
+
+        function Test() {
+          return (
+            <Fragment ref={fragmentRef}>
+              <input id="detached-input" />
+            </Fragment>
+          );
+        }
+
+        await act(() => {
+          root.render(<Test />);
+        });
+
+        expect(() => fragmentRef.current.blur()).not.toThrow();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

`FragmentInstance.blur()` missed two shadow DOM cases.

`Document.activeElement` is retargeted to the shadow host, so when the
fragment's container sits inside a shadow tree the lookup never matched any of
the fragment's children and `blur()` silently did nothing. It now reads
`activeElement` from the enclosing `DocumentOrShadowRoot`.

The mirror case also failed: when a child of the fragment owns a shadow tree,
retargeting makes that child the active element, so the containment check
matched, but blurring the host leaves the node inside its shadow tree focused.
The traversal now descends through `shadowRoot.activeElement` to the innermost
focused node before blurring. A closed shadow root cannot be entered and keeps
its focus.

## How did you test this change?

Four tests in the `blur()` block of `ReactDOMFragmentRefs-test.js`: a focused
child is blurred when the root container is a `ShadowRoot`; focus inside a
`ShadowRoot` owned by a child is blurred; a focused sibling outside the fragment
is left alone; a detached `DocumentFragment` container does not throw.

- `ReactDOMFragmentRefs-test.js` is green on `experimental`, `--prod`,
  `stable`, `www-classic` and `www-modern`
- `ReactDOMTestSelectors-test.js`, the other consumer of this code path, passes
- the rest of `packages/react-dom` is unchanged; its one failing test
  (`ReactDOMFizzServer`, deep-tree resume) fails on the parent commit too
- `yarn lint` and `yarn prettier-check` pass
- Flow is clean for `dom-browser` and `dom-browser-fb`